### PR TITLE
feat(engine): Complete Engine ↔ Strategy integration

### DIFF
--- a/crates/gb-engine/src/engine.rs
+++ b/crates/gb-engine/src/engine.rs
@@ -15,7 +15,6 @@ use rust_decimal::Decimal;
 /// Enhanced backtesting engine with event-driven simulation
 pub struct Engine {
     config: BacktestConfig,
-    data_manager: DataManager,
     portfolio: Portfolio,
     strategy: Box<dyn Strategy>,
     current_time: DateTime<Utc>,
@@ -28,7 +27,7 @@ impl Engine {
     /// Create a new engine with strategy and data manager
     pub async fn new(
         config: BacktestConfig,
-        mut data_manager: DataManager,
+        data_manager: &mut DataManager,
         strategy: Box<dyn Strategy>,
     ) -> GbResult<Self> {
         info!("Creating enhanced backtesting engine");
@@ -65,7 +64,6 @@ impl Engine {
         Ok(Self {
             current_time: config.start_date,
             config,
-            data_manager,
             portfolio,
             strategy,
             market_data,

--- a/crates/gb-engine/src/lib.rs
+++ b/crates/gb-engine/src/lib.rs
@@ -65,11 +65,10 @@ impl BacktestEngine {
     pub async fn run_with_strategy(&mut self, strategy: Box<dyn Strategy>) -> GbResult<BacktestResult> {
         info!("Starting backtest with strategy: {}", strategy.get_config().name);
         
-        // Create the full Engine with strategy support
-        let data_manager = DataManager::new().await?;
+        // Create the full Engine with strategy support using our existing data manager
         let mut engine = Engine::new(
             self.config.clone(),
-            data_manager,
+            &mut self.data_manager,
             strategy,
         ).await?;
         
@@ -386,10 +385,10 @@ mod tests {
         config.start_date = Utc::now() - Duration::days(5);
         config.end_date = Utc::now();
         
-        let data_manager = DataManager::new().await.unwrap();
+        let mut data_manager = DataManager::new().await.unwrap();
         let strategy = Box::new(BuyAndHoldStrategy::new());
         
-        let engine_result = Engine::new(config, data_manager, strategy).await;
+        let engine_result = Engine::new(config, &mut data_manager, strategy).await;
         assert!(engine_result.is_ok());
         
         let mut engine = engine_result.unwrap();


### PR DESCRIPTION
## Summary
This PR implements proper integration between the backtesting Engine and the Strategy trait, replacing the previous placeholder implementation.

## What was the problem?
The `Engine::generate_strategy_signals()` method was using mock signal generation instead of calling the actual `Strategy::on_market_event()` method. This meant strategies defined via the Strategy trait weren't actually being executed during backtests.

## What does this PR do?

### engine.rs
- **Replaced mock `generate_strategy_signals()`** with proper strategy integration that calls `strategy.on_market_event()` for each bar
- **Added `build_strategy_context()`** to create a complete StrategyContext with:
  - Current portfolio state
  - Market data buffers with historical bars up to current time
  - Pending orders
- **Added `process_strategy_action()`** to handle all StrategyAction variants (PlaceOrder, CancelOrder, Log, SetParameter)
- **Added `call_strategy_day_end()`** for end-of-day processing (needed by MomentumStrategy)
- **Added `call_strategy_stop()`** for cleanup when backtest completes
- **Updated simulation loop** to properly call strategy lifecycle methods in order

### lib.rs
- **Added `run_with_strategy()`** method to BacktestEngine for proper strategy execution
- **Re-exported `Engine`** for direct use
- **Preserved legacy `run()`** for backwards compatibility
- **Added comprehensive tests** for all 4 built-in strategies

## Testing
Added tests for:
- `test_backtest_with_buy_and_hold_strategy`
- `test_backtest_with_moving_average_crossover_strategy`
- `test_backtest_with_momentum_strategy`
- `test_backtest_with_mean_reversion_strategy`
- `test_strategy_integration_daily_returns_tracked`
- `test_engine_directly_with_strategy`

## Impact
The Rust backtesting engine now properly executes strategies. This enables:
- Strategies receiving market events and generating orders
- Access to current portfolio state and market data
- End-of-day rebalancing for strategies that need it
- Proper cleanup on stop

This completes the core Engine ↔ Strategy integration that was identified as the most important missing piece.