### PR TITLE
feat(docker): production-harden Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,9 @@ data
 assets
 node_modules
 ui/.streamlit
+site
+*.md
+!README.md
+.env
+.env.example
+docs

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# GlowBack Docker Environment Configuration
+# Copy this file to `.env` and customize as needed.
+
+# --- Ports ---
+GLOWBACK_ENGINE_PORT=8081
+GLOWBACK_API_PORT=8000
+GLOWBACK_UI_PORT=8501
+
+# --- API Authentication ---
+# Set a value to require an API key for all requests.
+# Leave empty to disable authentication.
+GLOWBACK_API_KEY=
+
+# --- Logging ---
+# Format: json | text
+GLOWBACK_LOG_FORMAT=json
+# Level: debug | info | warning | error
+GLOWBACK_LOG_LEVEL=info
+# Rust log filter (engine service)
+RUST_LOG=info
+
+# --- Rate Limiting ---
+# Max requests per window per IP
+GLOWBACK_RATE_LIMIT=100
+# Window size in seconds
+GLOWBACK_RATE_WINDOW=60
+
+# --- CORS ---
+# Comma-separated allowed origins (use * for development only)
+GLOWBACK_CORS_ORIGINS=*
+
+# --- Request Size ---
+# Max request body size in bytes (default 1 MiB)
+GLOWBACK_MAX_BODY_BYTES=1048576

--- a/README.md
+++ b/README.md
@@ -95,13 +95,17 @@ cd ui && python setup.py
 ### Docker (Compose)
 
 ```bash
-docker compose up --build
+cp .env.example .env   # configure ports, API key, etc.
+docker compose up --build -d
 ```
 
 Services:
 - UI: http://localhost:8501
 - API: http://localhost:8000 (set `GLOWBACK_API_KEY` to require auth)
 - Engine: http://localhost:8081 (health JSON)
+
+All services include health checks, restart policies, and resource limits.
+See the [Deployment Guide](docs/deployment.md) for production configuration.
 
 ## Python Bindings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,85 @@
-version: "3.9"
-
 services:
   engine:
     build:
       context: .
       dockerfile: docker/engine.Dockerfile
     ports:
-      - "8081:8081"
+      - "${GLOWBACK_ENGINE_PORT:-8081}:8081"
     environment:
       - GLOWBACK_ENGINE_ADDR=0.0.0.0:8081
+      - RUST_LOG=${RUST_LOG:-info}
+    volumes:
+      - engine-data:/app/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/gb-engine-healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
 
   api:
     build:
       context: .
       dockerfile: docker/api.Dockerfile
     ports:
-      - "8000:8000"
+      - "${GLOWBACK_API_PORT:-8000}:8000"
     environment:
       - GLOWBACK_ENGINE_URL=http://engine:8081
       - GLOWBACK_API_KEY=${GLOWBACK_API_KEY:-}
+      - GLOWBACK_RATE_LIMIT=${GLOWBACK_RATE_LIMIT:-100}
+      - GLOWBACK_RATE_WINDOW=${GLOWBACK_RATE_WINDOW:-60}
+      - GLOWBACK_CORS_ORIGINS=${GLOWBACK_CORS_ORIGINS:-*}
+      - GLOWBACK_LOG_FORMAT=${GLOWBACK_LOG_FORMAT:-json}
+      - GLOWBACK_LOG_LEVEL=${GLOWBACK_LOG_LEVEL:-info}
+      - GLOWBACK_MAX_BODY_BYTES=${GLOWBACK_MAX_BODY_BYTES:-1048576}
+    volumes:
+      - api-data:/app/data
+    restart: unless-stopped
     depends_on:
-      - engine
+      engine:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "1.0"
 
   ui:
     build:
       context: .
       dockerfile: docker/ui.Dockerfile
     ports:
-      - "8501:8501"
+      - "${GLOWBACK_UI_PORT:-8501}:8501"
     environment:
       - GLOWBACK_API_URL=http://api:8000
+    restart: unless-stopped
     depends_on:
-      - api
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8501/_stcore/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "1.0"
+
+volumes:
+  engine-data:
+  api-data:

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -10,6 +10,14 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY api/app /app/app
 
+RUN useradd -m -s /bin/false apiuser \
+    && mkdir -p /app/data \
+    && chown -R apiuser:apiuser /app
+
 EXPOSE 8000
+
+VOLUME ["/app/data"]
+
+USER apiuser
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -2,22 +2,36 @@ FROM rust:stable-slim AS builder
 
 WORKDIR /app
 
+# Cache dependency builds
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 
 RUN cargo build -p gb-engine --bin gb-engine-service --release
 
+# Build the health-check binary
+RUN printf '#!/bin/sh\nexec curl -sf http://localhost:8081/ > /dev/null 2>&1 || exit 1\n' > /tmp/healthcheck.sh
+
 FROM debian:bookworm-slim
 
-RUN useradd -m engine
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/false engine
 
 WORKDIR /app
 
+RUN mkdir -p /app/data && chown engine:engine /app/data
+
 COPY --from=builder /app/target/release/gb-engine-service /usr/local/bin/gb-engine-service
+COPY --from=builder /tmp/healthcheck.sh /usr/local/bin/gb-engine-healthcheck
+RUN chmod +x /usr/local/bin/gb-engine-healthcheck
 
 ENV GLOWBACK_ENGINE_ADDR=0.0.0.0:8081
+ENV RUST_LOG=info
 
 EXPOSE 8081
+
+VOLUME ["/app/data"]
 
 USER engine
 

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -10,6 +10,11 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY ui /app
 
+RUN useradd -m -s /bin/false uiuser \
+    && chown -R uiuser:uiuser /app
+
 EXPOSE 8501
+
+USER uiuser
 
 CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0", "--server.port=8501"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,148 @@
+# Deployment Guide
+
+This guide covers deploying GlowBack with Docker Compose for development and
+production environments.
+
+## Quick Start
+
+```bash
+# Clone and enter the repository
+git clone https://github.com/LatencyTDH/GlowBack.git
+cd GlowBack
+
+# Copy the environment template
+cp .env.example .env
+
+# Build and start all services
+docker compose up --build -d
+```
+
+Services become available at:
+
+| Service | URL                    | Purpose              |
+|---------|------------------------|----------------------|
+| UI      | http://localhost:8501   | Streamlit dashboard  |
+| API     | http://localhost:8000   | FastAPI REST service |
+| Engine  | http://localhost:8081   | Rust backtest engine |
+
+## Architecture
+
+```
+┌──────────┐     ┌──────────┐     ┌──────────┐
+│    UI    │────▸│   API    │────▸│  Engine  │
+│ :8501    │     │ :8000    │     │ :8081    │
+│Streamlit │     │ FastAPI  │     │  Rust    │
+└──────────┘     └──────────┘     └──────────┘
+```
+
+The UI depends on the API, and the API depends on the Engine. Docker Compose
+enforces this ordering with health-check-based `depends_on` so each service
+waits for its dependency to be fully healthy before starting.
+
+## Configuration
+
+Copy `.env.example` to `.env` and edit as needed:
+
+```bash
+cp .env.example .env
+```
+
+### Ports
+
+| Variable               | Default | Description          |
+|------------------------|---------|----------------------|
+| `GLOWBACK_ENGINE_PORT` | 8081    | Engine host port     |
+| `GLOWBACK_API_PORT`    | 8000    | API host port        |
+| `GLOWBACK_UI_PORT`     | 8501    | UI host port         |
+
+### Security
+
+| Variable                | Default | Description                              |
+|-------------------------|---------|------------------------------------------|
+| `GLOWBACK_API_KEY`      | _(empty)_ | API key for request auth (empty = off) |
+| `GLOWBACK_CORS_ORIGINS` | `*`     | Comma-separated allowed CORS origins     |
+| `GLOWBACK_RATE_LIMIT`   | 100     | Max requests per IP per window           |
+| `GLOWBACK_RATE_WINDOW`  | 60      | Rate limit window in seconds             |
+| `GLOWBACK_MAX_BODY_BYTES` | 1048576 | Max request body size (bytes)          |
+
+### Logging
+
+| Variable              | Default | Description                    |
+|-----------------------|---------|--------------------------------|
+| `GLOWBACK_LOG_FORMAT` | `json`  | Log format: `json` or `text`   |
+| `GLOWBACK_LOG_LEVEL`  | `info`  | Python log level               |
+| `RUST_LOG`            | `info`  | Rust tracing filter for engine |
+
+## Health Checks
+
+Every service includes a Docker health check:
+
+- **Engine:** Probes `http://localhost:8081/` via `curl`.
+- **API:** Probes `http://localhost:8000/healthz` via Python's `urllib`.
+- **UI:** Probes Streamlit's `http://localhost:8501/_stcore/health` via Python's
+  `urllib`.
+
+Check status at any time:
+
+```bash
+docker compose ps
+```
+
+The `STATUS` column shows `healthy`, `starting`, or `unhealthy`.
+
+## Data Persistence
+
+Two named volumes preserve data across container restarts:
+
+| Volume        | Mount Point | Purpose                  |
+|---------------|-------------|--------------------------|
+| `engine-data` | `/app/data` | Engine working data      |
+| `api-data`    | `/app/data` | API state and catalogs   |
+
+To back up volumes:
+
+```bash
+docker run --rm -v glowback_engine-data:/data -v $(pwd):/backup \
+  busybox tar czf /backup/engine-data.tar.gz -C /data .
+```
+
+## Resource Limits
+
+Default memory and CPU limits are set in `docker-compose.yml`:
+
+| Service | Memory | CPUs |
+|---------|--------|------|
+| Engine  | 2 GB   | 2.0  |
+| API     | 512 MB | 1.0  |
+| UI      | 512 MB | 1.0  |
+
+Adjust these in `docker-compose.yml` under `deploy.resources.limits` for your
+hardware.
+
+## Production Checklist
+
+1. **Set `GLOWBACK_API_KEY`** — never run without authentication in production.
+2. **Restrict CORS** — change `GLOWBACK_CORS_ORIGINS` from `*` to your domain.
+3. **Use a reverse proxy** — put Nginx, Caddy, or Traefik in front for TLS.
+4. **Monitor logs** — use `docker compose logs -f` or ship to a log aggregator.
+5. **Set resource limits** — tune memory/CPU for your workload.
+6. **Back up volumes** — schedule periodic backups of named volumes.
+
+## Updating
+
+```bash
+git pull
+docker compose up --build -d
+```
+
+Compose rebuilds only changed images and restarts affected services.
+
+## Stopping
+
+```bash
+# Stop services (keeps volumes)
+docker compose down
+
+# Stop and remove volumes (data loss!)
+docker compose down -v
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,11 @@ python setup.py
 ## Docker (Compose)
 
 ```bash
-docker compose up --build
+# Copy environment template and customize
+cp .env.example .env
+
+# Build and start all services
+docker compose up --build -d
 ```
 
 Note: The engine image builds with `rust:stable-slim` to match `rust-toolchain.toml`.
@@ -39,6 +43,9 @@ Services:
 - UI: http://localhost:8501
 - API: http://localhost:8000 (set `GLOWBACK_API_KEY` to require auth)
 - Engine: http://localhost:8081 (health JSON)
+
+All services include health checks, restart policies, and resource limits.
+For production deployment details, see the [Deployment Guide](deployment.md).
 
 ## Next Steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Notebook Workflow: tutorials/notebook.md
       - UI Workflow: tutorials/ui-workflow.md
   - Examples: examples/index.md
+  - Deployment: deployment.md
   - Architecture: architecture.md
   - API Reference:
       - Rust: api/rust.md


### PR DESCRIPTION
## Summary

Production-harden the Docker Compose deployment for all three services (engine, API, UI).

### Changes

- **Health checks** for all services: engine (curl), API (/healthz), UI (Streamlit /_stcore/health)
- **Restart policies** (`unless-stopped`) for reliability across reboots
- **Named volumes** (`engine-data`, `api-data`) for data persistence
- **Resource limits** (memory/CPU) via `deploy.resources.limits`
- **Non-root users** in all Dockerfiles for security hardening
- **`depends_on` with `service_healthy`** conditions for proper startup ordering
- **`.env.example`** template with all configurable environment variables (ports, API key, logging, rate limits, CORS, etc.)
- **Comprehensive deployment guide** (`docs/deployment.md`) covering quick start, architecture, configuration, health checks, data persistence, resource limits, production checklist, updating, and stopping
- **Updated mkdocs.yml** nav to include the new deployment docs
- **Improved `.dockerignore`** for leaner Docker builds
- **Updated README and getting-started docs** with improved Docker instructions

Refs #12