### PR TITLE
Fix #91: add a durable experiment registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ GlowBack provides a fast, realistic backtesting engine with data management, sto
 - Strategy library (4 built‑in strategies)
 - Python bindings (async support)
 - Streamlit UI for strategy development and analysis
+- Durable experiment registry for saved strategies, historical runs, and cross-session comparisons
 - Sandbox paper broker rejects sell orders that exceed held inventory (no implicit naked shorts)
 
 ## Project Status
@@ -43,6 +44,7 @@ Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress
 ### UI
 
 - Streamlit interface for data loading, strategy editing, running backtests, and result analysis
+- Persisted experiment history so runs and saved strategies survive restarts
 
 ## Features
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,7 +1,7 @@
 # GlowBack FastAPI Gateway (Phase 1)
 
 This folder contains a minimal FastAPI service that exposes the GlowBack backtesting API contract.
-It currently runs with a mock engine adapter and in‑memory storage while the Rust engine bindings are integrated.
+It currently runs with a mock engine adapter while persisting run history/events/results into a local SQLite-backed experiment registry.
 
 ## Quickstart
 
@@ -29,7 +29,7 @@ The server will be available at http://127.0.0.1:8000 with interactive docs at `
 
 ## Notes
 
-- Storage is in‑memory (process‑local).
+- Backtest run metadata, event history, and completed results are persisted in a local SQLite experiment registry so `GET /backtests` still shows historical runs after restart.
 - The engine adapter is a mock that emits progress events and a sample result.
 - `GLOWBACK_API_KEY` enables a stub auth check (`Authorization: Bearer <token>` or `X-API-Key: <token>`).
   WebSocket clients can pass `?api_key=<token>`.

--- a/api/app/experiment_registry.py
+++ b/api/app/experiment_registry.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+from functools import lru_cache
+from hashlib import sha256
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_registry_path() -> Path:
+    import os
+
+    env_value = os.getenv("GLOWBACK_REGISTRY_PATH")
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    return (_repo_root() / "data" / "experiment-registry.sqlite3").resolve()
+
+
+def sha256_text(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _to_jsonable(value: Any) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        return _to_jsonable(value.model_dump(mode="json"))
+    if is_dataclass(value):
+        return _to_jsonable(asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
+def stable_json_dumps(value: Any) -> str:
+    return json.dumps(_to_jsonable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+class ExperimentRegistry:
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path).expanduser().resolve() if path else default_registry_path()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = RLock()
+        self._conn = sqlite3.connect(self.path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._lock, self._conn:
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    run_id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    deleted_at TEXT,
+                    label TEXT,
+                    status_json TEXT NOT NULL,
+                    request_json TEXT,
+                    result_json TEXT,
+                    events_json TEXT NOT NULL DEFAULT '[]',
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    strategy_name TEXT,
+                    strategy_code TEXT,
+                    strategy_code_hash TEXT,
+                    strategy_config_json TEXT
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_runs_source_created
+                    ON runs(source, created_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_runs_state_created
+                    ON runs(state, created_at DESC);
+
+                CREATE TABLE IF NOT EXISTS strategies (
+                    name TEXT PRIMARY KEY,
+                    code TEXT NOT NULL,
+                    code_hash TEXT NOT NULL,
+                    config_json TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    deleted_at TEXT
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_strategies_updated
+                    ON strategies(updated_at DESC);
+                """
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _fetch_existing(self, table: str, key_column: str, key_value: str) -> sqlite3.Row | None:
+        cursor = self._conn.execute(
+            f"SELECT * FROM {table} WHERE {key_column} = ?",
+            (key_value,),
+        )
+        return cursor.fetchone()
+
+    def upsert_run(
+        self,
+        *,
+        run_id: str,
+        source: str,
+        status: Any,
+        request: Any | None = None,
+        result: Any | None = None,
+        events: Any | None = None,
+        metadata: Any | None = None,
+        strategy_name: str | None = None,
+        strategy_code: str | None = None,
+        strategy_config: Any | None = None,
+        label: str | None = None,
+    ) -> dict[str, Any]:
+        now = datetime.utcnow().isoformat() + "Z"
+        status_payload = _to_jsonable(status) or {}
+        request_payload = _to_jsonable(request)
+        result_payload = _to_jsonable(result)
+        events_payload = _to_jsonable(events) or []
+        metadata_payload = _to_jsonable(metadata) or {}
+        strategy_config_payload = _to_jsonable(strategy_config) or {}
+
+        created_at = status_payload.get("created_at") or now
+        state = status_payload.get("state") or "unknown"
+        strategy_code_hash = sha256_text(strategy_code) if strategy_code else None
+
+        with self._lock, self._conn:
+            existing = self._fetch_existing("runs", "run_id", run_id)
+            if existing is not None:
+                created_at = existing["created_at"]
+                if label is None:
+                    label = existing["label"]
+                if strategy_name is None:
+                    strategy_name = existing["strategy_name"]
+                if strategy_code is None:
+                    strategy_code = existing["strategy_code"]
+                    strategy_code_hash = existing["strategy_code_hash"]
+                if not strategy_config_payload:
+                    strategy_config_payload = json.loads(existing["strategy_config_json"] or "{}")
+                if request_payload is None and existing["request_json"]:
+                    request_payload = json.loads(existing["request_json"])
+                if result_payload is None and existing["result_json"]:
+                    result_payload = json.loads(existing["result_json"])
+                if (not events_payload) and existing["events_json"]:
+                    events_payload = json.loads(existing["events_json"])
+                if (not metadata_payload) and existing["metadata_json"]:
+                    metadata_payload = json.loads(existing["metadata_json"])
+
+            self._conn.execute(
+                """
+                INSERT INTO runs (
+                    run_id,
+                    source,
+                    state,
+                    created_at,
+                    updated_at,
+                    deleted_at,
+                    label,
+                    status_json,
+                    request_json,
+                    result_json,
+                    events_json,
+                    metadata_json,
+                    strategy_name,
+                    strategy_code,
+                    strategy_code_hash,
+                    strategy_config_json
+                ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    source = excluded.source,
+                    state = excluded.state,
+                    updated_at = excluded.updated_at,
+                    deleted_at = NULL,
+                    label = excluded.label,
+                    status_json = excluded.status_json,
+                    request_json = excluded.request_json,
+                    result_json = excluded.result_json,
+                    events_json = excluded.events_json,
+                    metadata_json = excluded.metadata_json,
+                    strategy_name = excluded.strategy_name,
+                    strategy_code = excluded.strategy_code,
+                    strategy_code_hash = excluded.strategy_code_hash,
+                    strategy_config_json = excluded.strategy_config_json
+                """,
+                (
+                    run_id,
+                    source,
+                    state,
+                    created_at,
+                    now,
+                    label,
+                    stable_json_dumps(status_payload),
+                    stable_json_dumps(request_payload) if request_payload is not None else None,
+                    stable_json_dumps(result_payload) if result_payload is not None else None,
+                    stable_json_dumps(events_payload),
+                    stable_json_dumps(metadata_payload),
+                    strategy_name,
+                    strategy_code,
+                    strategy_code_hash,
+                    stable_json_dumps(strategy_config_payload),
+                ),
+            )
+
+        record = self.get_run(run_id)
+        if record is None:  # pragma: no cover - defensive only
+            raise RuntimeError(f"Failed to persist run {run_id}")
+        return record
+
+    def list_runs(
+        self,
+        *,
+        source: str | None = None,
+        state: str | None = None,
+        limit: int = 200,
+        include_deleted: bool = False,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM runs"
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if not include_deleted:
+            conditions.append("deleted_at IS NULL")
+        if source:
+            conditions.append("source = ?")
+            params.append(source)
+        if state:
+            conditions.append("state = ?")
+            params.append(state)
+
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+        query += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        with self._lock:
+            rows = self._conn.execute(query, params).fetchall()
+        return [self._row_to_run(row) for row in rows]
+
+    def get_run(self, run_id: str, *, include_deleted: bool = False) -> dict[str, Any] | None:
+        query = "SELECT * FROM runs WHERE run_id = ?"
+        params: list[Any] = [run_id]
+        if not include_deleted:
+            query += " AND deleted_at IS NULL"
+
+        with self._lock:
+            row = self._conn.execute(query, params).fetchone()
+        return self._row_to_run(row) if row else None
+
+    def rename_run(self, run_id: str, label: str | None) -> dict[str, Any] | None:
+        now = datetime.utcnow().isoformat() + "Z"
+        with self._lock, self._conn:
+            self._conn.execute(
+                "UPDATE runs SET label = ?, updated_at = ?, deleted_at = NULL WHERE run_id = ?",
+                (label, now, run_id),
+            )
+        return self.get_run(run_id)
+
+    def delete_run(self, run_id: str) -> bool:
+        now = datetime.utcnow().isoformat() + "Z"
+        with self._lock, self._conn:
+            cursor = self._conn.execute(
+                "UPDATE runs SET deleted_at = ?, updated_at = ? WHERE run_id = ? AND deleted_at IS NULL",
+                (now, now, run_id),
+            )
+        return cursor.rowcount > 0
+
+    def upsert_strategy(
+        self,
+        *,
+        name: str,
+        code: str,
+        config: Any | None = None,
+        metadata: Any | None = None,
+    ) -> dict[str, Any]:
+        now = datetime.utcnow().isoformat() + "Z"
+        config_payload = _to_jsonable(config) or {}
+        metadata_payload = _to_jsonable(metadata) or {}
+        code_hash = sha256_text(code)
+
+        with self._lock, self._conn:
+            existing = self._fetch_existing("strategies", "name", name)
+            created_at = existing["created_at"] if existing is not None else now
+            self._conn.execute(
+                """
+                INSERT INTO strategies (
+                    name,
+                    code,
+                    code_hash,
+                    config_json,
+                    metadata_json,
+                    created_at,
+                    updated_at,
+                    deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(name) DO UPDATE SET
+                    code = excluded.code,
+                    code_hash = excluded.code_hash,
+                    config_json = excluded.config_json,
+                    metadata_json = excluded.metadata_json,
+                    updated_at = excluded.updated_at,
+                    deleted_at = NULL
+                """,
+                (
+                    name,
+                    code,
+                    code_hash,
+                    stable_json_dumps(config_payload),
+                    stable_json_dumps(metadata_payload),
+                    created_at,
+                    now,
+                ),
+            )
+        record = self.get_strategy(name)
+        if record is None:  # pragma: no cover - defensive only
+            raise RuntimeError(f"Failed to persist strategy {name}")
+        return record
+
+    def list_strategies(self, *, include_deleted: bool = False, limit: int = 200) -> list[dict[str, Any]]:
+        query = "SELECT * FROM strategies"
+        params: list[Any] = []
+        if not include_deleted:
+            query += " WHERE deleted_at IS NULL"
+        query += " ORDER BY updated_at DESC LIMIT ?"
+        params.append(limit)
+        with self._lock:
+            rows = self._conn.execute(query, params).fetchall()
+        return [self._row_to_strategy(row) for row in rows]
+
+    def get_strategy(self, name: str, *, include_deleted: bool = False) -> dict[str, Any] | None:
+        query = "SELECT * FROM strategies WHERE name = ?"
+        params: list[Any] = [name]
+        if not include_deleted:
+            query += " AND deleted_at IS NULL"
+        with self._lock:
+            row = self._conn.execute(query, params).fetchone()
+        return self._row_to_strategy(row) if row else None
+
+    def delete_strategy(self, name: str) -> bool:
+        now = datetime.utcnow().isoformat() + "Z"
+        with self._lock, self._conn:
+            cursor = self._conn.execute(
+                "UPDATE strategies SET deleted_at = ?, updated_at = ? WHERE name = ? AND deleted_at IS NULL",
+                (now, now, name),
+            )
+        return cursor.rowcount > 0
+
+    def _row_to_run(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "run_id": row["run_id"],
+            "source": row["source"],
+            "state": row["state"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "deleted_at": row["deleted_at"],
+            "label": row["label"],
+            "status": json.loads(row["status_json"]),
+            "request": json.loads(row["request_json"]) if row["request_json"] else None,
+            "result": json.loads(row["result_json"]) if row["result_json"] else None,
+            "events": json.loads(row["events_json"] or "[]"),
+            "metadata": json.loads(row["metadata_json"] or "{}"),
+            "strategy_name": row["strategy_name"],
+            "strategy_code": row["strategy_code"],
+            "strategy_code_hash": row["strategy_code_hash"],
+            "strategy_config": json.loads(row["strategy_config_json"] or "{}"),
+        }
+
+    def _row_to_strategy(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "name": row["name"],
+            "code": row["code"],
+            "code_hash": row["code_hash"],
+            "config": json.loads(row["config_json"] or "{}"),
+            "metadata": json.loads(row["metadata_json"] or "{}"),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "deleted_at": row["deleted_at"],
+        }
+
+
+@lru_cache(maxsize=1)
+def get_default_registry() -> ExperimentRegistry:
+    return ExperimentRegistry()

--- a/api/app/store.py
+++ b/api/app/store.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 from typing import Iterable
 from uuid import uuid4
 
-from .models import BacktestEvent, BacktestResult, BacktestStatus, BacktestRequest, EventType, RunState
+from .experiment_registry import ExperimentRegistry, get_default_registry
+from .models import BacktestEvent, BacktestRequest, BacktestResult, BacktestStatus, EventType, RunState
 
 
 @dataclass
@@ -20,9 +21,52 @@ class RunRecord:
 
 
 class RunStore:
-    def __init__(self) -> None:
+    def __init__(self, registry: ExperimentRegistry | None = None) -> None:
         self._runs: dict[str, RunRecord] = {}
         self._lock = asyncio.Lock()
+        self._registry = registry or get_default_registry()
+        self._hydrate_from_registry()
+
+    def _hydrate_from_registry(self) -> None:
+        for payload in self._registry.list_runs(source="api", limit=500):
+            request_payload = payload.get("request")
+            status_payload = payload.get("status")
+            if not request_payload or not status_payload:
+                continue
+
+            request = BacktestRequest.model_validate(request_payload)
+            status = BacktestStatus.model_validate(status_payload)
+            result_payload = payload.get("result")
+            result = BacktestResult.model_validate(result_payload) if result_payload else None
+            event_payloads = payload.get("events") or []
+            events = [BacktestEvent.model_validate(event) for event in event_payloads]
+            next_event_id = max((event.event_id for event in events), default=0) + 1
+            self._runs[status.run_id] = RunRecord(
+                request=request,
+                status=status,
+                result=result,
+                events=events,
+                next_event_id=next_event_id,
+            )
+
+    def _persist_record(self, run_id: str) -> None:
+        record = self._runs.get(run_id)
+        if not record:
+            return
+        self._registry.upsert_run(
+            run_id=run_id,
+            source="api",
+            status=record.status,
+            request=record.request,
+            result=record.result,
+            events=record.events,
+            metadata={
+                "subscriber_count": len(record.subscribers),
+                "event_count": len(record.events),
+            },
+            strategy_name=record.request.strategy.name,
+            strategy_config=record.request.strategy,
+        )
 
     async def create_run(self, request: BacktestRequest) -> BacktestStatus:
         run_id = str(uuid4())
@@ -36,6 +80,7 @@ class RunStore:
         record = RunRecord(request=request, status=status)
         async with self._lock:
             self._runs[run_id] = record
+        self._persist_record(run_id)
         await self._publish_event(
             run_id,
             EventType.state,
@@ -77,6 +122,7 @@ class RunStore:
             if not record:
                 return None
             record.subscribers.add(queue)
+            self._persist_record(run_id)
         return queue
 
     async def unsubscribe(self, run_id: str, queue: asyncio.Queue) -> None:
@@ -85,6 +131,7 @@ class RunStore:
             if not record:
                 return
             record.subscribers.discard(queue)
+            self._persist_record(run_id)
 
     async def update_state(self, run_id: str, state: RunState, error: str | None = None) -> None:
         now = datetime.now(timezone.utc)
@@ -98,6 +145,7 @@ class RunStore:
                 record.status.started_at = now
             if state in {RunState.completed, RunState.failed}:
                 record.status.finished_at = now
+            self._persist_record(run_id)
         await self._publish_event(
             run_id,
             EventType.state,
@@ -110,6 +158,7 @@ class RunStore:
             if not record:
                 return
             record.status.progress = max(0.0, min(progress, 1.0))
+            self._persist_record(run_id)
         payload = {"progress": progress}
         if message:
             payload["message"] = message
@@ -121,6 +170,7 @@ class RunStore:
             if not record:
                 return
             record.result = result
+            self._persist_record(run_id)
         await self.update_state(run_id, RunState.completed)
 
     async def _publish_event(self, run_id: str, event_type: EventType, payload: dict) -> None:
@@ -139,6 +189,7 @@ class RunStore:
             )
             record.events.append(event)
             subscribers = list(record.subscribers)
+            self._persist_record(run_id)
         await self._fanout(subscribers, event)
 
     async def _fanout(self, subscribers: Iterable[asyncio.Queue], event: BacktestEvent) -> None:
@@ -146,5 +197,4 @@ class RunStore:
             try:
                 queue.put_nowait(event)
             except asyncio.QueueFull:
-                # drop slow subscribers to avoid blocking the run
                 continue

--- a/api/tests/test_experiment_registry.py
+++ b/api/tests/test_experiment_registry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from api.app.experiment_registry import ExperimentRegistry, sha256_text
+from api.app.models import BacktestRequest, BacktestResult, RunState, StrategyConfig
+from api.app.store import RunStore
+
+
+class ExperimentRegistryTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.registry = ExperimentRegistry(Path(self.tempdir.name) / "registry.sqlite3")
+
+    def tearDown(self) -> None:
+        self.registry.close()
+        self.tempdir.cleanup()
+
+    async def test_run_store_rehydrates_persisted_api_runs(self) -> None:
+        store = RunStore(registry=self.registry)
+        request = BacktestRequest(
+            symbols=["AAPL"],
+            start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_date=datetime(2026, 1, 5, tzinfo=timezone.utc),
+            strategy=StrategyConfig(name="buy_and_hold"),
+            initial_capital=100000,
+        )
+
+        status_obj = await store.create_run(request)
+        await store.update_state(status_obj.run_id, RunState.running)
+        await store.set_result(
+            status_obj.run_id,
+            BacktestResult(
+                run_id=status_obj.run_id,
+                metrics_summary={"final_value": 101234.5},
+                equity_curve=[{"timestamp": "2026-01-01T00:00:00Z", "value": 100000.0}],
+                trades=[],
+                exposures=[],
+                logs=["completed"],
+            ),
+        )
+
+        reloaded = RunStore(registry=self.registry)
+        persisted_status = await reloaded.get_status(status_obj.run_id)
+        persisted_result = await reloaded.get_result(status_obj.run_id)
+        events = await reloaded.get_events_after(status_obj.run_id, None)
+
+        self.assertIsNotNone(persisted_status)
+        self.assertIsNotNone(persisted_result)
+        self.assertEqual(persisted_status.state, RunState.completed)
+        self.assertEqual(persisted_result.metrics_summary["final_value"], 101234.5)
+        self.assertGreaterEqual(len(events), 3)
+
+    async def test_registry_persists_strategy_snapshots_with_hashes(self) -> None:
+        strategy = self.registry.upsert_strategy(
+            name="Momentum Lab",
+            code="class MomentumLab:\n    pass\n",
+            config={"initial_capital": 250000, "commission": 0.001},
+            metadata={"saved_from": "test"},
+        )
+
+        loaded = self.registry.get_strategy("Momentum Lab")
+        listed = self.registry.list_strategies()
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(strategy["code_hash"], sha256_text("class MomentumLab:\n    pass\n"))
+        self.assertEqual(loaded["config"]["initial_capital"], 250000)
+        self.assertEqual(listed[0]["name"], "Momentum Lab")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Experiment durability:** GlowBack now persists Streamlit strategy snapshots, completed UI backtest runs, and API backtest history in a shared SQLite-backed experiment registry so saved strategies, comparison runs, and historical `/backtests` listings survive restarts and remain exportable/deletable intentionally.
 - **Engine scaling:** `gb-engine` now keeps per-symbol `StrategyContext` market buffers incrementally, reuses the live context across hot-path callbacks, and ships a Criterion benchmark covering representative 10-symbol/6-month and 50-symbol/1-year workloads instead of rebuilding full-history buffers on every callback.
 - **Catalog durability:** `gb-data` now reloads persisted `symbol_metadata` rows when `DataCatalog` starts, so symbol listings, metadata lookups, and catalog stats survive process restarts instead of disappearing from the in-memory cache.
 - **UI backtest correctness:** The Streamlit backtester now keeps last-known prices for every held symbol, analytics derive returns from the equity curve instead of `pct_change()` on cumulative return percentages, the dashboard no longer mutates the shared equity DataFrame in-place, and win rate is computed from realized closed trades (or shown as unavailable when nothing has closed yet).

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,10 +9,11 @@ The UI provides a full research loop: load data, edit strategies, run backtests,
 ## Features
 
 - Data loader (sample data, CSV, Alpha Vantage)
-- Strategy editor with templates and validation
-- Backtest runner with progress and logs
+- Strategy editor with templates, validation, and durable saved-strategy snapshots
+- Backtest runner with progress, logs, and persisted experiment history
 - Results dashboard (equity curve, drawdowns, metrics)
 - Portfolio analyzer (risk metrics, scenario analysis)
+- Advanced analytics compare view that can reload and compare historical runs across restarts
 
 ## Quick Start
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -88,6 +88,8 @@ def main():
         st.session_state.portfolio_data = None
     if 'saved_runs' not in st.session_state:
         st.session_state.saved_runs = {}
+    if 'saved_strategies' not in st.session_state:
+        st.session_state.saved_strategies = {}
     
     # Main navigation
     with st.sidebar:

--- a/ui/pages/advanced_analytics.py
+++ b/ui/pages/advanced_analytics.py
@@ -3,16 +3,24 @@ Advanced Analytics Page - Heatmaps, rolling statistics & interactive features
 Implements enhancements from issue #47.
 """
 
-import streamlit as st
-import pandas as pd
-import plotly.graph_objects as go
-import plotly.express as px
-from plotly.subplots import make_subplots
-import numpy as np
-from typing import Optional, Dict, List
 import io
 import json
-from datetime import datetime
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+from plotly.subplots import make_subplots
+
+from research_registry import (
+    delete_saved_run,
+    list_streamlit_runs,
+    rename_saved_run,
+    run_display_name,
+    run_summary_rows,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -50,14 +58,7 @@ def show():
     )
 
     results = st.session_state.get("backtest_results")
-    if not results:
-        st.warning("⚠️ No backtest results available. Run a backtest first.")
-        return
-
-    eq = _equity_df(results)
-    if eq is None or len(eq) < 2:
-        st.error("❌ Equity curve data is missing or too short for analytics.")
-        return
+    eq = _equity_df(results) if results else None
 
     tab_heatmaps, tab_rolling, tab_compare, tab_sensitivity, tab_export = st.tabs(
         [
@@ -70,19 +71,31 @@ def show():
     )
 
     with tab_heatmaps:
-        _show_heatmaps(eq, results)
+        if eq is None or len(eq) < 2 or not results:
+            st.warning("⚠️ Run a backtest to unlock heatmaps.")
+        else:
+            _show_heatmaps(eq, results)
 
     with tab_rolling:
-        _show_rolling_statistics(eq)
+        if eq is None or len(eq) < 2:
+            st.warning("⚠️ Run a backtest to unlock rolling statistics.")
+        else:
+            _show_rolling_statistics(eq)
 
     with tab_compare:
         _show_compare_runs()
 
     with tab_sensitivity:
-        _show_sensitivity()
+        if not results:
+            st.warning("⚠️ Run a backtest first to seed the sensitivity analysis.")
+        else:
+            _show_sensitivity()
 
     with tab_export:
-        _show_export(eq, results)
+        if eq is None or len(eq) < 2 or not results:
+            st.warning("⚠️ Run a backtest first to export analytics artifacts.")
+        else:
+            _show_export(eq, results)
 
 
 # ---------------------------------------------------------------------------
@@ -431,88 +444,94 @@ def _show_rolling_statistics(eq: pd.DataFrame):
 def _show_compare_runs():
     st.subheader("🔀 Compare Backtest Runs")
 
-    saved_runs: Dict[str, dict] = st.session_state.get("saved_runs", {})
-
-    # Save current run
-    current = st.session_state.get("backtest_results")
-    if current:
-        run_name = st.text_input(
-            "Save current run as",
-            value=f"Run {len(saved_runs) + 1}",
+    current = st.session_state.get("backtest_results") or {}
+    if current.get("run_id"):
+        save_label = st.text_input(
+            "Name the current run for later comparison",
+            value=str(current.get("strategy_name") or "Current Run"),
             key="save_run_name",
         )
-        if st.button("💾 Save Current Run"):
-            saved_runs[run_name] = {
-                "results": current,
-                "saved_at": datetime.now().isoformat(),
-            }
-            st.session_state.saved_runs = saved_runs
-            st.success(f"Saved as **{run_name}**")
+        if st.button("💾 Save Current Run Name"):
+            rename_saved_run(current["run_id"], save_label.strip() or None)
+            st.success(f"Saved current run as **{save_label.strip() or current['run_id']}**")
 
-    if len(saved_runs) < 2:
-        st.info(
-            "Save ≥ 2 backtest runs to compare them side-by-side. "
-            "Run different strategies or parameters and save each result."
-        )
-        if saved_runs:
-            st.markdown(f"**Saved runs:** {', '.join(saved_runs.keys())}")
+    persisted_runs = list_streamlit_runs()
+    if not persisted_runs:
+        st.info("No persisted runs yet. Run a backtest to create durable experiment history.")
         return
 
-    # Select runs to compare
+    st.markdown("**Persisted experiment history**")
+    st.dataframe(pd.DataFrame(run_summary_rows(persisted_runs)), use_container_width=True, hide_index=True)
+
+    option_lookup = {
+        f"{run_display_name(record)} [{record['run_id'][:8]}]": record for record in persisted_runs
+    }
+    default_selection = list(option_lookup.keys())[: min(2, len(option_lookup))]
     selected = st.multiselect(
         "Select runs to compare",
-        options=list(saved_runs.keys()),
-        default=list(saved_runs.keys())[:2],
+        options=list(option_lookup.keys()),
+        default=default_selection,
     )
     if len(selected) < 2:
-        st.warning("Select at least 2 runs.")
-        return
-
-    # Metrics comparison table
-    rows = []
-    for name in selected:
-        r = saved_runs[name]["results"]
-        rows.append(
-            {
-                "Run": name,
-                "Total Return (%)": f"{r.get('total_return', 0):.2f}",
-                "Sharpe": f"{r.get('sharpe_ratio', 0):.2f}",
-                "Max DD (%)": f"{r.get('max_drawdown', 0):.2f}",
-                "Trades": r.get("total_trades", 0),
-                "Final Value ($)": f"{r.get('final_value', 0):,.2f}",
-            }
-        )
-    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
-
-    # Equity overlay chart
-    fig = go.Figure()
-    for name in selected:
-        r = saved_runs[name]["results"]
-        edf = _equity_df(r)
-        if edf is not None:
-            fig.add_trace(
-                go.Scatter(
-                    x=edf.index,
-                    y=edf["value"],
-                    mode="lines",
-                    name=name,
-                )
+        st.info("Select at least 2 persisted runs to compare them across sessions.")
+    else:
+        rows = []
+        fig = go.Figure()
+        for name in selected:
+            record = option_lookup[name]
+            results = record.get("result") or {}
+            rows.append(
+                {
+                    "Run": name,
+                    "Total Return (%)": f"{results.get('total_return', 0):.2f}",
+                    "Sharpe": f"{results.get('sharpe_ratio', 0):.2f}",
+                    "Max DD (%)": f"{results.get('max_drawdown', 0):.2f}",
+                    "Trades": results.get("total_trades", 0),
+                    "Final Value ($)": f"{results.get('final_value', 0):,.2f}",
+                }
             )
-    fig.update_layout(
-        title="Equity Curve Comparison",
-        xaxis_title="Date",
-        yaxis_title="Portfolio Value ($)",
-        height=450,
-    )
-    st.plotly_chart(fig, use_container_width=True)
+            edf = _equity_df(results)
+            if edf is not None:
+                fig.add_trace(
+                    go.Scatter(
+                        x=edf.index,
+                        y=edf["value"],
+                        mode="lines",
+                        name=name,
+                    )
+                )
 
-    # Delete a saved run
-    with st.expander("🗑️ Manage saved runs"):
-        to_delete = st.selectbox("Delete a run", options=[""] + list(saved_runs.keys()))
-        if to_delete and st.button("Delete"):
-            del saved_runs[to_delete]
-            st.session_state.saved_runs = saved_runs
-            st.rerun()
+        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+        fig.update_layout(
+            title="Equity Curve Comparison",
+            xaxis_title="Date",
+            yaxis_title="Portfolio Value ($)",
+            height=450,
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+    with st.expander("🗂️ Manage persisted runs"):
+        selected_run_name = st.selectbox(
+            "Choose a persisted run",
+            options=[""] + list(option_lookup.keys()),
+            key="manage_persisted_run",
+        )
+        if selected_run_name:
+            selected_record = option_lookup[selected_run_name]
+            action_col1, action_col2 = st.columns(2)
+            with action_col1:
+                st.download_button(
+                    "⬇️ Export Run JSON",
+                    data=json.dumps(selected_record, indent=2),
+                    file_name=f"{selected_record['run_id']}.json",
+                    mime="application/json",
+                    use_container_width=True,
+                )
+            with action_col2:
+                if st.button("🗑️ Delete Run", type="secondary"):
+                    if delete_saved_run(selected_record["run_id"]):
+                        st.success(f"Deleted {selected_run_name}.")
+                        st.rerun()
 
 
 # ---------------------------------------------------------------------------

--- a/ui/pages/backtest_runner.py
+++ b/ui/pages/backtest_runner.py
@@ -5,11 +5,13 @@ Backtest Runner Page - Execute backtests and monitor progress
 import queue
 import threading
 import time
+from datetime import datetime, timezone
 
 import pandas as pd
 import streamlit as st
 
 from backtest_core import run_backtest
+from research_registry import persist_streamlit_run
 
 def show():
     """Main backtest runner page"""
@@ -101,6 +103,8 @@ def run_backtest_execution():
         st.session_state.backtest_progress = 0
         st.session_state.backtest_logs = []
         
+        run_started_at = datetime.now(timezone.utc).isoformat()
+
         # Create progress and log containers
         progress_container = st.container()
         log_container = st.container()
@@ -171,6 +175,18 @@ def run_backtest_execution():
         # Process results
         result = result_container[0]
         if result:
+            persisted = persist_streamlit_run(
+                result,
+                market_data,
+                config,
+                strategy_code,
+                created_at=run_started_at,
+                started_at=run_started_at,
+                finished_at=datetime.now(timezone.utc).isoformat(),
+            )
+            result["run_id"] = persisted["run_id"]
+            result["saved_at"] = persisted["created_at"]
+            result["strategy_name"] = persisted.get("strategy_name")
             st.session_state.backtest_results = result
             st.session_state.backtest_logs = logs
             progress_bar.progress(1.0)
@@ -222,6 +238,9 @@ def show_quick_results():
     with col4:
         st.metric("Total Trades", results['total_trades'])
     
+    if results.get('run_id'):
+        st.caption(f"Persisted experiment ID: `{results['run_id']}`")
+
     # Final portfolio
     col1, col2 = st.columns(2)
     

--- a/ui/pages/strategy_editor.py
+++ b/ui/pages/strategy_editor.py
@@ -2,8 +2,12 @@
 Strategy Editor Page - Create and edit trading strategies
 """
 
+import json
+
 import streamlit as st
 from streamlit_ace import st_ace
+
+from research_registry import delete_saved_strategy, get_saved_strategy, list_saved_strategies, save_strategy_snapshot
 
 # Strategy templates
 STRATEGY_TEMPLATES = {
@@ -214,15 +218,35 @@ def show():
         # Strategy configuration
         st.markdown("---")
         st.subheader("⚙️ Configuration")
-        
-        strategy_name = st.text_input("Strategy Name", value="My Strategy")
-        initial_capital = st.number_input("Initial Capital", value=100000, min_value=1000, step=1000)
+
+        existing_config = st.session_state.get("strategy_config", {})
+        strategy_name = st.text_input("Strategy Name", value=existing_config.get("name", "My Strategy"))
+        initial_capital = st.number_input(
+            "Initial Capital",
+            value=int(existing_config.get("initial_capital", 100000)),
+            min_value=1000,
+            step=1000,
+        )
         
         # Advanced settings
         with st.expander("Advanced Settings"):
-            commission = st.number_input("Commission per Trade", value=0.001, min_value=0.0, format="%.4f")
-            slippage = st.number_input("Slippage (bps)", value=5, min_value=0)
-            max_position_size = st.slider("Max Position Size (%)", 1, 100, 95)
+            commission = st.number_input(
+                "Commission per Trade",
+                value=float(existing_config.get("commission", 0.001)),
+                min_value=0.0,
+                format="%.4f",
+            )
+            slippage = st.number_input(
+                "Slippage (bps)",
+                value=int(existing_config.get("slippage", 5)),
+                min_value=0,
+            )
+            max_position_size = st.slider(
+                "Max Position Size (%)",
+                1,
+                100,
+                int(float(existing_config.get("max_position_size", 0.95)) * 100),
+            )
         
         # Save configuration
         if st.button("💾 Save Config"):
@@ -272,9 +296,38 @@ def show():
             if st.button("💾 Save Strategy"):
                 save_strategy_code(strategy_code, strategy_name)
         
+        saved_strategy_records = list_saved_strategies()
+        saved_strategy_lookup = {record["name"]: record for record in saved_strategy_records}
+        selected_saved_strategy = st.selectbox(
+            "Persisted Strategy Library",
+            options=[""] + list(saved_strategy_lookup.keys()),
+            key="persisted_strategy_selection",
+            help="Saved strategies survive restarts and can be exported or deleted intentionally.",
+        )
+
         with col3:
-            if st.button("📂 Load Strategy"):
-                load_saved_strategy()
+            if st.button("📂 Load Strategy", disabled=not selected_saved_strategy):
+                load_saved_strategy(selected_saved_strategy)
+
+        if selected_saved_strategy:
+            selected_record = saved_strategy_lookup[selected_saved_strategy]
+            st.caption(
+                f"Saved {selected_record['updated_at']} · code hash {selected_record['code_hash'][:12]}"
+            )
+            manage_col1, manage_col2 = st.columns(2)
+            with manage_col1:
+                st.download_button(
+                    "⬇️ Export Strategy JSON",
+                    data=json.dumps(selected_record, indent=2),
+                    file_name=f"{selected_saved_strategy.replace(' ', '_').lower()}_strategy.json",
+                    mime="application/json",
+                    use_container_width=True,
+                )
+            with manage_col2:
+                if st.button("🗑️ Delete Strategy", type="secondary"):
+                    if delete_saved_strategy(selected_saved_strategy):
+                        st.success(f"🗑️ Deleted strategy '{selected_saved_strategy}'.")
+                        st.rerun()
     
     st.markdown("---")
     
@@ -329,25 +382,26 @@ def validate_strategy_code(code):
         return False
 
 def save_strategy_code(code, name):
-    """Save strategy code to session state"""
+    """Persist strategy code so it survives restarts."""
+    record = save_strategy_snapshot(name, code, st.session_state.get('strategy_config', {}))
     if 'saved_strategies' not in st.session_state:
         st.session_state.saved_strategies = {}
-    
     st.session_state.saved_strategies[name] = code
-    st.success(f"✅ Strategy '{name}' saved!")
+    st.success(f"✅ Strategy '{name}' saved (hash {record['code_hash'][:12]}…).")
 
-def load_saved_strategy():
-    """Load a saved strategy"""
-    if 'saved_strategies' not in st.session_state or not st.session_state.saved_strategies:
+def load_saved_strategy(strategy_name):
+    """Load a persisted strategy snapshot."""
+    record = get_saved_strategy(strategy_name)
+    if not record:
         st.warning("⚠️ No saved strategies found.")
         return
-    
-    strategy_name = st.selectbox("Select Saved Strategy", list(st.session_state.saved_strategies.keys()))
-    
-    if st.button("📂 Load Selected Strategy"):
-        st.session_state.strategy_code = st.session_state.saved_strategies[strategy_name]
-        st.success(f"✅ Loaded strategy '{strategy_name}'")
-        st.rerun()
+
+    st.session_state.strategy_code = record['code']
+    config = record.get('config') or {}
+    if config:
+        st.session_state.strategy_config = config
+    st.success(f"✅ Loaded strategy '{strategy_name}'")
+    st.rerun()
 
 def show_strategy_documentation():
     """Show strategy development documentation"""

--- a/ui/research_registry.py
+++ b/ui/research_registry.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import pandas as pd
+
+from api.app.experiment_registry import ExperimentRegistry, get_default_registry, sha256_text, stable_json_dumps
+
+
+def _strategy_name(config: dict[str, Any]) -> str:
+    name = str(config.get("name") or "streamlit_strategy").strip()
+    return name or "streamlit_strategy"
+
+
+def build_streamlit_run_request(
+    market_data: pd.DataFrame,
+    config: dict[str, Any],
+    strategy_code: str,
+) -> dict[str, Any]:
+    if market_data.empty:
+        raise ValueError("market_data must not be empty")
+
+    timestamps = pd.to_datetime(market_data["timestamp"], utc=True)
+    symbols = sorted({str(symbol) for symbol in market_data.get("symbol", []) if symbol})
+    resolutions = sorted({str(resolution) for resolution in market_data.get("resolution", []) if resolution})
+
+    dataset_fingerprint = sha256_text(
+        stable_json_dumps(
+            {
+                "bars": int(len(market_data)),
+                "symbols": symbols,
+                "start": timestamps.min().isoformat(),
+                "end": timestamps.max().isoformat(),
+                "resolutions": resolutions,
+            }
+        )
+    )
+
+    initial_capital = float(config.get("initial_capital", 100000.0))
+    commission_bps = None
+    if config.get("commission") is not None:
+        commission_bps = float(config["commission"]) * 10_000
+
+    slippage_bps = None
+    if config.get("slippage") is not None:
+        slippage_bps = float(config["slippage"])
+
+    return {
+        "symbols": symbols or ["UNKNOWN"],
+        "start_date": timestamps.min().isoformat(),
+        "end_date": timestamps.max().isoformat(),
+        "resolution": resolutions[0] if resolutions else "day",
+        "strategy": {
+            "name": _strategy_name(config),
+            "params": {
+                "max_position_size": config.get("max_position_size"),
+            },
+        },
+        "execution": {
+            "commission_bps": commission_bps,
+            "slippage_bps": slippage_bps,
+            "latency_ms": None,
+        },
+        "initial_capital": initial_capital,
+        "currency": "USD",
+        "timezone": "UTC",
+        "provenance": {
+            "runner": "streamlit-local",
+            "bar_count": int(len(market_data)),
+            "symbol_count": len(symbols) or 1,
+            "dataset_fingerprint": dataset_fingerprint,
+            "strategy_code_hash": sha256_text(strategy_code),
+            "strategy_config_hash": sha256_text(stable_json_dumps(config)),
+        },
+    }
+
+
+def persist_streamlit_run(
+    result: dict[str, Any],
+    market_data: pd.DataFrame,
+    config: dict[str, Any],
+    strategy_code: str,
+    *,
+    registry: ExperimentRegistry | None = None,
+    label: str | None = None,
+    created_at: str | None = None,
+    started_at: str | None = None,
+    finished_at: str | None = None,
+) -> dict[str, Any]:
+    registry = registry or get_default_registry()
+    run_id = str(result.get("run_id") or uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    status = {
+        "run_id": run_id,
+        "state": "completed",
+        "progress": 1.0,
+        "created_at": created_at or now,
+        "started_at": started_at or created_at or now,
+        "finished_at": finished_at or now,
+        "error": None,
+    }
+
+    request = build_streamlit_run_request(market_data, config, strategy_code)
+    strategy_name = _strategy_name(config)
+    metadata = {
+        "runner": "streamlit-local",
+        "comparison_ready": True,
+        "saved_via": "advanced_analytics" if label else None,
+        "result_summary": {
+            "total_return": result.get("total_return"),
+            "sharpe_ratio": result.get("sharpe_ratio"),
+            "max_drawdown": result.get("max_drawdown"),
+            "final_value": result.get("final_value"),
+            "total_trades": result.get("total_trades"),
+        },
+    }
+
+    persisted = registry.upsert_run(
+        run_id=run_id,
+        source="ui",
+        status=status,
+        request=request,
+        result={**result, "run_id": run_id},
+        metadata=metadata,
+        strategy_name=strategy_name,
+        strategy_code=strategy_code,
+        strategy_config=config,
+        label=label,
+    )
+    return persisted
+
+
+def list_streamlit_runs(*, registry: ExperimentRegistry | None = None) -> list[dict[str, Any]]:
+    registry = registry or get_default_registry()
+    return registry.list_runs(source="ui", state="completed", limit=200)
+
+
+def list_saved_strategies(*, registry: ExperimentRegistry | None = None) -> list[dict[str, Any]]:
+    registry = registry or get_default_registry()
+    return registry.list_strategies(limit=200)
+
+
+def save_strategy_snapshot(
+    name: str,
+    code: str,
+    config: dict[str, Any] | None = None,
+    *,
+    registry: ExperimentRegistry | None = None,
+) -> dict[str, Any]:
+    registry = registry or get_default_registry()
+    return registry.upsert_strategy(
+        name=name,
+        code=code,
+        config=config or {},
+        metadata={
+            "saved_from": "streamlit-strategy-editor",
+            "strategy_config_hash": sha256_text(stable_json_dumps(config or {})),
+        },
+    )
+
+
+def get_saved_strategy(name: str, *, registry: ExperimentRegistry | None = None) -> dict[str, Any] | None:
+    registry = registry or get_default_registry()
+    return registry.get_strategy(name)
+
+
+def delete_saved_strategy(name: str, *, registry: ExperimentRegistry | None = None) -> bool:
+    registry = registry or get_default_registry()
+    return registry.delete_strategy(name)
+
+
+def rename_saved_run(run_id: str, label: str | None, *, registry: ExperimentRegistry | None = None) -> dict[str, Any] | None:
+    registry = registry or get_default_registry()
+    return registry.rename_run(run_id, label)
+
+
+def delete_saved_run(run_id: str, *, registry: ExperimentRegistry | None = None) -> bool:
+    registry = registry or get_default_registry()
+    return registry.delete_run(run_id)
+
+
+def run_display_name(record: dict[str, Any]) -> str:
+    label = str(record.get("label") or "").strip()
+    if label:
+        return label
+
+    strategy_name = record.get("strategy_name") or (record.get("request") or {}).get("strategy", {}).get("name") or "Run"
+    created_at = record.get("created_at") or ""
+    if created_at:
+        try:
+            parsed = pd.to_datetime(created_at, utc=True)
+            return f"{strategy_name} · {parsed.strftime('%Y-%m-%d %H:%M UTC')}"
+        except Exception:  # pragma: no cover - defensive formatting fallback
+            pass
+    return str(strategy_name)
+
+
+def run_summary_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for record in records:
+        result = record.get("result") or {}
+        request = record.get("request") or {}
+        rows.append(
+            {
+                "Run": run_display_name(record),
+                "Run ID": record["run_id"],
+                "Symbols": ", ".join(request.get("symbols", [])),
+                "Saved": record.get("created_at"),
+                "Total Return (%)": result.get("total_return"),
+                "Sharpe": result.get("sharpe_ratio"),
+                "Max DD (%)": result.get("max_drawdown"),
+                "Trades": result.get("total_trades"),
+                "Final Value ($)": result.get("final_value"),
+            }
+        )
+    return rows

--- a/ui/tests/test_research_registry.py
+++ b/ui/tests/test_research_registry.py
@@ -1,0 +1,61 @@
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from research_registry import build_streamlit_run_request  # noqa: E402
+
+
+class ResearchRegistryTests(unittest.TestCase):
+    def test_build_streamlit_run_request_captures_reproducibility_metadata(self):
+        market_data = pd.DataFrame(
+            [
+                {
+                    "timestamp": pd.Timestamp("2026-01-01T00:00:00Z"),
+                    "symbol": "MSFT",
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.5,
+                    "volume": 1000,
+                    "resolution": "day",
+                },
+                {
+                    "timestamp": pd.Timestamp("2026-01-02T00:00:00Z"),
+                    "symbol": "AAPL",
+                    "open": 200.0,
+                    "high": 202.0,
+                    "low": 198.0,
+                    "close": 201.0,
+                    "volume": 1500,
+                    "resolution": "day",
+                },
+            ]
+        )
+
+        payload = build_streamlit_run_request(
+            market_data,
+            {
+                "name": "Mean Reversion Lab",
+                "initial_capital": 50000,
+                "commission": 0.001,
+                "slippage": 5,
+                "max_position_size": 0.25,
+            },
+            "class MeanReversionLab:\n    pass\n",
+        )
+
+        self.assertEqual(payload["symbols"], ["AAPL", "MSFT"])
+        self.assertEqual(payload["resolution"], "day")
+        self.assertEqual(payload["strategy"]["name"], "Mean Reversion Lab")
+        self.assertEqual(payload["provenance"]["bar_count"], 2)
+        self.assertEqual(payload["provenance"]["symbol_count"], 2)
+        self.assertIn("strategy_code_hash", payload["provenance"])
+        self.assertIn("dataset_fingerprint", payload["provenance"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared SQLite-backed experiment registry for API runs, Streamlit backtest history, and saved strategies so experiment history survives restarts
- persist UI backtest runs automatically, let Advanced Analytics reload/export/delete historical runs, and let the Strategy Editor save/load/delete/export durable strategy snapshots
- add regression coverage for API run rehydration plus Streamlit reproducibility metadata, and document the new durability behavior

## Testing
- `python3 -m compileall api ui`
- `python3 -m unittest discover -s ui/tests -v`
- `PYTHONPATH=$PWD python3 -m unittest discover -s api/tests -v` *(fails in the shared host env because FastAPI imports an incompatible global Pydantic; rerun in a local target sandbox below)*
- `rm -rf .pydeps-test && python3 -m pip install -q --target ./.pydeps-test -r api/requirements.txt httpx && PYTHONPATH="$(pwd)/.pydeps-test:$PWD" python3 -m unittest discover -s api/tests -v && rm -rf .pydeps-test`
- `mkdocs build --strict`

Fixes #91
