### PR TITLE
Add public docs site (GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Docs
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 High‑performance quantitative backtesting platform built in Rust with Python bindings and a Streamlit UI.
 
 [![Tests](https://img.shields.io/badge/tests-25%20passing-brightgreen)](#testing)
+[![Docs](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs.yml/badge.svg?branch=main)](https://latencytdh.github.io/GlowBack/)
 [![Rust Version](https://img.shields.io/badge/rust-1.70%2B-blue)](#development-setup)
 [![Python Support](https://img.shields.io/badge/python-3.8%2B-blue)](#python-bindings)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,17 @@
+# Architecture
+
+GlowBack is a Rust‑first backtesting platform with a Python SDK and local UI.
+
+## Core Crates
+
+- **gb-types**: core data structures, orders, portfolio, strategies
+- **gb-data**: data ingestion, providers, DuckDB catalog, Parquet storage/loader
+- **gb-engine**: event‑driven backtesting engine and market simulation
+- **gb-python**: PyO3 Python bindings
+
+## Data Flow (high‑level)
+
+1. Load data from providers into storage/catalog.
+2. Configure a strategy and execution parameters.
+3. Run the engine and stream results to UI/SDK.
+4. Persist results for analysis and reporting.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,17 @@
+# Contributing
+
+We welcome contributions. Please keep changes scoped and well‑documented.
+
+## Workflow
+
+1. Create a branch from `main`.
+2. Make focused changes.
+3. Run relevant tests.
+4. Update docs if user‑facing behavior changes.
+5. Open a PR with a clear summary and test notes.
+
+## Tests
+
+```bash
+cargo test --workspace
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Prerequisites
+
+- Rust 1.70+
+- Python 3.8+ (for Python bindings)
+
+## Clone and Test
+
+```bash
+git clone https://github.com/LatencyTDH/GlowBack.git
+cd GlowBack
+cargo test --workspace
+```
+
+## Run an Example
+
+```bash
+cargo run --example basic_usage -p gb-types
+```
+
+## Launch the UI
+
+```bash
+cd ui
+python setup.py
+# Opens http://localhost:8501
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# GlowBack
+
+High‑performance quantitative backtesting platform built in Rust with Python bindings and a Streamlit UI.
+
+## Highlights
+
+- Event‑driven simulation engine with realistic execution models
+- Data ingestion (CSV, Alpha Vantage, sample data)
+- Arrow/Parquet storage with DuckDB metadata catalog
+- Strategy library (4 built‑in strategies)
+- Python bindings with async support
+- Streamlit UI for strategy development and analysis
+
+## Quick Links
+
+- [Getting Started](getting-started.md)
+- [Architecture](architecture.md)
+- [Contributing](contributing.md)
+
+## Status
+
+Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: GlowBack
+site_description: High-performance quantitative backtesting platform built in Rust with Python bindings and a Streamlit UI.
+site_url: https://latencytdh.github.io/GlowBack/
+repo_url: https://github.com/LatencyTDH/GlowBack
+repo_name: LatencyTDH/GlowBack
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - toc.integrate
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - Contributing: contributing.md


### PR DESCRIPTION
Adds MkDocs documentation and a GitHub Pages deploy workflow, plus a docs badge in the README.