### PR TITLE
Add docker-compose deployment for API/UI/engine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+**/__pycache__
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/.venv
+**/.env
+**/*.pyc
+target
+data
+assets
+node_modules
+ui/.streamlit

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ cd ui && python setup.py
 # Opens http://localhost:8501
 ```
 
+### Docker (Compose)
+
+```bash
+docker compose up --build
+```
+
+Services:
+- UI: http://localhost:8501
+- API: http://localhost:8000 (set `GLOWBACK_API_KEY` to require auth)
+- Engine: http://localhost:8081 (health JSON)
+
 ## Python Bindings
 
 ```python

--- a/crates/gb-engine/Cargo.toml
+++ b/crates/gb-engine/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "GlowBack backtesting engine"
 
+[[bin]]
+name = "gb-engine-service"
+path = "src/bin/engine_service.rs"
+
 [dependencies]
 gb-types = { path = "../gb-types" }
 gb-data = { path = "../gb-data" }

--- a/crates/gb-engine/src/bin/engine_service.rs
+++ b/crates/gb-engine/src/bin/engine_service.rs
@@ -1,0 +1,30 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("GLOWBACK_ENGINE_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:8081".to_string());
+
+    let listener = TcpListener::bind(&addr).await?;
+    println!("GlowBack engine service listening on {addr}");
+
+    loop {
+        let (mut socket, _) = listener.accept().await?;
+
+        tokio::spawn(async move {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer).await;
+
+            let body = r#"{"status":"ok","service":"engine"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+
+            let _ = socket.write_all(response.as_bytes()).await;
+            let _ = socket.shutdown().await;
+        });
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+services:
+  engine:
+    build:
+      context: .
+      dockerfile: docker/engine.Dockerfile
+    ports:
+      - "8081:8081"
+    environment:
+      - GLOWBACK_ENGINE_ADDR=0.0.0.0:8081
+
+  api:
+    build:
+      context: .
+      dockerfile: docker/api.Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - GLOWBACK_ENGINE_URL=http://engine:8081
+      - GLOWBACK_API_KEY=${GLOWBACK_API_KEY:-}
+    depends_on:
+      - engine
+
+  ui:
+    build:
+      context: .
+      dockerfile: docker/ui.Dockerfile
+    ports:
+      - "8501:8501"
+    environment:
+      - GLOWBACK_API_URL=http://api:8000
+    depends_on:
+      - api

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY api/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY api/app /app/app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -1,0 +1,24 @@
+FROM rust:1.75-slim AS builder
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+
+RUN cargo build -p gb-engine --bin gb-engine-service --release
+
+FROM debian:bookworm-slim
+
+RUN useradd -m engine
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/gb-engine-service /usr/local/bin/gb-engine-service
+
+ENV GLOWBACK_ENGINE_ADDR=0.0.0.0:8081
+
+EXPOSE 8081
+
+USER engine
+
+CMD ["gb-engine-service"]

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY ui/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY ui /app
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0", "--server.port=8501"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,17 @@ python setup.py
 # Opens http://localhost:8501
 ```
 
+## Docker (Compose)
+
+```bash
+docker compose up --build
+```
+
+Services:
+- UI: http://localhost:8501
+- API: http://localhost:8000 (set `GLOWBACK_API_KEY` to require auth)
+- Engine: http://localhost:8081 (health JSON)
+
 ## Next Steps
 
 - Load sample data via the UI


### PR DESCRIPTION
## Summary
- add docker-compose and Dockerfiles for API, UI, and engine
- add lightweight engine service stub for container health checks
- document docker workflow in README + getting started

## Testing
- cargo test -p gb-engine
