### PR TITLE
Enable Mermaid diagrams in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material pymdown-extensions
       - run: mkdocs build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,13 @@ theme:
 plugins:
   - search
 
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
 nav:
   - Home: index.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
Adds Mermaid support to MkDocs and installs the required pymdown extensions so diagrams render on the docs site.