### PR TITLE
Add Jupyter notebook helpers for Python bindings

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -46,6 +46,14 @@ Contains the results of a backtest run.
   - `total_commissions`
 - `equity_curve`: List of daily snapshots (`value`, `cash`, `positions`, `total_pnl`, `returns`, `daily_return`, `drawdown`).
 
+Notebook helpers (requires pandas/matplotlib):
+
+```python
+curve = result.to_dataframe()
+metrics = result.metrics_dataframe()
+ax = result.plot_equity()
+```
+
 ### `PyDataManager`
 
 Used for data ingestion and management.

--- a/docs/tutorials/notebook.md
+++ b/docs/tutorials/notebook.md
@@ -1,0 +1,45 @@
+# Jupyter Notebook Workflow
+
+GlowBack’s Python bindings are designed to work cleanly in notebooks. Use the helpers below to explore results inline.
+
+## Install Notebook Dependencies
+
+```bash
+pip install jupyter pandas matplotlib
+```
+
+## Run a Backtest
+
+```python
+import glowback
+
+engine = glowback.PyBacktestEngine(
+    symbols=["AAPL", "MSFT"],
+    start_date="2024-01-01T00:00:00Z",
+    end_date="2024-12-31T23:59:59Z",
+    initial_capital=100000.0,
+)
+
+result = engine.run_buy_and_hold()
+```
+
+## Explore Results Inline
+
+```python
+# Equity curve as a DataFrame
+curve = result.to_dataframe()
+curve.head()
+
+# Metrics summary table
+metrics = result.metrics_dataframe()
+metrics
+
+# Plot the equity curve
+ax = result.plot_equity()
+```
+
+## Notes
+
+- `to_dataframe()` and `metrics_dataframe()` require **pandas**.
+- `plot_equity()` requires **matplotlib**.
+- For custom visualizations, you can also use `result.equity_curve` directly (list of dicts).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - CSV Data: tutorials/csv-data.md
       - Alpha Vantage: tutorials/alpha-vantage.md
       - Strategy Templates: tutorials/strategy-templates.md
+      - Notebook Workflow: tutorials/notebook.md
       - UI Workflow: tutorials/ui-workflow.md
   - Examples: examples/index.md
   - Architecture: architecture.md


### PR DESCRIPTION
## Summary\n- add pandas/matplotlib helpers on PyBacktestResult (to_dataframe, metrics_dataframe, plot_equity)\n- document notebook workflow and wire it into mkdocs nav\n- document notebook helpers in the Python API reference\n\n## Testing\n- cargo test --workspace\n\nCloses #7