### PR TITLE
fix(engine): incrementally maintain strategy context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +486,58 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "const-random"
@@ -514,6 +584,42 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -811,6 +917,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "gb-data",
  "gb-types",
  "rust_decimal",
@@ -1020,6 +1127,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -1256,6 +1369,26 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1554,6 +1687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +1830,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2108,6 +2275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2602,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2982,15 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/gb-engine/Cargo.toml
+++ b/crates/gb-engine/Cargo.toml
@@ -17,3 +17,10 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 rust_decimal = { workspace = true }
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "strategy_context"
+harness = false

--- a/crates/gb-engine/benches/strategy_context.rs
+++ b/crates/gb-engine/benches/strategy_context.rs
@@ -1,0 +1,177 @@
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use gb_types::{
+    Bar, MarketDataBuffer, MarketEvent, Portfolio, Resolution, StrategyContext, Symbol,
+};
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+
+const STRATEGY_MARKET_DATA_WINDOW: usize = 100;
+
+fn timestamp(day_offset: i64) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap() + Duration::days(day_offset)
+}
+
+fn sample_market_data(
+    symbol_count: usize,
+    day_count: usize,
+) -> (Vec<DateTime<Utc>>, HashMap<Symbol, Vec<Bar>>) {
+    let dates = (0..day_count)
+        .map(|day| timestamp(day as i64))
+        .collect::<Vec<_>>();
+
+    let market_data = (0..symbol_count)
+        .map(|index| {
+            let symbol = Symbol::equity(&format!("SYM{index:03}"));
+            let bars = dates
+                .iter()
+                .enumerate()
+                .map(|(day, current_time)| {
+                    let price = Decimal::from(100 + index as i64 + day as i64);
+                    Bar::new(
+                        symbol.clone(),
+                        *current_time,
+                        price,
+                        price,
+                        price,
+                        price,
+                        Decimal::from(1_000),
+                        Resolution::Day,
+                    )
+                })
+                .collect::<Vec<_>>();
+            (symbol, bars)
+        })
+        .collect::<HashMap<_, _>>();
+
+    (dates, market_data)
+}
+
+fn legacy_rebuild_context(
+    current_time: DateTime<Utc>,
+    market_data: &HashMap<Symbol, Vec<Bar>>,
+    portfolio: &Portfolio,
+) -> StrategyContext {
+    let mut context = StrategyContext::new("bench".to_string(), portfolio.initial_capital);
+    context.current_time = current_time;
+    context.portfolio = portfolio.clone();
+
+    for (symbol, bars) in market_data {
+        let mut buffer = MarketDataBuffer::new(symbol.clone(), STRATEGY_MARKET_DATA_WINDOW);
+        for bar in bars {
+            if bar.timestamp <= current_time {
+                buffer.add_event(MarketEvent::Bar(bar.clone()));
+            }
+        }
+        context.market_data.insert(symbol.clone(), buffer);
+    }
+
+    context
+}
+
+fn run_legacy_context_updates(
+    dates: &[DateTime<Utc>],
+    market_data: &HashMap<Symbol, Vec<Bar>>,
+    portfolio: &Portfolio,
+) -> StrategyContext {
+    let mut latest = StrategyContext::new("bench".to_string(), portfolio.initial_capital);
+    for &current_time in dates {
+        latest = legacy_rebuild_context(current_time, market_data, portfolio);
+    }
+    latest
+}
+
+fn run_incremental_context_updates(
+    dates: &[DateTime<Utc>],
+    market_data: &HashMap<Symbol, Vec<Bar>>,
+    portfolio: &Portfolio,
+) -> StrategyContext {
+    let mut context = StrategyContext::new("bench".to_string(), portfolio.initial_capital);
+    context.portfolio = portfolio.clone();
+
+    for symbol in market_data.keys() {
+        context.market_data.insert(
+            symbol.clone(),
+            MarketDataBuffer::new(symbol.clone(), STRATEGY_MARKET_DATA_WINDOW),
+        );
+    }
+
+    let mut next_indices = market_data
+        .keys()
+        .cloned()
+        .map(|symbol| (symbol, 0usize))
+        .collect::<HashMap<_, _>>();
+
+    for &current_time in dates {
+        context.current_time = current_time;
+        let current_date = current_time.date_naive();
+
+        for (symbol, bars) in market_data {
+            let next_index = next_indices
+                .get_mut(symbol)
+                .expect("symbol index should exist");
+            while let Some(bar) = bars.get(*next_index) {
+                let bar_date = bar.timestamp.date_naive();
+                if bar_date < current_date {
+                    *next_index += 1;
+                    continue;
+                }
+                if bar_date > current_date {
+                    break;
+                }
+
+                context
+                    .market_data
+                    .get_mut(symbol)
+                    .expect("symbol buffer should exist")
+                    .add_event(MarketEvent::Bar(bar.clone()));
+                *next_index += 1;
+            }
+        }
+    }
+
+    context
+}
+
+fn benchmark_strategy_context_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("strategy_context_scaling");
+
+    for (symbol_count, day_count) in [(10usize, 126usize), (50usize, 252usize)] {
+        let scenario_name = format!("{symbol_count}symbols_{day_count}days");
+        let (dates, market_data) = sample_market_data(symbol_count, day_count);
+        let portfolio = Portfolio::new("bench".to_string(), Decimal::from(100_000));
+
+        group.throughput(Throughput::Elements((symbol_count * day_count) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("legacy_full_rebuild", &scenario_name),
+            &scenario_name,
+            |b, _| {
+                b.iter(|| {
+                    black_box(run_legacy_context_updates(
+                        black_box(&dates),
+                        black_box(&market_data),
+                        black_box(&portfolio),
+                    ))
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("incremental_buffers", &scenario_name),
+            &scenario_name,
+            |b, _| {
+                b.iter(|| {
+                    black_box(run_incremental_context_updates(
+                        black_box(&dates),
+                        black_box(&market_data),
+                        black_box(&portfolio),
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_strategy_context_scaling);
+criterion_main!(benches);

--- a/crates/gb-engine/src/engine.rs
+++ b/crates/gb-engine/src/engine.rs
@@ -5,11 +5,14 @@ use chrono::{DateTime, Duration, Utc};
 use gb_data::DataManager;
 use gb_types::{
     BacktestConfig, BacktestError, BacktestResult, Bar, EquityCurvePoint, Fill, GbResult,
-    MarketEvent, Order, Portfolio, Strategy, StrategyContext, StrategyMetrics, Symbol,
+    MarketDataBuffer, MarketEvent, Order, Portfolio, Strategy, StrategyContext, StrategyMetrics,
+    Symbol,
 };
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
+
+const STRATEGY_MARKET_DATA_WINDOW: usize = 100;
 
 /// Enhanced backtesting engine with event-driven simulation
 pub struct Engine {
@@ -18,7 +21,10 @@ pub struct Engine {
     strategy: Box<dyn Strategy>,
     current_time: DateTime<Utc>,
     market_data: HashMap<Symbol, Vec<Bar>>,
+    next_bar_indices: HashMap<Symbol, usize>,
+    current_market_bars: Vec<(Symbol, Bar)>,
     pending_orders: Vec<Order>,
+    strategy_context: StrategyContext,
     strategy_metrics: StrategyMetrics,
     equity_curve: Vec<EquityCurvePoint>,
     equity_peak: Decimal,
@@ -82,14 +88,34 @@ impl Engine {
             .into());
         }
 
+        let mut strategy_context = StrategyContext::new(
+            strategy.get_config().strategy_id.clone(),
+            config.initial_capital,
+        );
+        strategy_context.current_time = config.start_date;
+        strategy_context.portfolio = portfolio.clone();
+        for symbol in market_data.keys() {
+            strategy_context.market_data.insert(
+                symbol.clone(),
+                MarketDataBuffer::new(symbol.clone(), STRATEGY_MARKET_DATA_WINDOW),
+            );
+        }
+
         Ok(Self {
             current_time: config.start_date,
             equity_peak: config.initial_capital,
+            next_bar_indices: market_data
+                .keys()
+                .cloned()
+                .map(|symbol| (symbol, 0))
+                .collect(),
+            current_market_bars: Vec::new(),
             config,
             portfolio,
             strategy,
             market_data,
             pending_orders: Vec::new(),
+            strategy_context,
             strategy_metrics,
             equity_curve: Vec::new(),
         })
@@ -162,22 +188,46 @@ impl Engine {
 
     /// Process market data for the current time
     async fn process_market_data(&mut self) -> GbResult<()> {
-        for (symbol, bars) in &self.market_data {
-            // Find bars for current time
-            let current_bars: Vec<&Bar> = bars
-                .iter()
-                .filter(|bar| bar.timestamp.date_naive() == self.current_time.date_naive())
-                .collect();
+        self.strategy_context.current_time = self.current_time;
+        self.current_market_bars.clear();
 
-            for bar in current_bars {
-                let _market_event = MarketEvent::Bar(bar.clone());
+        let current_date = self.current_time.date_naive();
+        for symbol in self.config.symbols.clone() {
+            let Some(bars) = self.market_data.get(&symbol) else {
+                continue;
+            };
+            let next_index = self.next_bar_indices.entry(symbol.clone()).or_insert(0);
 
-                debug!(
-                    "Market data: {} at {}: {}",
-                    symbol, bar.timestamp, bar.close
-                );
+            while let Some(bar) = bars.get(*next_index) {
+                let bar_date = bar.timestamp.date_naive();
+                if bar_date < current_date {
+                    *next_index += 1;
+                    continue;
+                }
+                if bar_date > current_date {
+                    break;
+                }
+
+                self.current_market_bars.push((symbol.clone(), bar.clone()));
+                *next_index += 1;
             }
         }
+
+        for (symbol, bar) in &self.current_market_bars {
+            self.strategy_context
+                .market_data
+                .entry(symbol.clone())
+                .or_insert_with(|| {
+                    MarketDataBuffer::new(symbol.clone(), STRATEGY_MARKET_DATA_WINDOW)
+                })
+                .add_event(MarketEvent::Bar(bar.clone()));
+
+            debug!(
+                "Market data: {} at {}: {}",
+                symbol, bar.timestamp, bar.close
+            );
+        }
+
         Ok(())
     }
 
@@ -216,18 +266,25 @@ impl Engine {
             self.pending_orders.remove(index);
         }
 
+        if !order_events_to_process.is_empty() {
+            self.sync_strategy_context_account_state();
+        }
+
         // Notify strategy of order events
         for order_event in order_events_to_process {
-            let context = self.build_strategy_context();
-            match self.strategy.on_order_event(&order_event, &context) {
-                Ok(actions) => {
-                    for action in actions {
-                        self.process_strategy_action(action)?;
-                    }
-                }
+            let actions = match self
+                .strategy
+                .on_order_event(&order_event, &self.strategy_context)
+            {
+                Ok(actions) => actions,
                 Err(e) => {
                     warn!("Strategy on_order_event error: {}", e);
+                    continue;
                 }
+            };
+
+            for action in actions {
+                self.process_strategy_action(action)?;
             }
         }
 
@@ -263,91 +320,48 @@ impl Engine {
 
     /// Update portfolio values with current market prices
     async fn update_portfolio_values(&mut self) -> GbResult<()> {
-        let mut current_prices = HashMap::new();
+        let current_prices = self
+            .current_market_bars
+            .iter()
+            .map(|(symbol, bar)| (symbol.clone(), bar.close))
+            .collect();
 
-        // Collect current prices
-        for (symbol, bars) in &self.market_data {
-            for bar in bars {
-                if bar.timestamp.date_naive() == self.current_time.date_naive() {
-                    current_prices.insert(symbol.clone(), bar.close);
-                    break;
-                }
-            }
-        }
-
-        // Update portfolio with current prices
         self.portfolio.update_market_prices(&current_prices);
+        self.strategy_context.portfolio = self.portfolio.clone();
 
         Ok(())
     }
 
     /// Generate strategy signals by calling the strategy's on_market_event method
     async fn generate_strategy_signals(&mut self) -> GbResult<()> {
-        // Build the current strategy context with market data and portfolio state
-        let context = self.build_strategy_context();
+        let current_bars_to_process = self.current_market_bars.clone();
 
-        // Collect all current bars first to avoid borrow conflicts
-        let mut current_bars_to_process: Vec<(Symbol, Bar)> = Vec::new();
-
-        for symbol in &self.config.symbols.clone() {
-            if let Some(bars) = self.market_data.get(symbol) {
-                for bar in bars.iter() {
-                    if bar.timestamp.date_naive() == self.current_time.date_naive() {
-                        current_bars_to_process.push((symbol.clone(), bar.clone()));
-                    }
-                }
-            }
-        }
-
-        // Now process each bar - no borrow conflict since we own the data
         for (symbol, bar) in current_bars_to_process {
             let market_event = MarketEvent::Bar(bar);
 
-            // Call the strategy's on_market_event method
-            match self.strategy.on_market_event(&market_event, &context) {
-                Ok(actions) => {
-                    for action in actions {
-                        self.process_strategy_action(action)?;
-                    }
-                }
+            let actions = match self
+                .strategy
+                .on_market_event(&market_event, &self.strategy_context)
+            {
+                Ok(actions) => actions,
                 Err(e) => {
                     warn!("Strategy error processing {}: {}", symbol, e);
+                    continue;
                 }
+            };
+
+            for action in actions {
+                self.process_strategy_action(action)?;
             }
         }
 
         Ok(())
     }
 
-    /// Build a complete StrategyContext with current market data and portfolio state
-    fn build_strategy_context(&self) -> StrategyContext {
-        use gb_types::{MarketDataBuffer, MarketEvent as ME};
-
-        let mut context = StrategyContext::new(
-            self.strategy.get_config().strategy_id.clone(),
-            self.config.initial_capital,
-        );
-
-        // Copy portfolio state
-        context.portfolio = self.portfolio.clone();
-        context.current_time = self.current_time;
-        context.pending_orders = self.pending_orders.clone();
-
-        // Build market data buffers for each symbol with historical data up to current time
-        for (symbol, bars) in &self.market_data {
-            let mut buffer = MarketDataBuffer::new(symbol.clone(), 100); // Keep last 100 bars
-
-            // Add all bars up to and including current date
-            for bar in bars {
-                if bar.timestamp <= self.current_time {
-                    buffer.add_event(ME::Bar(bar.clone()));
-                }
-            }
-
-            context.market_data.insert(symbol.clone(), buffer);
-        }
-
-        context
+    fn sync_strategy_context_account_state(&mut self) {
+        self.strategy_context.current_time = self.current_time;
+        self.strategy_context.portfolio = self.portfolio.clone();
+        self.strategy_context.pending_orders = self.pending_orders.clone();
     }
 
     /// Process a single strategy action
@@ -360,11 +374,15 @@ impl Engine {
                     "Strategy placed order: {:?} {} {} at {:?}",
                     order.side, order.quantity, order.symbol, order.order_type
                 );
+                self.strategy_context.pending_orders.push(order.clone());
                 self.pending_orders.push(order);
             }
             StrategyAction::CancelOrder { order_id } => {
                 debug!("Strategy cancelled order: {}", order_id);
                 self.pending_orders.retain(|o| o.id != order_id);
+                self.strategy_context
+                    .pending_orders
+                    .retain(|o| o.id != order_id);
             }
             StrategyAction::Log { level, message } => match level {
                 gb_types::LogLevel::Debug => debug!("[Strategy] {}", message),
@@ -538,17 +556,18 @@ impl Engine {
 
     /// Call strategy's on_day_end method for end-of-day processing
     async fn call_strategy_day_end(&mut self) -> GbResult<()> {
-        let context = self.build_strategy_context();
+        self.sync_strategy_context_account_state();
 
-        match self.strategy.on_day_end(&context) {
-            Ok(actions) => {
-                for action in actions {
-                    self.process_strategy_action(action)?;
-                }
-            }
+        let actions = match self.strategy.on_day_end(&self.strategy_context) {
+            Ok(actions) => actions,
             Err(e) => {
                 warn!("Strategy on_day_end error: {}", e);
+                return Ok(());
             }
+        };
+
+        for action in actions {
+            self.process_strategy_action(action)?;
         }
 
         Ok(())
@@ -556,20 +575,203 @@ impl Engine {
 
     /// Call strategy's on_stop method for cleanup
     async fn call_strategy_stop(&mut self) -> GbResult<()> {
-        let context = self.build_strategy_context();
+        self.sync_strategy_context_account_state();
 
-        match self.strategy.on_stop(&context) {
-            Ok(actions) => {
-                for action in actions {
-                    self.process_strategy_action(action)?;
-                }
-            }
+        let actions = match self.strategy.on_stop(&self.strategy_context) {
+            Ok(actions) => actions,
             Err(e) => {
                 warn!("Strategy on_stop error: {}", e);
+                info!("Strategy stopped");
+                return Ok(());
             }
+        };
+
+        for action in actions {
+            self.process_strategy_action(action)?;
         }
 
         info!("Strategy stopped");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use gb_types::{OrderEvent, Resolution, Side, StrategyAction, StrategyConfig};
+
+    #[derive(Debug, Clone)]
+    struct NoopStrategy {
+        config: StrategyConfig,
+    }
+
+    impl NoopStrategy {
+        fn new() -> Self {
+            Self {
+                config: StrategyConfig::new("noop".to_string(), "Noop Strategy".to_string()),
+            }
+        }
+    }
+
+    impl Strategy for NoopStrategy {
+        fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
+            self.config = config.clone();
+            Ok(())
+        }
+
+        fn on_market_event(
+            &mut self,
+            _event: &MarketEvent,
+            _context: &StrategyContext,
+        ) -> Result<Vec<StrategyAction>, String> {
+            Ok(vec![])
+        }
+
+        fn on_order_event(
+            &mut self,
+            _event: &OrderEvent,
+            _context: &StrategyContext,
+        ) -> Result<Vec<StrategyAction>, String> {
+            Ok(vec![])
+        }
+
+        fn on_day_end(
+            &mut self,
+            _context: &StrategyContext,
+        ) -> Result<Vec<StrategyAction>, String> {
+            Ok(vec![])
+        }
+
+        fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+            Ok(vec![])
+        }
+
+        fn get_config(&self) -> &StrategyConfig {
+            &self.config
+        }
+
+        fn get_metrics(&self) -> StrategyMetrics {
+            StrategyMetrics::new(self.config.strategy_id.clone())
+        }
+    }
+
+    fn ts(day: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 1, day, 0, 0, 0).unwrap()
+    }
+
+    fn test_bar(symbol: &Symbol, day: u32, price: i64) -> Bar {
+        let price = Decimal::from(price);
+        Bar::new(
+            symbol.clone(),
+            ts(day),
+            price,
+            price,
+            price,
+            price,
+            Decimal::from(1_000),
+            Resolution::Day,
+        )
+    }
+
+    fn test_engine(symbol: Symbol, bars: Vec<Bar>) -> Engine {
+        let mut config = BacktestConfig::new(
+            "engine-test".to_string(),
+            StrategyConfig::new("noop".to_string(), "Noop Strategy".to_string()),
+        );
+        config.start_date = ts(1);
+        config.end_date = ts(5);
+        config.initial_capital = Decimal::from(100_000);
+        config.resolution = Resolution::Day;
+        config.symbols = vec![symbol.clone()];
+
+        let portfolio = Portfolio::new("test-account".to_string(), config.initial_capital);
+        let mut strategy_context = StrategyContext::new("noop".to_string(), config.initial_capital);
+        strategy_context.current_time = config.start_date;
+        strategy_context.portfolio = portfolio.clone();
+        strategy_context.market_data.insert(
+            symbol.clone(),
+            MarketDataBuffer::new(symbol.clone(), STRATEGY_MARKET_DATA_WINDOW),
+        );
+
+        Engine {
+            config,
+            portfolio,
+            strategy: Box::new(NoopStrategy::new()),
+            current_time: ts(1),
+            market_data: HashMap::from([(symbol.clone(), bars)]),
+            next_bar_indices: HashMap::from([(symbol.clone(), 0)]),
+            current_market_bars: Vec::new(),
+            pending_orders: Vec::new(),
+            strategy_context,
+            strategy_metrics: StrategyMetrics::new("noop".to_string()),
+            equity_curve: Vec::new(),
+            equity_peak: Decimal::from(100_000),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_market_data_updates_context_incrementally() {
+        let symbol = Symbol::equity("AAPL");
+        let mut engine = test_engine(
+            symbol.clone(),
+            vec![
+                test_bar(&symbol, 1, 101),
+                test_bar(&symbol, 2, 102),
+                test_bar(&symbol, 4, 104),
+            ],
+        );
+
+        engine.process_market_data().await.unwrap();
+        assert_eq!(engine.current_market_bars.len(), 1);
+        assert_eq!(engine.next_bar_indices[&symbol], 1);
+        let buffer = engine.strategy_context.market_data.get(&symbol).unwrap();
+        assert_eq!(buffer.data.len(), 1);
+        assert_eq!(buffer.get_current_price(), Some(Decimal::from(101)));
+
+        engine.current_time = ts(2);
+        engine.process_market_data().await.unwrap();
+        assert_eq!(engine.current_market_bars.len(), 1);
+        assert_eq!(engine.next_bar_indices[&symbol], 2);
+        let buffer = engine.strategy_context.market_data.get(&symbol).unwrap();
+        assert_eq!(buffer.data.len(), 2);
+        assert_eq!(buffer.get_current_price(), Some(Decimal::from(102)));
+
+        engine.current_time = ts(3);
+        engine.process_market_data().await.unwrap();
+        assert!(engine.current_market_bars.is_empty());
+        assert_eq!(engine.next_bar_indices[&symbol], 2);
+        let buffer = engine.strategy_context.market_data.get(&symbol).unwrap();
+        assert_eq!(buffer.data.len(), 2);
+        assert_eq!(buffer.get_current_price(), Some(Decimal::from(102)));
+
+        engine.current_time = ts(4);
+        engine.process_market_data().await.unwrap();
+        assert_eq!(engine.current_market_bars.len(), 1);
+        assert_eq!(engine.next_bar_indices[&symbol], 3);
+        let buffer = engine.strategy_context.market_data.get(&symbol).unwrap();
+        assert_eq!(buffer.data.len(), 3);
+        assert_eq!(buffer.get_current_price(), Some(Decimal::from(104)));
+    }
+
+    #[test]
+    fn process_strategy_action_keeps_pending_order_snapshots_in_sync() {
+        let symbol = Symbol::equity("AAPL");
+        let mut engine = test_engine(symbol.clone(), Vec::new());
+        let order = Order::market_order(symbol, Side::Buy, Decimal::from(5), "noop".to_string());
+        let order_id = order.id;
+
+        engine
+            .process_strategy_action(StrategyAction::PlaceOrder(order.clone()))
+            .unwrap();
+        assert_eq!(engine.pending_orders.len(), 1);
+        assert_eq!(engine.strategy_context.pending_orders.len(), 1);
+        assert_eq!(engine.strategy_context.pending_orders[0].id, order_id);
+
+        engine
+            .process_strategy_action(StrategyAction::CancelOrder { order_id })
+            .unwrap();
+        assert!(engine.pending_orders.is_empty());
+        assert!(engine.strategy_context.pending_orders.is_empty());
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Engine scaling:** `gb-engine` now keeps per-symbol `StrategyContext` market buffers incrementally, reuses the live context across hot-path callbacks, and ships a Criterion benchmark covering representative 10-symbol/6-month and 50-symbol/1-year workloads instead of rebuilding full-history buffers on every callback.
 - **Catalog durability:** `gb-data` now reloads persisted `symbol_metadata` rows when `DataCatalog` starts, so symbol listings, metadata lookups, and catalog stats survive process restarts instead of disappearing from the in-memory cache.
 - **UI backtest correctness:** The Streamlit backtester now keeps last-known prices for every held symbol, analytics derive returns from the equity curve instead of `pct_change()` on cumulative return percentages, the dashboard no longer mutates the shared equity DataFrame in-place, and win rate is computed from realized closed trades (or shown as unavailable when nothing has closed yet).
 - **Live risk safety:** Total exposure checks in `gb-live` now price each held symbol from its own latest mark instead of reusing the incoming order's price across the whole book; added multi-symbol regression tests for both false-approve and false-reject cases.


### PR DESCRIPTION
## Summary
- keep a live `StrategyContext` inside `Engine`, incrementally append only the current day's bars, and reuse it across market/order/day-end callbacks instead of rebuilding full-history buffers every time
- track per-symbol bar cursors and current-day bars so the hot path stops rescanning full histories, while keeping pending-order snapshots in sync as strategy actions place/cancel orders
- add regression tests plus a Criterion benchmark covering 10-symbol/6-month and 50-symbol/1-year workloads, and document the scaling fix in the changelog

Fixes #60

## Benchmark
- `legacy_full_rebuild/10symbols_126days`: ~7.93 ms
- `incremental_buffers/10symbols_126days`: ~0.286 ms (~28x faster)
- `legacy_full_rebuild/50symbols_252days`: ~261 ms
- `incremental_buffers/50symbols_252days`: ~5.91 ms (~44x faster)

## Validation
- cargo test -p gb-engine
- cargo bench -p gb-engine --bench strategy_context -- --noplot --sample-size 10
- cargo test --workspace --locked
- mkdocs build --strict
