### PR TITLE
Expand docs site structure and content

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -1,0 +1,5 @@
+# Python API Reference
+
+Python bindings are provided via `gb-python` (PyO3).
+
+For now, see the Python examples and type hints in the package. This page will link to generated API docs once they are published.

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -1,0 +1,10 @@
+# Rust API Reference
+
+We plan to publish rustdoc for the core crates.
+
+For now, see the crate sources:
+- `crates/gb-types`
+- `crates/gb-data`
+- `crates/gb-engine`
+
+When rustdoc is enabled, this page will link to the generated docs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,3 +15,18 @@ GlowBack is a Rust‑first backtesting platform with a Python SDK and local UI.
 2. Configure a strategy and execution parameters.
 3. Run the engine and stream results to UI/SDK.
 4. Persist results for analysis and reporting.
+
+## System Diagram
+
+```mermaid
+graph TD
+    subgraph Researcher Workspace
+        Jupyter[JupyterLab]
+        CLI[CLI]
+    end
+    Jupyter -->|REST/WS| API[FastAPI Gateway]
+    CLI -->|gRPC| API
+    API --> Engine[Rust Engine]
+    Engine --> Store[(Storage)]
+    API --> UI[React/Streamlit UI]
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Docs site created and expanded
+- CI and workflow improvements

--- a/docs/concepts/core-concepts.md
+++ b/docs/concepts/core-concepts.md
@@ -1,0 +1,11 @@
+# Core Concepts
+
+GlowBack is an event‑driven backtesting system. Understanding a few core concepts helps you reason about results and performance.
+
+## Key Ideas
+
+- **Events**: Market data is processed in chronological order across symbols.
+- **Strategies**: Logic that emits orders in response to events.
+- **Execution**: Orders fill with realistic slippage, latency, and commission.
+- **Portfolio**: Tracks positions, cash, and P&L over time.
+- **Results**: Metrics and artifacts (equity curve, trades) for evaluation.

--- a/docs/concepts/data-model.md
+++ b/docs/concepts/data-model.md
@@ -1,0 +1,16 @@
+# Data Model
+
+GlowBack uses explicit, typed structures for market data and execution.
+
+## Bars
+
+Bars represent OHLCV data with nanosecond timestamps in UTC.
+
+## Symbols
+
+Symbols identify instruments (equities, later crypto/FX). Resolution specifies the bar interval.
+
+## Storage
+
+- **Arrow/Parquet** for columnar storage
+- **DuckDB** for metadata and queryable catalogs

--- a/docs/concepts/execution-model.md
+++ b/docs/concepts/execution-model.md
@@ -1,0 +1,10 @@
+# Execution Model
+
+The engine simulates realistic execution:
+
+- **Latency**: configurable delay between order submission and fill
+- **Slippage**: basis‑point or custom models
+- **Commission**: per‑share or percentage models
+- **Order types**: market, limit, stop, stop‑limit
+
+The simulator processes events in time order across symbols to avoid look‑ahead bias.

--- a/docs/concepts/results-metrics.md
+++ b/docs/concepts/results-metrics.md
@@ -1,0 +1,10 @@
+# Results & Metrics
+
+Backtest results include:
+
+- **Equity curve** and drawdowns
+- **Performance metrics**: Sharpe, Sortino, Calmar, CAGR
+- **Risk metrics**: VaR, CVaR, skewness, kurtosis
+- **Trade analytics**: win rate, profit factor, average win/loss
+
+Results are persisted for later analysis and reporting.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,3 +15,9 @@ We welcome contributions. Please keep changes scoped and well‑documented.
 ```bash
 cargo test --workspace
 ```
+
+## Repo Structure
+
+- `crates/` — Rust crates
+- `ui/` — Streamlit UI
+- `docs/` — MkDocs documentation

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,11 @@
+# Examples
+
+This section will host runnable examples with expected outputs.
+
+Planned examples:
+
+- Buy & Hold on AAPL
+- Moving Average Crossover on SPY
+- Momentum strategy with parameter sweep
+
+If you want a specific example, open an issue and it can be added here.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,10 @@
+# FAQ
+
+## The docs are minimal. Is that expected?
+Yes. The docs are being expanded; contributions are welcome.
+
+## Do I need Rust installed to use the UI?
+Not strictly. The UI can run in Python‑only mode, but some features may be limited.
+
+## Where do I file bugs?
+Open an issue in the GitHub repository with reproduction steps.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,3 +26,9 @@ cd ui
 python setup.py
 # Opens http://localhost:8501
 ```
+
+## Next Steps
+
+- Load sample data via the UI
+- Try a built‑in strategy template
+- Review results in the dashboard

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,12 +11,24 @@ High‑performance quantitative backtesting platform built in Rust with Python b
 - Python bindings with async support
 - Streamlit UI for strategy development and analysis
 
-## Quick Links
+## Quickstart
 
-- [Getting Started](getting-started.md)
-- [Architecture](architecture.md)
-- [Contributing](contributing.md)
+```bash
+git clone https://github.com/LatencyTDH/GlowBack.git
+cd GlowBack
+cargo test --workspace
+cargo run --example basic_usage -p gb-types
+```
 
-## Status
+```bash
+cd ui
+python setup.py
+# Opens http://localhost:8501
+```
 
-Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress.
+## Where to go next
+
+- **Getting Started** for setup and first run
+- **Concepts** for data model and execution details
+- **Tutorials** for common workflows
+- **API Reference** for bindings and crate docs

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,9 @@
+# Performance
+
+## Goals
+
+- Backtest 10 years of daily data for ~500 equities in < 60 seconds on an 8‑core dev machine.
+
+## Benchmarks (planned)
+
+We will publish reproducible benchmarks once the engine stabilization work is complete.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+**Phase 1 – Alpha**
+- FastAPI gateway
+- Jupyter integration
+- Basic analytics
+
+**Phase 2 – Beta**
+- React dashboard
+- Ray optimization
+- Crypto support
+- Docker deploy
+
+**Phase 3 – GA**
+- Security hardening / SOC2 prep
+- Documentation site
+- Community launch
+
+**Phase 4 – Extended**
+- Live trading module
+- Options support
+- Real‑time risk engine

--- a/docs/tutorials/alpha-vantage.md
+++ b/docs/tutorials/alpha-vantage.md
@@ -1,0 +1,19 @@
+# Alpha Vantage
+
+## Setup
+
+1. Get an API key from https://www.alphavantage.co/
+2. Add the provider in Python or UI.
+
+## Load via Python
+
+```python
+import glowback
+
+manager = glowback.PyDataManager()
+manager.add_alpha_vantage_provider("YOUR_API_KEY")
+```
+
+## Notes
+
+Alpha Vantage has rate limits on the free tier. Use caching for repeated runs.

--- a/docs/tutorials/csv-data.md
+++ b/docs/tutorials/csv-data.md
@@ -1,0 +1,21 @@
+# CSV Data
+
+## Prepare a CSV
+
+Include columns for timestamp, open, high, low, close, volume.
+
+## Load via UI
+
+1. Open the **Data Loader** page.
+2. Select **CSV Upload**.
+3. Map columns and choose a symbol.
+4. Load and validate the dataset.
+
+## Load via Python
+
+```python
+import glowback
+
+manager = glowback.PyDataManager()
+manager.add_csv_provider("/path/to/data")
+```

--- a/docs/tutorials/strategy-templates.md
+++ b/docs/tutorials/strategy-templates.md
@@ -1,0 +1,22 @@
+# Strategy Templates
+
+The UI includes built‑in templates for common strategies:
+
+- Buy & Hold
+- Moving Average Crossover
+- Momentum
+- Mean Reversion
+
+## Use in UI
+
+1. Open **Strategy Editor**.
+2. Choose a template from the dropdown.
+3. Adjust parameters and save the configuration.
+
+## Use in Rust (conceptual)
+
+```rust
+let strategy = MovingAverageCrossoverStrategy::new()
+  .with_fast_period(10)
+  .with_slow_period(30);
+```

--- a/docs/tutorials/ui-workflow.md
+++ b/docs/tutorials/ui-workflow.md
@@ -1,0 +1,14 @@
+# UI Workflow
+
+## Steps
+
+1. **Load data** in the Data Loader page.
+2. **Create a strategy** in the Strategy Editor.
+3. **Run backtest** in the Backtest Runner.
+4. **Review results** in Results Dashboard and Portfolio Analyzer.
+
+## Tips
+
+- Start with sample data to validate logic quickly.
+- Save configurations for reproducibility.
+- Export results for offline analysis.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,9 +11,32 @@ theme:
     - navigation.instant
     - navigation.tabs
     - toc.integrate
+    - search.suggest
+    - search.highlight
+
+plugins:
+  - search
 
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Concepts:
+      - Core Concepts: concepts/core-concepts.md
+      - Data Model: concepts/data-model.md
+      - Execution Model: concepts/execution-model.md
+      - Results & Metrics: concepts/results-metrics.md
+  - Tutorials:
+      - CSV Data: tutorials/csv-data.md
+      - Alpha Vantage: tutorials/alpha-vantage.md
+      - Strategy Templates: tutorials/strategy-templates.md
+      - UI Workflow: tutorials/ui-workflow.md
+  - Examples: examples/index.md
   - Architecture: architecture.md
+  - API Reference:
+      - Rust: api/rust.md
+      - Python: api/python.md
+  - Performance: performance.md
+  - Roadmap: roadmap.md
+  - FAQ: faq.md
+  - Changelog: changelog.md
   - Contributing: contributing.md


### PR DESCRIPTION
Adds a full docs information architecture (concepts, tutorials, examples, API reference, roadmap, FAQ, changelog) and enables search in MkDocs.