### PR TITLE
fix(ci): docs guard — query labels via API so reruns work

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -19,13 +19,21 @@ jobs:
             docs:
               - docs/**
               - README.md
+      - name: Check for no-docs label
+        id: labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HAS_NO_DOCS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            --jq '[.[].name] | if index("no-docs") then "true" else "false" end')
+          echo "no_docs=$HAS_NO_DOCS" >> "$GITHUB_OUTPUT"
       - name: Enforce docs update
-        if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'no-docs') }}
+        if: steps.labels.outputs.no_docs != 'true'
         run: |
           if [[ "${{ steps.filter.outputs.code }}" == "true" && "${{ steps.filter.outputs.docs }}" != "true" ]]; then
             echo "Docs update required when code changes. Either update docs/README or add a no-docs label to the PR."
             exit 1
           fi
       - name: Allow no-docs label
-        if: contains(join(github.event.pull_request.labels.*.name, ','), 'no-docs')
+        if: steps.labels.outputs.no_docs == 'true'
         run: echo "no-docs label present; bypassing docs requirement."


### PR DESCRIPTION
## Problem

The docs-guard workflow read labels from `github.event.pull_request.labels`, which is frozen at trigger time. Adding `no-docs` after the initial run and re-running the check had no effect — you had to close/reopen the PR to get it to pick up the label.

## Fix

Replace the event-payload label check with a live API query (`gh api .../labels`) at runtime. Now reruns correctly see labels added after the original trigger.

No functional change to the docs requirement logic itself — just how it detects the `no-docs` label.