### PR TITLE
Add manual full-workspace CI trigger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,13 +17,23 @@ on:
       - ".github/workflows/rust.yml"
   schedule:
     - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      full_workspace:
+        description: "Run full workspace build/tests"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   changes:
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && inputs.full_workspace == 'true')
     runs-on: ubuntu-latest
     outputs:
       crates: ${{ steps.set-matrix.outputs.crates }}
@@ -75,7 +85,7 @@ jobs:
           fi
 
   test:
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && inputs.full_workspace == 'true')
     runs-on: ubuntu-latest
     needs: changes
     strategy:
@@ -94,7 +104,7 @@ jobs:
         run: cargo test -p ${{ matrix.crate }} --verbose
 
   full-workspace:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full_workspace == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds workflow_dispatch with a full_workspace input to run the full workspace build/tests on demand.