### PR TITLE
Fix engine Docker build with stable Rust

### DIFF
--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-slim AS builder
+FROM rust:stable-slim AS builder
 
 WORKDIR /app
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,8 @@ python setup.py
 docker compose up --build
 ```
 
+Note: The engine image builds with `rust:stable-slim` to match `rust-toolchain.toml`.
+
 Services:
 - UI: http://localhost:8501
 - API: http://localhost:8000 (set `GLOWBACK_API_KEY` to require auth)


### PR DESCRIPTION
## Summary\n- switch engine Docker builder image to rust:stable-slim (matches rust-toolchain)\n- document the Docker engine Rust toolchain note\n\n## Testing\n- cargo test --workspace