### PR TITLE
feat: add gb-options crate — options pricing, greeks & execution

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,10 +54,12 @@ jobs:
               - crates/gb-types/**
             gb-python:
               - crates/gb-python/**
+            gb-options:
+              - crates/gb-options/**
       - id: set-matrix
         run: |
           if [[ "${{ steps.filter.outputs.common }}" == "true" ]]; then
-            echo 'crates=["gb-engine","gb-data","gb-types","gb-python"]' >> $GITHUB_OUTPUT
+            echo 'crates=["gb-engine","gb-data","gb-types","gb-options","gb-python"]' >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -65,15 +67,17 @@ jobs:
           gb_data="${{ steps.filter.outputs.gb-data }}"
           gb_types="${{ steps.filter.outputs.gb-types }}"
           gb_python="${{ steps.filter.outputs.gb-python }}"
+          gb_options="${{ steps.filter.outputs.gb-options }}"
 
           crates=()
           [[ "$gb_engine" == "true" ]] && crates+=("gb-engine")
           [[ "$gb_data" == "true" ]] && crates+=("gb-data")
           [[ "$gb_types" == "true" ]] && crates+=("gb-types")
+          [[ "$gb_options" == "true" ]] && crates+=("gb-options")
           [[ "$gb_python" == "true" ]] && crates+=("gb-python")
 
           if [ ${#crates[@]} -eq 0 ]; then
-            echo 'crates=["gb-engine","gb-data","gb-types","gb-python"]' >> $GITHUB_OUTPUT
+            echo 'crates=["gb-engine","gb-data","gb-types","gb-options","gb-python"]' >> $GITHUB_OUTPUT
           else
             json="["
             for c in "${crates[@]}"; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gb-options"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "gb-types",
+ "num-traits",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "gb-python"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/gb-engine",
     "crates/gb-data", 
     "crates/gb-types",
+    "crates/gb-options",
     "crates/gb-optimizer",
     "crates/gb-python"
 ]

--- a/crates/gb-options/Cargo.toml
+++ b/crates/gb-options/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gb-options"
+version = "0.1.0"
+edition = "2021"
+description = "Options pricing, greeks, and execution for GlowBack"
+
+[dependencies]
+gb-types = { path = "../gb-types" }
+chrono = { workspace = true }
+rust_decimal = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+num-traits = { workspace = true }
+
+[dev-dependencies]
+rust_decimal_macros = "1.37"

--- a/crates/gb-options/src/chain.rs
+++ b/crates/gb-options/src/chain.rs
@@ -1,0 +1,235 @@
+//! Options chain — a collection of contracts for a single underlying and expiration.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use gb_types::market::Symbol;
+
+use crate::contract::{ExerciseStyle, OptionContract, OptionKind};
+use crate::pricing::{black_scholes_price, PricingInput, PricingResult};
+
+/// A single row in an option chain (call + put at the same strike).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChainRow {
+    pub strike: Decimal,
+    pub call: PricingResult,
+    pub put: PricingResult,
+}
+
+/// An option chain for a single underlying/expiration pair.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OptionChain {
+    pub underlying: Symbol,
+    pub expiration: DateTime<Utc>,
+    pub rows: Vec<ChainRow>,
+    pub spot: Decimal,
+    pub generated_at: DateTime<Utc>,
+}
+
+/// Build an option chain with strikes spaced evenly around the spot price.
+///
+/// * `num_strikes` — total number of strikes (centered around ATM).
+/// * `strike_step` — spacing between consecutive strikes.
+pub fn build_chain(
+    underlying: Symbol,
+    expiration: DateTime<Utc>,
+    spot: f64,
+    risk_free_rate: f64,
+    volatility: f64,
+    dividend_yield: f64,
+    time_to_expiry: f64,
+    num_strikes: usize,
+    strike_step: f64,
+    exercise_style: ExerciseStyle,
+    multiplier: Decimal,
+) -> OptionChain {
+    let half = num_strikes / 2;
+    let atm_strike = (spot / strike_step).round() * strike_step;
+
+    let mut rows = Vec::with_capacity(num_strikes);
+
+    for i in 0..num_strikes {
+        let offset = i as f64 - half as f64;
+        let strike_f = atm_strike + offset * strike_step;
+        if strike_f <= 0.0 {
+            continue;
+        }
+        let strike = Decimal::from_f64_retain(strike_f).unwrap_or_default();
+
+        let call_contract = OptionContract::new(
+            underlying.clone(),
+            OptionKind::Call,
+            strike,
+            expiration,
+            exercise_style,
+            multiplier,
+        );
+        let put_contract = OptionContract::new(
+            underlying.clone(),
+            OptionKind::Put,
+            strike,
+            expiration,
+            exercise_style,
+            multiplier,
+        );
+
+        let input = PricingInput {
+            spot,
+            risk_free_rate,
+            volatility,
+            dividend_yield,
+            time_to_expiry,
+        };
+
+        let call_result = black_scholes_price(&call_contract, &input);
+        let put_result = black_scholes_price(&put_contract, &input);
+
+        rows.push(ChainRow {
+            strike,
+            call: call_result,
+            put: put_result,
+        });
+    }
+
+    OptionChain {
+        underlying,
+        expiration,
+        rows,
+        spot: Decimal::from_f64_retain(spot).unwrap_or_default(),
+        generated_at: Utc::now(),
+    }
+}
+
+impl OptionChain {
+    /// Find the ATM strike (closest to spot).
+    pub fn atm_strike(&self) -> Option<Decimal> {
+        self.rows
+            .iter()
+            .min_by_key(|r| {
+                let diff = (r.strike - self.spot).abs();
+                // Convert to a sortable integer (cents precision)
+                (diff * Decimal::from(10000)).to_i64().unwrap_or(i64::MAX)
+            })
+            .map(|r| r.strike)
+    }
+
+    /// Get a specific row by strike.
+    pub fn get_strike(&self, strike: Decimal) -> Option<&ChainRow> {
+        self.rows.iter().find(|r| r.strike == strike)
+    }
+
+    /// Number of strikes in the chain.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// True if the chain is empty.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::ExerciseStyle;
+    use chrono::{TimeZone, Utc};
+    use gb_types::market::Symbol;
+    use rust_decimal_macros::dec;
+
+    fn build_test_chain() -> OptionChain {
+        let underlying = Symbol::equity("AAPL");
+        let expiration = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+        build_chain(
+            underlying,
+            expiration,
+            150.0,
+            0.05,
+            0.25,
+            0.0,
+            0.25,
+            11,  // 11 strikes
+            5.0, // $5 apart
+            ExerciseStyle::European,
+            dec!(100),
+        )
+    }
+
+    #[test]
+    fn test_chain_has_strikes() {
+        let chain = build_test_chain();
+        assert_eq!(chain.len(), 11);
+        assert!(!chain.is_empty());
+    }
+
+    #[test]
+    fn test_chain_atm_strike() {
+        let chain = build_test_chain();
+        let atm = chain.atm_strike().unwrap();
+        // ATM should be 150
+        assert_eq!(atm, dec!(150));
+    }
+
+    #[test]
+    fn test_chain_strike_ordering() {
+        let chain = build_test_chain();
+        for i in 1..chain.rows.len() {
+            assert!(chain.rows[i].strike > chain.rows[i - 1].strike);
+        }
+    }
+
+    #[test]
+    fn test_chain_call_put_prices_positive() {
+        let chain = build_test_chain();
+        for row in &chain.rows {
+            let call_price = row.call.price.to_f64().unwrap();
+            let put_price = row.put.price.to_f64().unwrap();
+            assert!(
+                call_price >= 0.0,
+                "call price negative at strike {}",
+                row.strike
+            );
+            assert!(
+                put_price >= 0.0,
+                "put price negative at strike {}",
+                row.strike
+            );
+        }
+    }
+
+    #[test]
+    fn test_chain_get_strike() {
+        let chain = build_test_chain();
+        let row = chain.get_strike(dec!(150));
+        assert!(row.is_some());
+        assert_eq!(row.unwrap().strike, dec!(150));
+    }
+
+    #[test]
+    fn test_chain_get_strike_missing() {
+        let chain = build_test_chain();
+        assert!(chain.get_strike(dec!(999)).is_none());
+    }
+
+    #[test]
+    fn test_put_call_parity_across_chain() {
+        let chain = build_test_chain();
+        let s: f64 = 150.0;
+        let r: f64 = 0.05;
+        let t: f64 = 0.25;
+        for row in &chain.rows {
+            let c = row.call.price.to_f64().unwrap();
+            let p = row.put.price.to_f64().unwrap();
+            let k = row.strike.to_f64().unwrap();
+            let lhs = c - p;
+            let rhs = s - k * (-r * t).exp();
+            assert!(
+                (lhs - rhs).abs() < 0.02,
+                "put-call parity violated at strike {}: lhs={lhs}, rhs={rhs}",
+                row.strike,
+            );
+        }
+    }
+}

--- a/crates/gb-options/src/contract.rs
+++ b/crates/gb-options/src/contract.rs
@@ -1,0 +1,226 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use gb_types::market::Symbol;
+
+/// Option type — call or put.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum OptionKind {
+    Call,
+    Put,
+}
+
+impl fmt::Display for OptionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OptionKind::Call => write!(f, "Call"),
+            OptionKind::Put => write!(f, "Put"),
+        }
+    }
+}
+
+/// Exercise style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ExerciseStyle {
+    /// Can only be exercised at expiration.
+    European,
+    /// Can be exercised any time before expiration.
+    American,
+}
+
+impl fmt::Display for ExerciseStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExerciseStyle::European => write!(f, "European"),
+            ExerciseStyle::American => write!(f, "American"),
+        }
+    }
+}
+
+/// A single options contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OptionContract {
+    /// Underlying symbol.
+    pub underlying: Symbol,
+    /// Call or put.
+    pub kind: OptionKind,
+    /// Strike price.
+    pub strike: Decimal,
+    /// Expiration date (end of day UTC).
+    pub expiration: DateTime<Utc>,
+    /// Exercise style.
+    pub exercise_style: ExerciseStyle,
+    /// Contract multiplier (typically 100 for equity options).
+    pub multiplier: Decimal,
+}
+
+impl OptionContract {
+    pub fn new(
+        underlying: Symbol,
+        kind: OptionKind,
+        strike: Decimal,
+        expiration: DateTime<Utc>,
+        exercise_style: ExerciseStyle,
+        multiplier: Decimal,
+    ) -> Self {
+        Self {
+            underlying,
+            kind,
+            strike,
+            expiration,
+            exercise_style,
+            multiplier,
+        }
+    }
+
+    /// Convenience constructor for a standard equity option (multiplier = 100, European).
+    pub fn equity(
+        underlying: Symbol,
+        kind: OptionKind,
+        strike: Decimal,
+        expiration: DateTime<Utc>,
+    ) -> Self {
+        Self::new(
+            underlying,
+            kind,
+            strike,
+            expiration,
+            ExerciseStyle::European,
+            Decimal::from(100),
+        )
+    }
+
+    /// Years remaining until expiration from `now`.
+    /// Returns 0 if already expired.
+    pub fn time_to_expiry(&self, now: DateTime<Utc>) -> f64 {
+        let secs = (self.expiration - now).num_seconds();
+        if secs <= 0 {
+            0.0
+        } else {
+            secs as f64 / (365.25 * 86400.0)
+        }
+    }
+
+    /// True if the option has expired relative to `now`.
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now >= self.expiration
+    }
+
+    /// Intrinsic value given the current underlying price.
+    pub fn intrinsic_value(&self, spot: Decimal) -> Decimal {
+        let iv = match self.kind {
+            OptionKind::Call => spot - self.strike,
+            OptionKind::Put => self.strike - spot,
+        };
+        if iv > Decimal::ZERO {
+            iv
+        } else {
+            Decimal::ZERO
+        }
+    }
+
+    /// True when the option is in-the-money.
+    pub fn is_itm(&self, spot: Decimal) -> bool {
+        self.intrinsic_value(spot) > Decimal::ZERO
+    }
+
+    /// True when at-the-money (strike == spot, within tolerance).
+    pub fn is_atm(&self, spot: Decimal, tolerance: Decimal) -> bool {
+        (self.strike - spot).abs() <= tolerance
+    }
+}
+
+impl fmt::Display for OptionContract {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {} {} ({})",
+            self.underlying.symbol,
+            self.expiration.format("%Y-%m-%d"),
+            self.strike,
+            self.kind,
+            self.exercise_style,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use rust_decimal_macros::dec;
+
+    fn sample_contract(kind: OptionKind, strike: Decimal) -> OptionContract {
+        let underlying = Symbol::equity("AAPL");
+        let expiration = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+        OptionContract::equity(underlying, kind, strike, expiration)
+    }
+
+    #[test]
+    fn test_intrinsic_value_call_itm() {
+        let c = sample_contract(OptionKind::Call, dec!(150));
+        assert_eq!(c.intrinsic_value(dec!(160)), dec!(10));
+    }
+
+    #[test]
+    fn test_intrinsic_value_call_otm() {
+        let c = sample_contract(OptionKind::Call, dec!(150));
+        assert_eq!(c.intrinsic_value(dec!(140)), dec!(0));
+    }
+
+    #[test]
+    fn test_intrinsic_value_put_itm() {
+        let c = sample_contract(OptionKind::Put, dec!(150));
+        assert_eq!(c.intrinsic_value(dec!(140)), dec!(10));
+    }
+
+    #[test]
+    fn test_intrinsic_value_put_otm() {
+        let c = sample_contract(OptionKind::Put, dec!(150));
+        assert_eq!(c.intrinsic_value(dec!(160)), dec!(0));
+    }
+
+    #[test]
+    fn test_is_itm() {
+        let call = sample_contract(OptionKind::Call, dec!(150));
+        assert!(call.is_itm(dec!(160)));
+        assert!(!call.is_itm(dec!(140)));
+    }
+
+    #[test]
+    fn test_is_atm() {
+        let c = sample_contract(OptionKind::Call, dec!(150));
+        assert!(c.is_atm(dec!(150), dec!(1)));
+        assert!(c.is_atm(dec!(150.5), dec!(1)));
+        assert!(!c.is_atm(dec!(155), dec!(1)));
+    }
+
+    #[test]
+    fn test_time_to_expiry() {
+        let c = sample_contract(OptionKind::Call, dec!(150));
+        let now = Utc.with_ymd_and_hms(2026, 3, 20, 20, 0, 0).unwrap();
+        let tte = c.time_to_expiry(now);
+        // ~92 days ≈ 0.252 years
+        assert!(tte > 0.24 && tte < 0.26, "tte = {tte}");
+    }
+
+    #[test]
+    fn test_expired() {
+        let c = sample_contract(OptionKind::Call, dec!(150));
+        let before = Utc.with_ymd_and_hms(2026, 6, 19, 0, 0, 0).unwrap();
+        let after = Utc.with_ymd_and_hms(2026, 6, 21, 0, 0, 0).unwrap();
+        assert!(!c.is_expired(before));
+        assert!(c.is_expired(after));
+    }
+
+    #[test]
+    fn test_display() {
+        let c = sample_contract(OptionKind::Call, dec!(150));
+        let s = format!("{c}");
+        assert!(s.contains("AAPL"));
+        assert!(s.contains("150"));
+        assert!(s.contains("Call"));
+    }
+}

--- a/crates/gb-options/src/execution.rs
+++ b/crates/gb-options/src/execution.rs
@@ -1,0 +1,252 @@
+//! Options execution — fill simulation and exercise/assignment handling.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use gb_types::orders::Side;
+
+use crate::contract::{OptionContract, OptionKind};
+use crate::pricing::{black_scholes_price, PricingInput};
+
+/// Errors specific to options execution.
+#[derive(Debug, Error)]
+pub enum OptionsExecError {
+    #[error("option has expired")]
+    Expired,
+    #[error("option is out of the money at expiration")]
+    OutOfTheMoney,
+    #[error("insufficient premium: required {required}, available {available}")]
+    InsufficientPremium {
+        required: Decimal,
+        available: Decimal,
+    },
+    #[error("invalid quantity: {0}")]
+    InvalidQuantity(String),
+}
+
+/// An options trade (open or close).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OptionsTrade {
+    pub id: Uuid,
+    pub contract: OptionContract,
+    pub side: Side,
+    pub quantity: Decimal,
+    pub premium: Decimal,
+    pub commission: Decimal,
+    pub executed_at: DateTime<Utc>,
+    pub strategy_id: String,
+}
+
+impl OptionsTrade {
+    /// Total cash impact of the trade (premium × multiplier × quantity ± commission).
+    pub fn cash_flow(&self) -> Decimal {
+        let notional = self.premium * self.contract.multiplier * self.quantity;
+        match self.side {
+            Side::Buy => -(notional + self.commission),
+            Side::Sell => notional - self.commission,
+        }
+    }
+}
+
+/// Result of exercising or being assigned on an option.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExerciseResult {
+    pub contract: OptionContract,
+    /// Shares delivered (positive = bought, negative = sold).
+    pub shares_delivered: Decimal,
+    /// Cash exchanged at the strike price (negative = paid, positive = received).
+    pub cash_exchanged: Decimal,
+    pub exercised_at: DateTime<Utc>,
+}
+
+/// Simulate opening an options position.
+pub fn simulate_open(
+    contract: &OptionContract,
+    side: Side,
+    quantity: Decimal,
+    input: &PricingInput,
+    commission_per_contract: Decimal,
+    strategy_id: &str,
+) -> Result<OptionsTrade, OptionsExecError> {
+    if quantity <= Decimal::ZERO {
+        return Err(OptionsExecError::InvalidQuantity(
+            "quantity must be positive".into(),
+        ));
+    }
+    if input.time_to_expiry <= 0.0 {
+        return Err(OptionsExecError::Expired);
+    }
+
+    let result = black_scholes_price(contract, input);
+    let premium = result.price;
+    let commission = commission_per_contract * quantity;
+
+    Ok(OptionsTrade {
+        id: Uuid::new_v4(),
+        contract: contract.clone(),
+        side,
+        quantity,
+        premium,
+        commission,
+        executed_at: Utc::now(),
+        strategy_id: strategy_id.to_string(),
+    })
+}
+
+/// Simulate exercise at expiration (auto-exercise if ITM).
+pub fn simulate_exercise(
+    contract: &OptionContract,
+    spot: Decimal,
+    quantity: Decimal,
+    now: DateTime<Utc>,
+) -> Result<ExerciseResult, OptionsExecError> {
+    if quantity <= Decimal::ZERO {
+        return Err(OptionsExecError::InvalidQuantity(
+            "quantity must be positive".into(),
+        ));
+    }
+
+    if !contract.is_itm(spot) {
+        return Err(OptionsExecError::OutOfTheMoney);
+    }
+
+    let total_shares = quantity * contract.multiplier;
+
+    let (shares_delivered, cash_exchanged) = match contract.kind {
+        OptionKind::Call => {
+            // Exercise call: buy shares at strike
+            let cash = -(contract.strike * total_shares);
+            (total_shares, cash)
+        }
+        OptionKind::Put => {
+            // Exercise put: sell shares at strike
+            let cash = contract.strike * total_shares;
+            (-total_shares, cash)
+        }
+    };
+
+    Ok(ExerciseResult {
+        contract: contract.clone(),
+        shares_delivered,
+        cash_exchanged,
+        exercised_at: now,
+    })
+}
+
+/// Simple P&L for a closed options round-trip.
+pub fn options_pnl(entry: &OptionsTrade, exit: &OptionsTrade) -> Decimal {
+    entry.cash_flow() + exit.cash_flow()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::{ExerciseStyle, OptionKind};
+    use chrono::{TimeZone, Utc};
+    use gb_types::market::Symbol;
+    use rust_decimal_macros::dec;
+
+    fn make_contract(kind: OptionKind) -> OptionContract {
+        OptionContract::new(
+            Symbol::equity("AAPL"),
+            kind,
+            dec!(150),
+            Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap(),
+            ExerciseStyle::European,
+            dec!(100),
+        )
+    }
+
+    fn default_input() -> PricingInput {
+        PricingInput {
+            spot: 155.0,
+            risk_free_rate: 0.05,
+            volatility: 0.25,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.25,
+        }
+    }
+
+    #[test]
+    fn test_simulate_open_buy_call() {
+        let c = make_contract(OptionKind::Call);
+        let input = default_input();
+        let trade = simulate_open(&c, Side::Buy, dec!(1), &input, dec!(0.65), "test").unwrap();
+        assert_eq!(trade.side, Side::Buy);
+        assert!(trade.premium > Decimal::ZERO);
+        assert!(trade.cash_flow() < Decimal::ZERO); // buyer pays
+    }
+
+    #[test]
+    fn test_simulate_open_sell_put() {
+        let c = make_contract(OptionKind::Put);
+        let input = default_input();
+        let trade = simulate_open(&c, Side::Sell, dec!(2), &input, dec!(0.65), "test").unwrap();
+        assert_eq!(trade.side, Side::Sell);
+        assert!(trade.cash_flow() > Decimal::ZERO); // seller receives
+    }
+
+    #[test]
+    fn test_simulate_open_expired() {
+        let c = make_contract(OptionKind::Call);
+        let mut input = default_input();
+        input.time_to_expiry = 0.0;
+        let err = simulate_open(&c, Side::Buy, dec!(1), &input, dec!(0.65), "test");
+        assert!(matches!(err, Err(OptionsExecError::Expired)));
+    }
+
+    #[test]
+    fn test_simulate_open_zero_quantity() {
+        let c = make_contract(OptionKind::Call);
+        let input = default_input();
+        let err = simulate_open(&c, Side::Buy, dec!(0), &input, dec!(0.65), "test");
+        assert!(matches!(err, Err(OptionsExecError::InvalidQuantity(_))));
+    }
+
+    #[test]
+    fn test_exercise_call_itm() {
+        let c = make_contract(OptionKind::Call); // strike = 150
+        let now = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+        let result = simulate_exercise(&c, dec!(160), dec!(1), now).unwrap();
+        assert_eq!(result.shares_delivered, dec!(100)); // 1 contract * 100 multiplier
+        assert_eq!(result.cash_exchanged, dec!(-15000)); // -(150 * 100)
+    }
+
+    #[test]
+    fn test_exercise_put_itm() {
+        let c = make_contract(OptionKind::Put); // strike = 150
+        let now = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+        let result = simulate_exercise(&c, dec!(140), dec!(1), now).unwrap();
+        assert_eq!(result.shares_delivered, dec!(-100)); // sold 100 shares
+        assert_eq!(result.cash_exchanged, dec!(15000)); // 150 * 100
+    }
+
+    #[test]
+    fn test_exercise_otm_fails() {
+        let c = make_contract(OptionKind::Call); // strike = 150
+        let now = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+        let err = simulate_exercise(&c, dec!(140), dec!(1), now);
+        assert!(matches!(err, Err(OptionsExecError::OutOfTheMoney)));
+    }
+
+    #[test]
+    fn test_pnl_round_trip() {
+        let c = make_contract(OptionKind::Call);
+        let input = default_input();
+        let buy = simulate_open(&c, Side::Buy, dec!(1), &input, dec!(0.65), "test").unwrap();
+
+        // Simulate exit at a higher price
+        let exit_input = PricingInput {
+            spot: 165.0,
+            ..input
+        };
+        let sell = simulate_open(&c, Side::Sell, dec!(1), &exit_input, dec!(0.65), "test").unwrap();
+
+        let pnl = options_pnl(&buy, &sell);
+        // Should be positive (underlying moved in our favour)
+        assert!(pnl > Decimal::ZERO, "pnl = {pnl}");
+    }
+}

--- a/crates/gb-options/src/greeks.rs
+++ b/crates/gb-options/src/greeks.rs
@@ -1,0 +1,44 @@
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Option greeks computed from a pricing model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Greeks {
+    /// Rate of change of option price w.r.t. underlying price.
+    pub delta: Decimal,
+    /// Rate of change of delta w.r.t. underlying price.
+    pub gamma: Decimal,
+    /// Rate of change of option price w.r.t. time (per calendar day).
+    pub theta: Decimal,
+    /// Rate of change of option price w.r.t. volatility (per 1% move).
+    pub vega: Decimal,
+    /// Rate of change of option price w.r.t. risk-free rate (per 1% move).
+    pub rho: Decimal,
+}
+
+impl Greeks {
+    pub fn zero() -> Self {
+        Self {
+            delta: Decimal::ZERO,
+            gamma: Decimal::ZERO,
+            theta: Decimal::ZERO,
+            vega: Decimal::ZERO,
+            rho: Decimal::ZERO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero_greeks() {
+        let g = Greeks::zero();
+        assert_eq!(g.delta, Decimal::ZERO);
+        assert_eq!(g.gamma, Decimal::ZERO);
+        assert_eq!(g.theta, Decimal::ZERO);
+        assert_eq!(g.vega, Decimal::ZERO);
+        assert_eq!(g.rho, Decimal::ZERO);
+    }
+}

--- a/crates/gb-options/src/lib.rs
+++ b/crates/gb-options/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod chain;
+pub mod contract;
+pub mod execution;
+pub mod greeks;
+pub mod pricing;
+
+pub use chain::*;
+pub use contract::*;
+pub use execution::*;
+pub use greeks::*;
+pub use pricing::*;

--- a/crates/gb-options/src/pricing.rs
+++ b/crates/gb-options/src/pricing.rs
@@ -1,0 +1,374 @@
+//! Black-Scholes pricing and greeks for European options.
+
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+use rust_decimal::Decimal;
+
+use crate::contract::{OptionContract, OptionKind};
+use crate::greeks::Greeks;
+
+/// Inputs shared by all pricing calls.
+#[derive(Debug, Clone)]
+pub struct PricingInput {
+    /// Current underlying spot price.
+    pub spot: f64,
+    /// Annualised risk-free rate (e.g. 0.05 = 5 %).
+    pub risk_free_rate: f64,
+    /// Annualised implied volatility (e.g. 0.20 = 20 %).
+    pub volatility: f64,
+    /// Continuous dividend yield (e.g. 0.02 = 2 %).
+    pub dividend_yield: f64,
+    /// Time to expiry in years.
+    pub time_to_expiry: f64,
+}
+
+/// Result of a pricing calculation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PricingResult {
+    /// Theoretical option price.
+    pub price: Decimal,
+    /// Greeks.
+    pub greeks: Greeks,
+}
+
+use serde::{Deserialize, Serialize};
+
+// ---------- normal distribution helpers (no external dep) ----------
+
+/// Standard normal cumulative distribution function (Abramowitz & Stegun 26.2.17).
+fn norm_cdf(x: f64) -> f64 {
+    if x >= 8.0 {
+        return 1.0;
+    }
+    if x <= -8.0 {
+        return 0.0;
+    }
+
+    let a1 = 0.254829592_f64;
+    let a2 = -0.284496736_f64;
+    let a3 = 1.421413741_f64;
+    let a4 = -1.453152027_f64;
+    let a5 = 1.061405429_f64;
+    let p = 0.3275911_f64;
+
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x_abs = x.abs();
+    let t = 1.0 / (1.0 + p * x_abs);
+    let y =
+        1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * (-x_abs * x_abs / 2.0).exp();
+
+    0.5 * (1.0 + sign * y)
+}
+
+/// Standard normal probability density function.
+fn norm_pdf(x: f64) -> f64 {
+    const INV_SQRT_2PI: f64 = 0.398_942_280_401_432_7;
+    INV_SQRT_2PI * (-0.5 * x * x).exp()
+}
+
+// ---------- Black-Scholes core ----------
+
+/// Compute d1 and d2.
+fn d1_d2(s: f64, k: f64, r: f64, q: f64, sigma: f64, t: f64) -> (f64, f64) {
+    let d1 = ((s / k).ln() + (r - q + 0.5 * sigma * sigma) * t) / (sigma * t.sqrt());
+    let d2 = d1 - sigma * t.sqrt();
+    (d1, d2)
+}
+
+/// Price a European option using the Black-Scholes model.
+pub fn black_scholes_price(contract: &OptionContract, input: &PricingInput) -> PricingResult {
+    let s = input.spot;
+    let k = contract.strike.to_f64().unwrap_or(0.0);
+    let r = input.risk_free_rate;
+    let q = input.dividend_yield;
+    let sigma = input.volatility;
+    let t = input.time_to_expiry;
+
+    // Degenerate: expired option
+    if t <= 0.0 {
+        let iv = contract.intrinsic_value(Decimal::from_f64(s).unwrap_or_default());
+        return PricingResult {
+            price: iv,
+            greeks: Greeks::zero(),
+        };
+    }
+
+    let (d1, d2) = d1_d2(s, k, r, q, sigma, t);
+    let disc = (-r * t).exp();
+    let div_disc = (-q * t).exp();
+
+    let price = match contract.kind {
+        OptionKind::Call => s * div_disc * norm_cdf(d1) - k * disc * norm_cdf(d2),
+        OptionKind::Put => k * disc * norm_cdf(-d2) - s * div_disc * norm_cdf(-d1),
+    };
+
+    // --- Greeks ---
+    let delta = match contract.kind {
+        OptionKind::Call => div_disc * norm_cdf(d1),
+        OptionKind::Put => -div_disc * norm_cdf(-d1),
+    };
+
+    let gamma = div_disc * norm_pdf(d1) / (s * sigma * t.sqrt());
+
+    let theta_common = -(s * div_disc * norm_pdf(d1) * sigma) / (2.0 * t.sqrt());
+    let theta = match contract.kind {
+        OptionKind::Call => {
+            theta_common - r * k * disc * norm_cdf(d2) + q * s * div_disc * norm_cdf(d1)
+        }
+        OptionKind::Put => {
+            theta_common + r * k * disc * norm_cdf(-d2) - q * s * div_disc * norm_cdf(-d1)
+        }
+    };
+    // Convert theta to per-calendar-day
+    let theta_daily = theta / 365.0;
+
+    let vega = s * div_disc * norm_pdf(d1) * t.sqrt();
+    // Vega per 1 % vol move
+    let vega_pct = vega / 100.0;
+
+    let rho = match contract.kind {
+        OptionKind::Call => k * t * disc * norm_cdf(d2),
+        OptionKind::Put => -k * t * disc * norm_cdf(-d2),
+    };
+    let rho_pct = rho / 100.0;
+
+    let to_dec = |v: f64| Decimal::from_f64(v).unwrap_or(Decimal::ZERO);
+
+    PricingResult {
+        price: to_dec(price),
+        greeks: Greeks {
+            delta: to_dec(delta),
+            gamma: to_dec(gamma),
+            theta: to_dec(theta_daily),
+            vega: to_dec(vega_pct),
+            rho: to_dec(rho_pct),
+        },
+    }
+}
+
+/// Implied volatility via Newton-Raphson on Black-Scholes vega.
+/// Returns `None` if it fails to converge.
+pub fn implied_volatility(
+    contract: &OptionContract,
+    market_price: f64,
+    spot: f64,
+    risk_free_rate: f64,
+    dividend_yield: f64,
+    time_to_expiry: f64,
+) -> Option<f64> {
+    let k = contract.strike.to_f64().unwrap_or(0.0);
+    if time_to_expiry <= 0.0 || market_price <= 0.0 || spot <= 0.0 || k <= 0.0 {
+        return None;
+    }
+
+    let mut sigma = 0.30; // initial guess
+    let max_iter = 100;
+    let tol = 1e-8;
+
+    for _ in 0..max_iter {
+        let input = PricingInput {
+            spot,
+            risk_free_rate,
+            volatility: sigma,
+            dividend_yield,
+            time_to_expiry,
+        };
+        let result = black_scholes_price(contract, &input);
+        let model_price = result.price.to_f64().unwrap_or(0.0);
+        let diff = model_price - market_price;
+
+        if diff.abs() < tol {
+            return Some(sigma);
+        }
+
+        // Vega in absolute terms (undo the /100 scaling)
+        let vega_abs = result.greeks.vega.to_f64().unwrap_or(0.0) * 100.0;
+        if vega_abs.abs() < 1e-12 {
+            return None; // vega too small to converge
+        }
+
+        sigma -= diff / vega_abs;
+        if sigma <= 0.0 {
+            sigma = 0.001; // clamp positive
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::{ExerciseStyle, OptionKind};
+    use chrono::{TimeZone, Utc};
+    use gb_types::market::Symbol;
+    use rust_decimal_macros::dec;
+
+    fn make_contract(kind: OptionKind, strike: Decimal) -> OptionContract {
+        let exp = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+        OptionContract::new(
+            Symbol::equity("AAPL"),
+            kind,
+            strike,
+            exp,
+            ExerciseStyle::European,
+            dec!(100),
+        )
+    }
+
+    #[test]
+    fn test_call_price_sanity() {
+        let c = make_contract(OptionKind::Call, dec!(150));
+        let input = PricingInput {
+            spot: 155.0,
+            risk_free_rate: 0.05,
+            volatility: 0.25,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.25,
+        };
+        let res = black_scholes_price(&c, &input);
+        let price = res.price.to_f64().unwrap();
+        // ITM call should be worth at least intrinsic ($5)
+        assert!(price > 5.0, "call price = {price}");
+        assert!(price < 20.0, "call price unreasonably high = {price}");
+    }
+
+    #[test]
+    fn test_put_price_sanity() {
+        let c = make_contract(OptionKind::Put, dec!(150));
+        let input = PricingInput {
+            spot: 145.0,
+            risk_free_rate: 0.05,
+            volatility: 0.25,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.25,
+        };
+        let res = black_scholes_price(&c, &input);
+        let price = res.price.to_f64().unwrap();
+        assert!(price > 5.0, "put price = {price}");
+        assert!(price < 20.0, "put price unreasonably high = {price}");
+    }
+
+    #[test]
+    fn test_put_call_parity() {
+        let strike = dec!(150);
+        let call = make_contract(OptionKind::Call, strike);
+        let put = make_contract(OptionKind::Put, strike);
+        let input = PricingInput {
+            spot: 150.0,
+            risk_free_rate: 0.05,
+            volatility: 0.30,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.5,
+        };
+        let c_price = black_scholes_price(&call, &input).price.to_f64().unwrap();
+        let p_price = black_scholes_price(&put, &input).price.to_f64().unwrap();
+        let k = strike.to_f64().unwrap();
+        // C - P = S - K*exp(-rT)
+        let lhs = c_price - p_price;
+        let rhs = input.spot - k * (-input.risk_free_rate * input.time_to_expiry).exp();
+        assert!(
+            (lhs - rhs).abs() < 0.01,
+            "put-call parity violated: lhs={lhs}, rhs={rhs}"
+        );
+    }
+
+    #[test]
+    fn test_expired_option_returns_intrinsic() {
+        let c = make_contract(OptionKind::Call, dec!(150));
+        let input = PricingInput {
+            spot: 160.0,
+            risk_free_rate: 0.05,
+            volatility: 0.25,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.0,
+        };
+        let res = black_scholes_price(&c, &input);
+        assert_eq!(res.price, dec!(10));
+    }
+
+    #[test]
+    fn test_greeks_sign_call() {
+        let c = make_contract(OptionKind::Call, dec!(150));
+        let input = PricingInput {
+            spot: 150.0,
+            risk_free_rate: 0.05,
+            volatility: 0.25,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.25,
+        };
+        let res = black_scholes_price(&c, &input);
+        let g = &res.greeks;
+        assert!(g.delta > Decimal::ZERO, "call delta should be positive");
+        assert!(g.gamma > Decimal::ZERO, "gamma should be positive");
+        assert!(
+            g.theta < Decimal::ZERO,
+            "theta should be negative (time decay)"
+        );
+        assert!(g.vega > Decimal::ZERO, "vega should be positive");
+        assert!(g.rho > Decimal::ZERO, "call rho should be positive");
+    }
+
+    #[test]
+    fn test_greeks_sign_put() {
+        let c = make_contract(OptionKind::Put, dec!(150));
+        let input = PricingInput {
+            spot: 150.0,
+            risk_free_rate: 0.05,
+            volatility: 0.25,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.25,
+        };
+        let res = black_scholes_price(&c, &input);
+        let g = &res.greeks;
+        assert!(g.delta < Decimal::ZERO, "put delta should be negative");
+        assert!(g.gamma > Decimal::ZERO, "gamma should be positive");
+        assert!(g.vega > Decimal::ZERO, "vega should be positive");
+        assert!(g.rho < Decimal::ZERO, "put rho should be negative");
+    }
+
+    #[test]
+    fn test_implied_volatility_roundtrip() {
+        let c = make_contract(OptionKind::Call, dec!(150));
+        let true_vol = 0.25;
+        let input = PricingInput {
+            spot: 155.0,
+            risk_free_rate: 0.05,
+            volatility: true_vol,
+            dividend_yield: 0.0,
+            time_to_expiry: 0.25,
+        };
+        let price = black_scholes_price(&c, &input).price.to_f64().unwrap();
+
+        let iv = implied_volatility(&c, price, 155.0, 0.05, 0.0, 0.25);
+        assert!(iv.is_some(), "IV should converge");
+        let iv = iv.unwrap();
+        assert!(
+            (iv - true_vol).abs() < 0.001,
+            "IV={iv} should match true vol={true_vol}"
+        );
+    }
+
+    #[test]
+    fn test_implied_volatility_put() {
+        let c = make_contract(OptionKind::Put, dec!(150));
+        let true_vol = 0.30;
+        let input = PricingInput {
+            spot: 148.0,
+            risk_free_rate: 0.04,
+            volatility: true_vol,
+            dividend_yield: 0.01,
+            time_to_expiry: 0.5,
+        };
+        let price = black_scholes_price(&c, &input).price.to_f64().unwrap();
+
+        let iv = implied_volatility(&c, price, 148.0, 0.04, 0.01, 0.5);
+        assert!(iv.is_some());
+        assert!((iv.unwrap() - true_vol).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_norm_cdf_boundaries() {
+        assert!((norm_cdf(0.0) - 0.5).abs() < 1e-6);
+        assert!(norm_cdf(8.0) == 1.0);
+        assert!(norm_cdf(-8.0) == 0.0);
+    }
+}

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,78 @@
+# Options Module (`gb-options`)
+
+The `gb-options` crate adds options instrument support to GlowBack, including
+pricing, greeks computation, chain generation, and trade execution simulation.
+
+## Features
+
+### Contract Modelling (`contract`)
+- `OptionContract` — call/put, strike, expiration, exercise style, multiplier
+- European and American exercise styles
+- Intrinsic value, ITM/ATM/OTM classification, time-to-expiry helpers
+
+### Black-Scholes Pricing (`pricing`)
+- `black_scholes_price()` — theoretical price for European options
+- Full greeks: delta, gamma, theta (daily), vega (per 1%), rho (per 1%)
+- Dividend yield support via continuous-yield model
+- `implied_volatility()` — Newton-Raphson solver to back out IV from market price
+
+### Greeks (`greeks`)
+- `Greeks` struct with delta, gamma, theta, vega, rho
+- Computed analytically from the Black-Scholes closed-form solution
+
+### Execution Simulation (`execution`)
+- `simulate_open()` — open a long or short options position with theoretical premium
+- `simulate_exercise()` — exercise at expiration (auto-exercise if ITM)
+- `options_pnl()` — round-trip P&L calculation
+- Commission handling per contract
+
+### Option Chain (`chain`)
+- `build_chain()` — generate a full option chain (calls + puts at evenly spaced strikes)
+- `OptionChain` — ATM strike lookup, strike-level access, put-call parity
+
+## Quick Start
+
+```rust
+use gb_options::*;
+use gb_types::market::Symbol;
+use rust_decimal_macros::dec;
+use chrono::{Utc, TimeZone};
+
+// Define a contract
+let underlying = Symbol::equity("AAPL");
+let expiration = Utc.with_ymd_and_hms(2026, 6, 20, 20, 0, 0).unwrap();
+let contract = OptionContract::equity(
+    underlying, OptionKind::Call, dec!(150), expiration,
+);
+
+// Price it
+let input = PricingInput {
+    spot: 155.0,
+    risk_free_rate: 0.05,
+    volatility: 0.25,
+    dividend_yield: 0.0,
+    time_to_expiry: 0.25,
+};
+let result = black_scholes_price(&contract, &input);
+println!("Price: {}, Delta: {}", result.price, result.greeks.delta);
+
+// Compute implied vol from a market price
+let iv = implied_volatility(&contract, 8.50, 155.0, 0.05, 0.0, 0.25);
+println!("IV: {:?}", iv);
+```
+
+## Tests
+
+```bash
+cargo test -p gb-options
+```
+
+34 unit tests covering:
+- Contract intrinsic value, ITM/OTM, time-to-expiry
+- Black-Scholes pricing sanity (call & put)
+- Put-call parity verification
+- Greeks sign correctness (call & put)
+- Implied volatility round-trip convergence
+- Exercise simulation (ITM call, ITM put, OTM rejection)
+- Trade P&L round-trip
+- Option chain generation and structure


### PR DESCRIPTION
## Summary

Implements **#16** — adds the `gb-options` crate for options instrument support.

### New Crate: `gb-options`

#### Contract Modelling (`contract.rs`)
- `OptionContract` — call/put, strike, expiration, European/American exercise style, multiplier
- Intrinsic value, ITM/ATM/OTM classification, time-to-expiry helpers

#### Black-Scholes Pricing (`pricing.rs`)
- `black_scholes_price()` — closed-form European option pricing
- Full greeks: delta, gamma, theta (daily), vega (per 1%), rho (per 1%)
- Dividend yield support (continuous model)
- `implied_volatility()` — Newton-Raphson IV solver

#### Greeks (`greeks.rs`)
- `Greeks` struct with delta, gamma, theta, vega, rho

#### Execution Simulation (`execution.rs`)
- `simulate_open()` — open long/short options positions with theoretical premium
- `simulate_exercise()` — auto-exercise at expiration if ITM
- `options_pnl()` — round-trip P&L calculation
- Commission handling per contract

#### Option Chain (`chain.rs`)
- `build_chain()` — generate a full chain (calls + puts at evenly spaced strikes)
- `OptionChain` — ATM strike lookup, strike-level access

### CI
- Added `gb-options` to the Rust build pipeline path filters and matrix

### Docs
- Added `docs/options.md` with usage examples

## Testing

```
cargo test -p gb-options
```

34 tests covering pricing sanity, put-call parity, greeks sign correctness, IV round-trip convergence, exercise simulation, trade P&L, and chain generation.

Fixes #16