### PR TITLE
Add docs update guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+## Checklist
+
+- [ ] Docs updated (or not needed — explain below)
+
+## Docs note
+
+If docs are not needed, explain why:
+

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -1,0 +1,31 @@
+name: Docs Guard
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - crates/**
+              - ui/**
+            docs:
+              - docs/**
+              - README.md
+      - name: Enforce docs update
+        if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'no-docs') }}
+        run: |
+          if [[ "${{ steps.filter.outputs.code }}" == "true" && "${{ steps.filter.outputs.docs }}" != "true" ]]; then
+            echo "Docs update required when code changes. Either update docs/README or add a no-docs label to the PR."
+            exit 1
+          fi
+      - name: Allow no-docs label
+        if: contains(join(github.event.pull_request.labels.*.name, ','), 'no-docs')
+        run: echo "no-docs label present; bypassing docs requirement."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ GlowBack is a Rust‑first quantitative backtesting platform with Python binding
 ## Development Standards
 
 - **Keep changes scoped.** Prefer small, reviewable commits.
-- **Document behavior.** If you change APIs or user behavior, update the relevant README or docs.
+- **Document behavior.** If you change APIs or user behavior, update docs in the same PR.
 - **Respect invariants.** Financial data uses `Decimal` and nanosecond UTC timestamps.
 - **Avoid breaking tests.** Run targeted tests for the crate you touch.
 


### PR DESCRIPTION
Adds a PR template, a docs-required check for code changes (with a no-docs label override), and updates AGENTS.md to require docs when behavior changes.