### PR TITLE
feat: security hardening — rate limiting, CORS, HSTS, structured logging & input validation

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -8,7 +8,13 @@ from pydantic import BaseModel, Field
 
 
 class StrategyConfig(BaseModel):
-    name: str = Field(default="buy_and_hold", description="Strategy identifier")
+    name: str = Field(
+        default="buy_and_hold",
+        description="Strategy identifier",
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-z0-9_]+$",
+    )
     params: dict[str, Any] = Field(default_factory=dict, description="Strategy parameters")
 
 
@@ -19,15 +25,19 @@ class ExecutionConfig(BaseModel):
 
 
 class BacktestRequest(BaseModel):
-    symbols: list[str] = Field(min_length=1)
+    symbols: list[str] = Field(min_length=1, max_length=100)
     start_date: datetime
     end_date: datetime
-    resolution: str = Field(default="day", description="tick|second|minute|hour|day")
+    resolution: str = Field(
+        default="day",
+        description="tick|second|minute|hour|day",
+        pattern=r"^(tick|second|minute|hour|day)$",
+    )
     strategy: StrategyConfig = Field(default_factory=StrategyConfig)
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
-    initial_capital: float = Field(default=1_000_000.0)
-    currency: str = Field(default="USD")
-    timezone: str = Field(default="UTC")
+    initial_capital: float = Field(default=1_000_000.0, gt=0, le=1e12)
+    currency: str = Field(default="USD", min_length=3, max_length=5, pattern=r"^[A-Z]{3,5}$")
+    timezone: str = Field(default="UTC", max_length=64)
 
 
 class RunState(str, Enum):

--- a/api/app/rate_limit.py
+++ b/api/app/rate_limit.py
@@ -1,0 +1,80 @@
+"""Simple in-memory per-IP rate limiter for SOC2 compliance."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from threading import Lock
+
+from fastapi import HTTPException, Request, status
+
+
+@dataclass
+class _Bucket:
+    """Token bucket for a single client."""
+
+    tokens: float
+    last_refill: float
+
+
+class RateLimiter:
+    """Per-IP token-bucket rate limiter.
+
+    Configurable via environment variables:
+      - GLOWBACK_RATE_LIMIT  – max requests per window (default 100)
+      - GLOWBACK_RATE_WINDOW – window in seconds (default 60)
+    """
+
+    def __init__(self) -> None:
+        self._max_tokens = int(os.getenv("GLOWBACK_RATE_LIMIT", "100"))
+        self._window = float(os.getenv("GLOWBACK_RATE_WINDOW", "60"))
+        self._buckets: dict[str, _Bucket] = defaultdict(
+            lambda: _Bucket(tokens=self._max_tokens, last_refill=time.monotonic())
+        )
+        self._lock = Lock()
+
+    def _refill(self, bucket: _Bucket) -> None:
+        now = time.monotonic()
+        elapsed = now - bucket.last_refill
+        bucket.tokens = min(
+            self._max_tokens,
+            bucket.tokens + elapsed * (self._max_tokens / self._window),
+        )
+        bucket.last_refill = now
+
+    def check(self, client_ip: str) -> tuple[bool, dict[str, str]]:
+        """Return (allowed, headers). Headers are always set for observability."""
+        with self._lock:
+            bucket = self._buckets[client_ip]
+            self._refill(bucket)
+
+            headers = {
+                "X-RateLimit-Limit": str(self._max_tokens),
+                "X-RateLimit-Remaining": str(max(0, int(bucket.tokens) - 1)),
+                "X-RateLimit-Reset": str(int(bucket.last_refill + self._window)),
+            }
+
+            if bucket.tokens >= 1:
+                bucket.tokens -= 1
+                return True, headers
+
+            return False, headers
+
+
+_rate_limiter = RateLimiter()
+
+
+async def rate_limit_check(request: Request) -> None:
+    """FastAPI dependency that enforces per-IP rate limiting."""
+    client_ip = request.client.host if request.client else "unknown"
+    allowed, headers = _rate_limiter.check(client_ip)
+    # Stash headers so the audit middleware can apply them
+    request.state.rate_limit_headers = headers
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded",
+            headers=headers,
+        )

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -1,0 +1,112 @@
+# Security Configuration
+
+GlowBack follows SOC2 alignment practices. This page documents the security
+controls available in the API gateway and how to configure them.
+
+## Authentication
+
+The API requires an API key for all endpoints except `/healthz`.
+
+Set the allowed keys via the `GLOWBACK_API_KEY` environment variable
+(comma-separated for multiple keys):
+
+```bash
+export GLOWBACK_API_KEY="key-one,key-two"
+```
+
+Keys can be sent as:
+
+- `Authorization: Bearer <key>` header (preferred)
+- `X-API-Key: <key>` header
+- `?api_key=<key>` query parameter (not recommended for production)
+
+If `GLOWBACK_API_KEY` is **unset**, authentication is disabled (development
+mode only).
+
+## CORS
+
+Set `GLOWBACK_CORS_ORIGINS` to a comma-separated list of allowed origins:
+
+```bash
+export GLOWBACK_CORS_ORIGINS="https://app.example.com,https://admin.example.com"
+```
+
+When unset, no CORS middleware is applied (requests from other origins are
+blocked by browsers by default).
+
+## Rate Limiting
+
+Per-IP token-bucket rate limiting is enforced on all authenticated endpoints.
+
+| Variable              | Default | Description            |
+| --------------------- | ------- | ---------------------- |
+| `GLOWBACK_RATE_LIMIT` | 100     | Max requests per window |
+| `GLOWBACK_RATE_WINDOW` | 60     | Window in seconds       |
+
+Rate limit headers are returned on every response:
+
+- `X-RateLimit-Limit`
+- `X-RateLimit-Remaining`
+- `X-RateLimit-Reset`
+
+## Request Body Size
+
+The maximum request body size defaults to **1 MiB**. Override with:
+
+```bash
+export GLOWBACK_MAX_BODY_BYTES=2097152  # 2 MiB
+```
+
+Requests exceeding the limit receive a `413 Request Entity Too Large` response.
+
+## Security Headers
+
+All HTTP responses include the following headers:
+
+| Header                      | Value                                                  |
+| --------------------------- | ------------------------------------------------------ |
+| `X-Content-Type-Options`    | `nosniff`                                              |
+| `X-Frame-Options`           | `DENY`                                                 |
+| `Referrer-Policy`           | `no-referrer`                                          |
+| `Permissions-Policy`        | `geolocation=(), microphone=(), camera=()`             |
+| `Cache-Control`             | `no-store`                                             |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload`         |
+| `Content-Security-Policy`   | `default-src 'none'; frame-ancestors 'none'`           |
+| `X-Request-ID`              | Per-request UUID (or client-provided `X-Request-ID`)   |
+
+## Structured Logging
+
+Logs are emitted as single-line JSON by default for easy ingestion into SIEM
+systems. Override with `GLOWBACK_LOG_FORMAT=text` for human-readable output.
+
+Set the log level with `GLOWBACK_LOG_LEVEL` (default `INFO`).
+
+Every HTTP request is logged with:
+
+- `request_id`
+- `method`, `path`, `status`
+- `client_ip`
+- `duration_ms`
+
+Failed authentication and rate-limit violations are logged at `WARNING` level.
+
+## Health Check
+
+`GET /healthz` returns `{"status": "healthy", "version": "..."}` with no
+authentication required. Use this for load balancer and Kubernetes liveness
+probes.
+
+## Audit Trail
+
+All requests receive a unique `X-Request-ID` that threads through logs and
+response headers, enabling full request traceability for incident response.
+
+## Input Validation
+
+- **Strategy names** are restricted to lowercase alphanumeric + underscore
+  (`^[a-z0-9_]+$`), max 128 characters.
+- **Currency** must be 3–5 uppercase letters (`^[A-Z]{3,5}$`).
+- **Resolution** is constrained to the enum
+  `tick|second|minute|hour|day`.
+- **Symbols list** is capped at 100 entries.
+- **Initial capital** must be positive and ≤ 1 trillion.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - Data Model: concepts/data-model.md
       - Execution Model: concepts/execution-model.md
       - Results & Metrics: concepts/results-metrics.md
+      - Security: concepts/security.md
   - Tutorials:
       - CSV Data: tutorials/csv-data.md
       - Alpha Vantage: tutorials/alpha-vantage.md


### PR DESCRIPTION
## Summary

Implements additional security controls for SOC2 alignment, building on the audit logging and security headers from PR #44.

### New Features

#### Rate Limiting
- Per-IP **token-bucket rate limiter** with configurable limits via `GLOWBACK_RATE_LIMIT` (default 100 req) and `GLOWBACK_RATE_WINDOW` (default 60s)
- Rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) on every response
- `429 Too Many Requests` returned when limit exceeded

#### CORS
- Configurable CORS middleware via `GLOWBACK_CORS_ORIGINS` (comma-separated)
- Restricted to GET/POST methods, exposes rate-limit and request-ID headers

#### Security Headers
- **HSTS** (`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`)
- **Content-Security-Policy** (`default-src 'none'; frame-ancestors 'none'`)

#### Health Check
- `GET /healthz` — unauthenticated liveness probe for load balancers / k8s

#### Structured Logging
- JSON-formatted log output by default (`GLOWBACK_LOG_FORMAT=json`)
- Configurable log level (`GLOWBACK_LOG_LEVEL`)
- Every request logged with request_id, method, path, status, client_ip, duration_ms

#### Request Body Size Limit
- Default 1 MiB (`GLOWBACK_MAX_BODY_BYTES`), returns `413` when exceeded

#### Input Validation Hardening
- Strategy name restricted to `^[a-z0-9_]+$` (max 128 chars)
- Currency field restricted to `^[A-Z]{3,5}$`
- Resolution constrained to enum `tick|second|minute|hour|day`
- Symbols list capped at 100 entries
- Initial capital bounded: `> 0, ≤ 1e12`

### Files Changed
- `api/app/main.py` — CORS, rate limiting, HSTS, CSP, JSON logging, body size limit, healthz endpoint
- `api/app/rate_limit.py` — new per-IP token-bucket rate limiter module
- `api/app/models.py` — tightened input validation constraints
- `docs/concepts/security.md` — new security configuration documentation
- `mkdocs.yml` — added Security to nav

### Testing
- All Python files compile cleanly (`py_compile`)
- `cargo test --workspace` — all 56 tests pass
- `mkdocs build --strict` — passes cleanly
- Docs updated to satisfy docs-guard CI check

## Checklist
- [x] Docs updated

Refs #13