### PR TITLE
Fix #92: ship benchmark-aware attribution and tearsheets

### DIFF
--- a/api/app/adapter.py
+++ b/api/app/adapter.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import asyncio
 import math
 import statistics
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from typing import Protocol
 
 from .models import BacktestRequest, BacktestResult, RunState
 from .store import RunStore
+
+
+TRADING_DAYS_PER_YEAR = 252
+RISK_FREE_RATE = 0.02
 
 
 class EngineAdapter(Protocol):
@@ -15,41 +19,125 @@ class EngineAdapter(Protocol):
         ...
 
 
-def _build_sample_results(initial_capital: float, start_date: datetime, end_date: datetime) -> tuple[list[dict], dict]:
+def _build_sample_curve(
+    initial_capital: float,
+    start_date: datetime,
+    end_date: datetime,
+    amplitude: float,
+    drift: float,
+    phase_divisor: float,
+    symbol: str | None = None,
+) -> tuple[list[dict], list[float]]:
     days = max(2, (end_date - start_date).days + 1)
     steps = min(days, 60)
 
     equity = initial_capital
     peak = equity
-    equity_curve: list[dict] = []
+    curve: list[dict] = []
     daily_returns: list[float] = []
 
     for step in range(steps):
-        daily_return = 0.002 * math.sin(step / 4) + 0.0005
+        daily_return = amplitude * math.sin(step / phase_divisor) + drift
         equity *= 1 + daily_return
         peak = max(peak, equity)
         drawdown = (peak - equity) / peak if peak else 0.0
 
-        cash = equity * 0.05
-        positions = equity - cash
-        cumulative_return = (equity - initial_capital) / initial_capital * 100
-        total_pnl = equity - initial_capital
-
-        equity_curve.append(
+        curve.append(
             {
                 "timestamp": (start_date + timedelta(days=step)).isoformat(),
                 "value": equity,
-                "cash": cash,
-                "positions": positions,
-                "total_pnl": total_pnl,
-                "returns": cumulative_return,
+                "cash": equity * 0.05,
+                "positions": equity * 0.95,
+                "total_pnl": equity - initial_capital,
+                "returns": (equity - initial_capital) / initial_capital * 100,
                 "daily_return": daily_return * 100,
                 "drawdown": drawdown * 100,
+                **({"symbol": symbol} if symbol else {}),
             }
         )
         daily_returns.append(daily_return)
 
-    total_return = (equity - initial_capital) / initial_capital * 100
+    return curve, daily_returns
+
+
+def _calculate_benchmark_metrics(
+    equity_curve: list[dict],
+    benchmark_curve: list[dict],
+) -> dict[str, float]:
+    strategy_returns = [point["daily_return"] / 100 for point in equity_curve[1:]]
+    benchmark_returns = [point["daily_return"] / 100 for point in benchmark_curve[1:]]
+    periods = min(len(strategy_returns), len(benchmark_returns))
+    if periods <= 1:
+        return {}
+
+    strategy_returns = strategy_returns[:periods]
+    benchmark_returns = benchmark_returns[:periods]
+    active_returns = [s - b for s, b in zip(strategy_returns, benchmark_returns)]
+
+    benchmark_mean = statistics.mean(benchmark_returns)
+    strategy_mean = statistics.mean(strategy_returns)
+    benchmark_var = statistics.variance(benchmark_returns) if len(benchmark_returns) > 1 else 0.0
+
+    beta = None
+    alpha = None
+    if benchmark_var > 0:
+        covariance = statistics.covariance(strategy_returns, benchmark_returns)
+        beta = covariance / benchmark_var
+        alpha_daily = (strategy_mean - RISK_FREE_RATE / TRADING_DAYS_PER_YEAR) - beta * (
+            benchmark_mean - RISK_FREE_RATE / TRADING_DAYS_PER_YEAR
+        )
+        alpha = alpha_daily * TRADING_DAYS_PER_YEAR * 100
+
+    active_std = statistics.pstdev(active_returns) if len(active_returns) > 1 else 0.0
+    information_ratio = None
+    tracking_error = None
+    if active_std > 0:
+        information_ratio = statistics.mean(active_returns) / active_std * math.sqrt(TRADING_DAYS_PER_YEAR)
+        tracking_error = active_std * math.sqrt(TRADING_DAYS_PER_YEAR) * 100
+
+    benchmark_total_return = benchmark_curve[-1]["returns"]
+    strategy_total_return = equity_curve[-1]["returns"]
+    benchmark_annualized_return = ((1 + benchmark_total_return / 100) ** (TRADING_DAYS_PER_YEAR / len(benchmark_curve)) - 1) * 100
+    strategy_annualized_return = ((1 + strategy_total_return / 100) ** (TRADING_DAYS_PER_YEAR / len(equity_curve)) - 1) * 100
+
+    return {
+        "beta": float(beta) if beta is not None else None,
+        "alpha": float(alpha) if alpha is not None else None,
+        "tracking_error": float(tracking_error) if tracking_error is not None else None,
+        "information_ratio": float(information_ratio) if information_ratio is not None else None,
+        "excess_return": float(strategy_annualized_return - benchmark_annualized_return),
+        "benchmark_total_return": float(benchmark_total_return),
+        "benchmark_annualized_return": float(benchmark_annualized_return),
+        "strategy_total_return": float(strategy_total_return),
+        "strategy_annualized_return": float(strategy_annualized_return),
+    }
+
+
+def _build_sample_results(
+    initial_capital: float,
+    start_date: datetime,
+    end_date: datetime,
+    benchmark_symbol: str | None,
+) -> tuple[list[dict], list[dict], dict, dict]:
+    equity_curve, daily_returns = _build_sample_curve(
+        initial_capital=initial_capital,
+        start_date=start_date,
+        end_date=end_date,
+        amplitude=0.002,
+        drift=0.0005,
+        phase_divisor=4,
+    )
+    benchmark_curve, benchmark_daily_returns = _build_sample_curve(
+        initial_capital=initial_capital,
+        start_date=start_date,
+        end_date=end_date,
+        amplitude=0.0016,
+        drift=0.00035,
+        phase_divisor=5,
+        symbol=benchmark_symbol,
+    )
+
+    total_return = equity_curve[-1]["returns"]
     max_drawdown = max(point["drawdown"] for point in equity_curve)
 
     max_drawdown_duration_days = 0
@@ -68,8 +156,8 @@ def _build_sample_results(initial_capital: float, start_date: datetime, end_date
         mean_return = 0.0
         stdev_return = 0.0
 
-    volatility = stdev_return * math.sqrt(252) * 100 if stdev_return > 0 else 0.0
-    sharpe_ratio = (mean_return / stdev_return) * math.sqrt(252) if stdev_return > 0 else 0.0
+    volatility = stdev_return * math.sqrt(TRADING_DAYS_PER_YEAR) * 100 if stdev_return > 0 else 0.0
+    sharpe_ratio = (mean_return / stdev_return) * math.sqrt(TRADING_DAYS_PER_YEAR) if stdev_return > 0 else 0.0
 
     downside_returns = [r for r in daily_returns if r < 0]
     if downside_returns:
@@ -77,7 +165,7 @@ def _build_sample_results(initial_capital: float, start_date: datetime, end_date
     else:
         downside_deviation = 0.0
     sortino_ratio = (
-        (mean_return / downside_deviation) * math.sqrt(252)
+        (mean_return / downside_deviation) * math.sqrt(TRADING_DAYS_PER_YEAR)
         if downside_deviation > 0
         else 0.0
     )
@@ -94,27 +182,30 @@ def _build_sample_results(initial_capital: float, start_date: datetime, end_date
         cvar_95 = -statistics.mean(tail_returns) if tail_returns else 0.0
 
         if stdev_return > 0 and len(daily_returns) >= 3:
-            skewness = sum(
-                ((r - mean_return) / stdev_return) ** 3 for r in daily_returns
-            ) / len(daily_returns)
+            skewness = sum(((r - mean_return) / stdev_return) ** 3 for r in daily_returns) / len(daily_returns)
         if stdev_return > 0 and len(daily_returns) >= 4:
             kurtosis = (
-                sum(((r - mean_return) / stdev_return) ** 4 for r in daily_returns)
-                / len(daily_returns)
-                - 3
+                sum(((r - mean_return) / stdev_return) ** 4 for r in daily_returns) / len(daily_returns) - 3
             )
 
-    annualized_return = 0.0
-    if steps > 1:
-        annualized_return = ((1 + total_return / 100) ** (252 / steps) - 1) * 100
+    annualized_return = ((1 + total_return / 100) ** (TRADING_DAYS_PER_YEAR / len(equity_curve)) - 1) * 100 if len(equity_curve) > 1 else 0.0
+    calmar_ratio = annualized_return / max_drawdown if max_drawdown > 0 else 0.0
 
-    calmar_ratio = 0.0
-    if max_drawdown > 0:
-        calmar_ratio = annualized_return / max_drawdown
+    benchmark_metrics = _calculate_benchmark_metrics(equity_curve, benchmark_curve)
+    benchmark_metrics["benchmark_symbol"] = benchmark_symbol
+
+    cost_summary = {
+        "total_commissions": 0.0,
+        "total_slippage_cost": 0.0,
+        "total_cost_drag": 0.0,
+        "cost_drag_pct_initial": 0.0,
+        "turnover_multiple": 0.0,
+        "total_notional": 0.0,
+    }
 
     metrics_summary = {
         "initial_capital": initial_capital,
-        "final_value": equity,
+        "final_value": equity_curve[-1]["value"],
         "total_return": total_return,
         "annualized_return": annualized_return,
         "volatility": volatility,
@@ -135,9 +226,24 @@ def _build_sample_results(initial_capital: float, start_date: datetime, end_date
         "largest_win": 0.0,
         "largest_loss": 0.0,
         "total_commissions": 0.0,
+        **benchmark_metrics,
     }
 
-    return equity_curve, metrics_summary
+    tearsheet = {
+        "overview": {
+            "final_value": metrics_summary["final_value"],
+            "total_return": total_return,
+            "annualized_return": annualized_return,
+            "sharpe_ratio": sharpe_ratio,
+            "max_drawdown": max_drawdown,
+        },
+        "benchmark": benchmark_metrics,
+        "costs": cost_summary,
+        "top_contributors": [],
+        "biggest_detractors": [],
+    }
+
+    return equity_curve, benchmark_curve, metrics_summary, tearsheet
 
 
 class MockEngineAdapter:
@@ -153,19 +259,24 @@ class MockEngineAdapter:
                 progress = step / total_steps
                 await self._store.update_progress(run_id, progress, message=f"Step {step}/{total_steps}")
 
-            equity_curve, metrics_summary = _build_sample_results(
+            benchmark_symbol = request.benchmark_symbol or (request.symbols[0] if request.symbols else "SPY")
+            equity_curve, benchmark_curve, metrics_summary, tearsheet = _build_sample_results(
                 request.initial_capital,
                 request.start_date,
                 request.end_date,
+                benchmark_symbol,
             )
 
             result = BacktestResult(
                 run_id=run_id,
                 metrics_summary=metrics_summary,
                 equity_curve=equity_curve,
+                benchmark_curve=benchmark_curve,
+                benchmark_symbol=benchmark_symbol,
                 trades=[],
                 exposures=[],
-                logs=["Mock run completed"],
+                tearsheet=tearsheet,
+                logs=[f"Mock run completed against benchmark {benchmark_symbol}"],
             )
             await self._store.set_result(run_id, result)
         except Exception as exc:  # pragma: no cover - safety net

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -38,6 +38,7 @@ class BacktestRequest(BaseModel):
     initial_capital: float = Field(default=1_000_000.0, gt=0, le=1e12)
     currency: str = Field(default="USD", min_length=3, max_length=5, pattern=r"^[A-Z]{3,5}$")
     timezone: str = Field(default="UTC", max_length=64)
+    benchmark_symbol: str | None = Field(default=None, min_length=1, max_length=16)
 
 
 class RunState(str, Enum):
@@ -74,8 +75,11 @@ class BacktestEvent(BaseModel):
 
 class BacktestResult(BaseModel):
     run_id: str
-    metrics_summary: dict[str, float] = Field(default_factory=dict)
+    metrics_summary: dict[str, Any] = Field(default_factory=dict)
     equity_curve: list[dict[str, Any]] = Field(default_factory=list)
+    benchmark_curve: list[dict[str, Any]] = Field(default_factory=list)
+    benchmark_symbol: str | None = None
     trades: list[dict[str, Any]] = Field(default_factory=list)
     exposures: list[dict[str, Any]] = Field(default_factory=list)
+    tearsheet: dict[str, Any] = Field(default_factory=dict)
     logs: list[str] = Field(default_factory=list)

--- a/api/tests/test_backtest_adapter.py
+++ b/api/tests/test_backtest_adapter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+from api.app.adapter import MockEngineAdapter
+from api.app.models import BacktestRequest
+from api.app.store import RunStore
+
+
+class BacktestAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_mock_adapter_emits_benchmark_curve_and_tearsheet(self) -> None:
+        store = RunStore()
+        adapter = MockEngineAdapter(store)
+        request = BacktestRequest(
+            symbols=["AAPL"],
+            start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end_date=datetime(2024, 3, 1, tzinfo=timezone.utc),
+            benchmark_symbol="SPY",
+        )
+
+        status_obj = await store.create_run(request)
+        await adapter.run(status_obj.run_id, request)
+        result = await store.get_result(status_obj.run_id)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.benchmark_symbol, "SPY")
+        self.assertTrue(result.benchmark_curve)
+        self.assertIn("benchmark_symbol", result.metrics_summary)
+        self.assertIn("information_ratio", result.metrics_summary)
+        self.assertIn("benchmark", result.tearsheet)
+        self.assertEqual(result.tearsheet["benchmark"]["benchmark_symbol"], "SPY")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/api/fastapi.md
+++ b/docs/api/fastapi.md
@@ -56,7 +56,8 @@ POST /backtests
   "end_date": "2024-12-31T23:59:59Z",
   "resolution": "day",
   "strategy": {"name": "buy_and_hold"},
-  "execution": {"slippage_bps": 1.0, "commission_bps": 0.5}
+  "execution": {"slippage_bps": 1.0, "commission_bps": 0.5},
+  "benchmark_symbol": "SPY"
 }
 ```
 
@@ -91,8 +92,24 @@ POST /backtests
       "drawdown": 0.0
     }
   ],
+  "benchmark_symbol": "SPY",
+  "benchmark_curve": [
+    {
+      "timestamp": "2024-01-01T00:00:00+00:00",
+      "symbol": "SPY",
+      "value": 1003200.0,
+      "returns": 0.32,
+      "daily_return": 0.32,
+      "drawdown": 0.0
+    }
+  ],
   "trades": [],
   "exposures": [],
+  "tearsheet": {
+    "overview": {"final_value": 1012345.67},
+    "benchmark": {"beta": 0.94, "alpha": 1.85, "information_ratio": 0.42},
+    "costs": {"total_cost_drag": 0.0}
+  },
   "logs": []
 }
 ```
@@ -107,6 +124,11 @@ Common `metrics_summary` keys include:
 - `total_trades`, `win_rate`, `profit_factor`
 - `average_win`, `average_loss`, `largest_win`, `largest_loss`
 - `total_commissions`
+- benchmark-relative metrics such as `beta`, `alpha`, `tracking_error`, `information_ratio`, and `excess_return`
+
+Additional top-level result fields include:
+- `benchmark_symbol`, `benchmark_curve`
+- `tearsheet`
 
 Notes:
 - `returns`, `daily_return`, `max_drawdown`, and `volatility` are expressed as percentages.
@@ -123,4 +145,5 @@ Notes:
 
 - Storage is in‑memory; restarting the service clears runs.
 - The mock engine emits progress updates and a sample result.
+- Benchmark-relative metrics are computed from the returned strategy and benchmark curves, not placeholder percentages.
 - Replace the mock adapter with `gb-python` bindings or a CLI bridge in Phase 2.

--- a/docs/tutorials/ui-workflow.md
+++ b/docs/tutorials/ui-workflow.md
@@ -20,7 +20,7 @@ The **🔬 Advanced Analytics** page provides:
 ### Rolling Statistics
 - Rolling Sharpe ratio with configurable window (30/60/90/252 days).
 - Annualised rolling volatility with percentile bands.
-- Rolling beta against a benchmark.
+- Rolling beta against an actual benchmark series loaded into the run.
 - Rolling maximum drawdown (trailing window).
 
 ### Compare Runs
@@ -32,6 +32,7 @@ Sweep two parameters across a grid and visualise the impact on return, Sharpe, d
 ### Export
 - Download equity curve and trades as CSV.
 - Download summary metrics as JSON.
+- Download an institutional-style tearsheet in JSON or Markdown.
 - Use browser print (Ctrl+P) for a quick PDF snapshot.
 
 ## Dark Mode
@@ -42,5 +43,6 @@ Toggle **🌙 Dark Mode** in the sidebar for a dark colour scheme.
 
 - Start with sample data to validate logic quickly.
 - Save configurations for reproducibility.
-- Export results for offline analysis.
+- Include benchmark bars in the loaded dataset to unlock real beta/alpha/information-ratio analytics.
+- Export results or tearsheets for offline analysis.
 - Use the *Compare Runs* tab to evaluate strategies against each other.

--- a/ui/backtest_core.py
+++ b/ui/backtest_core.py
@@ -7,38 +7,72 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from datetime import datetime
 from typing import Any, Iterable
+import math
 import time
 
 import numpy as np
 import pandas as pd
 
 
+TRADING_DAYS_PER_YEAR = 252
+RISK_FREE_RATE = 0.02
+
+
 class SimplePortfolio:
     """Simple long-only portfolio implementation for UI backtests."""
 
-    def __init__(self, initial_cash: float = 100000):
+    def __init__(
+        self,
+        initial_cash: float = 100000,
+        commission_rate: float = 0.0,
+        slippage_bps: float = 0.0,
+    ):
         self.initial_cash = initial_cash
         self.cash = initial_cash
         self.positions: dict[str, float] = {}
         self.trades: list[dict[str, Any]] = []
         self.equity_curve: list[dict[str, Any]] = []
         self.last_prices: dict[str, float] = {}
+        self.total_commissions = 0.0
+        self.total_slippage_cost = 0.0
+        self.commission_rate = max(float(commission_rate or 0.0), 0.0)
+        self.slippage_bps = max(float(slippage_bps or 0.0), 0.0)
+
+    def _slippage_multiplier(self) -> float:
+        return self.slippage_bps / 10000.0
 
     def buy(self, symbol, shares, price, timestamp=None):
         """Buy shares."""
-        cost = shares * price
-        if cost <= self.cash:
-            self.cash -= cost
+        if shares <= 0 or price <= 0:
+            return False
+
+        gross_notional = shares * price
+        fill_price = price * (1 + self._slippage_multiplier())
+        executed_notional = shares * fill_price
+        slippage_cost = max(executed_notional - gross_notional, 0.0)
+        commission = executed_notional * self.commission_rate
+        total_cost = executed_notional + commission
+
+        if total_cost <= self.cash:
+            self.cash -= total_cost
             self.positions[symbol] = self.positions.get(symbol, 0) + shares
             self.last_prices[symbol] = price
+            self.total_commissions += commission
+            self.total_slippage_cost += slippage_cost
             self.trades.append(
                 {
                     "timestamp": timestamp or datetime.now(),
                     "symbol": symbol,
                     "action": "BUY",
                     "shares": shares,
-                    "price": price,
-                    "cost": cost,
+                    "price": fill_price,
+                    "market_price": price,
+                    "cost": total_cost,
+                    "gross_notional": gross_notional,
+                    "executed_notional": executed_notional,
+                    "commission": commission,
+                    "slippage_cost": slippage_cost,
+                    "net_cash_flow": -total_cost,
                 }
             )
             return True
@@ -46,11 +80,21 @@ class SimplePortfolio:
 
     def sell(self, symbol, shares, price, timestamp=None):
         """Sell shares."""
+        if shares <= 0 or price <= 0:
+            return False
+
         if self.positions.get(symbol, 0) >= shares:
-            proceeds = shares * price
+            gross_notional = shares * price
+            fill_price = price * (1 - self._slippage_multiplier())
+            executed_notional = shares * fill_price
+            slippage_cost = max(gross_notional - executed_notional, 0.0)
+            commission = executed_notional * self.commission_rate
+            proceeds = executed_notional - commission
             self.cash += proceeds
             self.positions[symbol] -= shares
             self.last_prices[symbol] = price
+            self.total_commissions += commission
+            self.total_slippage_cost += slippage_cost
             if self.positions[symbol] == 0:
                 del self.positions[symbol]
             self.trades.append(
@@ -59,8 +103,14 @@ class SimplePortfolio:
                     "symbol": symbol,
                     "action": "SELL",
                     "shares": shares,
-                    "price": price,
+                    "price": fill_price,
+                    "market_price": price,
                     "proceeds": proceeds,
+                    "gross_notional": gross_notional,
+                    "executed_notional": executed_notional,
+                    "commission": commission,
+                    "slippage_cost": slippage_cost,
+                    "net_cash_flow": proceeds,
                 }
             )
             return True
@@ -130,6 +180,7 @@ def prepare_equity_curve_frame(equity_curve: Iterable[dict[str, Any]] | pd.DataF
     frame = equity_curve.copy() if isinstance(equity_curve, pd.DataFrame) else pd.DataFrame(list(equity_curve))
     if not frame.empty and "timestamp" in frame.columns:
         frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+        frame = frame.sort_values("timestamp").reset_index(drop=True)
     return frame
 
 
@@ -146,7 +197,7 @@ def calculate_period_return_series(equity_curve: Iterable[dict[str, Any]] | pd.D
     return returns
 
 
-def calculate_sharpe_ratio(equity_curve: Iterable[dict[str, Any]] | pd.DataFrame, periods_per_year: int = 252) -> float:
+def calculate_sharpe_ratio(equity_curve: Iterable[dict[str, Any]] | pd.DataFrame, periods_per_year: int = TRADING_DAYS_PER_YEAR) -> float:
     """Calculate Sharpe ratio from true per-period returns."""
     period_returns = calculate_period_return_series(equity_curve).dropna()
     if period_returns.empty:
@@ -174,7 +225,7 @@ def calculate_max_drawdown(equity_curve: Iterable[dict[str, Any]] | pd.DataFrame
 
 def calculate_annualized_return_pct(
     equity_curve: Iterable[dict[str, Any]] | pd.DataFrame,
-    periods_per_year: int = 252,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
 ) -> float:
     """Calculate annualized return percentage from the equity curve."""
     frame = prepare_equity_curve_frame(equity_curve)
@@ -211,12 +262,15 @@ def calculate_closed_trade_win_rate(trades: list[dict[str, Any]]) -> float | Non
         shares = float(trade.get("shares", 0) or 0)
         price = float(trade.get("price", 0) or 0)
         action = trade.get("action")
+        commission = float(trade.get("commission", 0) or 0)
+        slippage_cost = float(trade.get("slippage_cost", 0) or 0)
 
         if not symbol or shares <= 0:
             continue
 
         if action == "BUY":
-            open_lots[symbol].append({"shares": shares, "price": price})
+            cost_per_share = (shares * price + commission + slippage_cost) / shares
+            open_lots[symbol].append({"shares": shares, "price": cost_per_share})
             continue
 
         if action != "SELL":
@@ -225,11 +279,12 @@ def calculate_closed_trade_win_rate(trades: list[dict[str, Any]]) -> float | Non
         remaining = shares
         realized_pnl = 0.0
         closed_any_quantity = False
+        net_proceeds_per_share = max(shares * price - commission - slippage_cost, 0.0) / shares
 
         while remaining > 0 and open_lots[symbol]:
             lot = open_lots[symbol][0]
             matched_shares = min(remaining, lot["shares"])
-            realized_pnl += matched_shares * (price - lot["price"])
+            realized_pnl += matched_shares * (net_proceeds_per_share - lot["price"])
             lot["shares"] -= matched_shares
             remaining -= matched_shares
             closed_any_quantity = True
@@ -245,6 +300,263 @@ def calculate_closed_trade_win_rate(trades: list[dict[str, Any]]) -> float | Non
 
     wins = sum(1 for pnl in closed_trade_pnls if pnl > 0)
     return wins / len(closed_trade_pnls) * 100.0
+
+
+def build_buy_and_hold_benchmark_curve(
+    market_data: pd.DataFrame,
+    benchmark_symbol: str | None,
+    initial_capital: float,
+) -> list[dict[str, Any]] | None:
+    """Build an actual benchmark curve from benchmark price bars."""
+    if not benchmark_symbol or market_data.empty:
+        return None
+
+    if "symbol" not in market_data.columns or "close" not in market_data.columns or "timestamp" not in market_data.columns:
+        return None
+
+    benchmark_rows = market_data.loc[market_data["symbol"] == benchmark_symbol, ["timestamp", "close"]].copy()
+    if benchmark_rows.empty:
+        return None
+
+    benchmark_rows["timestamp"] = pd.to_datetime(benchmark_rows["timestamp"])
+    benchmark_rows["close"] = pd.to_numeric(benchmark_rows["close"], errors="coerce")
+    benchmark_rows = benchmark_rows.dropna(subset=["close"]).sort_values("timestamp")
+    benchmark_rows = benchmark_rows.drop_duplicates(subset=["timestamp"], keep="last")
+    if benchmark_rows.empty:
+        return None
+
+    starting_price = float(benchmark_rows["close"].iloc[0])
+    if starting_price <= 0:
+        return None
+
+    shares = initial_capital / starting_price
+    curve: list[dict[str, Any]] = []
+    previous_value = initial_capital
+
+    for row in benchmark_rows.itertuples(index=False):
+        value = shares * float(row.close)
+        period_return = 0.0 if previous_value == 0 else (value - previous_value) / previous_value
+        curve.append(
+            {
+                "timestamp": row.timestamp,
+                "symbol": benchmark_symbol,
+                "value": value,
+                "price": float(row.close),
+                "period_return": period_return,
+                "returns": (value - initial_capital) / initial_capital * 100,
+            }
+        )
+        previous_value = value
+
+    return curve
+
+
+def calculate_benchmark_metrics(
+    equity_curve: Iterable[dict[str, Any]] | pd.DataFrame,
+    benchmark_curve: Iterable[dict[str, Any]] | pd.DataFrame,
+    periods_per_year: int = TRADING_DAYS_PER_YEAR,
+    risk_free_rate: float = RISK_FREE_RATE,
+) -> dict[str, Any]:
+    """Calculate benchmark-relative metrics from actual strategy and benchmark curves."""
+    strategy_frame = prepare_equity_curve_frame(equity_curve)
+    benchmark_frame = prepare_equity_curve_frame(benchmark_curve)
+    if len(strategy_frame) < 2 or len(benchmark_frame) < 2:
+        return {}
+
+    strategy_series = strategy_frame[["timestamp", "value"]].rename(columns={"value": "strategy_value"})
+    benchmark_series = benchmark_frame[["timestamp", "value"]].rename(columns={"value": "benchmark_value"})
+    aligned = strategy_series.merge(benchmark_series, on="timestamp", how="inner")
+    if len(aligned) < 2:
+        return {}
+
+    aligned["strategy_return"] = aligned["strategy_value"].pct_change(fill_method=None)
+    aligned["benchmark_return"] = aligned["benchmark_value"].pct_change(fill_method=None)
+    aligned = aligned.dropna(subset=["strategy_return", "benchmark_return"]).reset_index(drop=True)
+    if aligned.empty:
+        return {}
+
+    rf_daily = risk_free_rate / periods_per_year
+    strategy_returns = aligned["strategy_return"]
+    benchmark_returns = aligned["benchmark_return"]
+    active_returns = strategy_returns - benchmark_returns
+
+    benchmark_var = benchmark_returns.var(ddof=1)
+    beta = None
+    alpha = None
+    if not pd.isna(benchmark_var) and benchmark_var > 0:
+        beta = float(strategy_returns.cov(benchmark_returns) / benchmark_var)
+        alpha_daily = (strategy_returns.mean() - rf_daily) - beta * (benchmark_returns.mean() - rf_daily)
+        alpha = float(alpha_daily * periods_per_year * 100)
+
+    active_std = active_returns.std(ddof=1)
+    information_ratio = None
+    tracking_error = None
+    if not pd.isna(active_std) and active_std > 0:
+        information_ratio = float(active_returns.mean() / active_std * np.sqrt(periods_per_year))
+        tracking_error = float(active_std * np.sqrt(periods_per_year) * 100)
+
+    strategy_annualized = calculate_annualized_return_pct(aligned.rename(columns={"strategy_value": "value"})[["timestamp", "value"]])
+    benchmark_annualized = calculate_annualized_return_pct(aligned.rename(columns={"benchmark_value": "value"})[["timestamp", "value"]])
+    strategy_total_return = (aligned["strategy_value"].iloc[-1] / aligned["strategy_value"].iloc[0] - 1) * 100
+    benchmark_total_return = (aligned["benchmark_value"].iloc[-1] / aligned["benchmark_value"].iloc[0] - 1) * 100
+
+    benchmark_symbol = None
+    if "symbol" in benchmark_frame.columns and benchmark_frame["symbol"].notna().any():
+        benchmark_symbol = str(benchmark_frame["symbol"].dropna().iloc[0])
+
+    return {
+        "benchmark_symbol": benchmark_symbol,
+        "beta": beta,
+        "alpha": alpha,
+        "information_ratio": information_ratio,
+        "tracking_error": tracking_error,
+        "excess_return": float(strategy_annualized - benchmark_annualized),
+        "benchmark_total_return": float(benchmark_total_return),
+        "benchmark_annualized_return": float(benchmark_annualized),
+        "strategy_total_return": float(strategy_total_return),
+        "strategy_annualized_return": float(strategy_annualized),
+        "observations": int(len(aligned)),
+    }
+
+
+def calculate_trading_cost_summary(
+    trades: list[dict[str, Any]],
+    initial_capital: float,
+    final_value: float | None = None,
+) -> dict[str, float]:
+    """Summarize actual commissions, slippage drag, and turnover from trades."""
+    total_commissions = float(sum(float(t.get("commission", 0) or 0) for t in trades))
+    total_slippage_cost = float(sum(float(t.get("slippage_cost", 0) or 0) for t in trades))
+    total_notional = float(sum(float(t.get("gross_notional", 0) or 0) for t in trades))
+    total_cost = total_commissions + total_slippage_cost
+    return {
+        "total_commissions": total_commissions,
+        "total_slippage_cost": total_slippage_cost,
+        "total_cost_drag": total_cost,
+        "cost_drag_pct_initial": (total_cost / initial_capital * 100) if initial_capital else 0.0,
+        "turnover_multiple": (total_notional / initial_capital) if initial_capital else 0.0,
+        "total_notional": total_notional,
+        "ending_equity": float(final_value or 0.0),
+    }
+
+
+def calculate_symbol_attribution(
+    trades: list[dict[str, Any]],
+    final_positions: dict[str, float],
+    latest_prices: dict[str, float],
+    initial_capital: float,
+) -> list[dict[str, Any]]:
+    """Build real per-symbol attribution from trades and marked positions."""
+    open_lots: dict[str, deque[dict[str, float]]] = defaultdict(deque)
+    buckets: dict[str, dict[str, float]] = defaultdict(
+        lambda: {
+            "realized_pnl": 0.0,
+            "unrealized_pnl": 0.0,
+            "commissions": 0.0,
+            "slippage_cost": 0.0,
+            "gross_notional": 0.0,
+        }
+    )
+
+    for trade in trades:
+        symbol = trade.get("symbol")
+        shares = float(trade.get("shares", 0) or 0)
+        price = float(trade.get("price", 0) or 0)
+        commission = float(trade.get("commission", 0) or 0)
+        slippage_cost = float(trade.get("slippage_cost", 0) or 0)
+        gross_notional = float(trade.get("gross_notional", shares * price) or 0)
+        action = trade.get("action")
+        if not symbol or shares <= 0 or price <= 0:
+            continue
+
+        bucket = buckets[symbol]
+        bucket["commissions"] += commission
+        bucket["slippage_cost"] += slippage_cost
+        bucket["gross_notional"] += gross_notional
+
+        if action == "BUY":
+            total_cost = float(trade.get("cost", shares * price + commission + slippage_cost) or 0)
+            open_lots[symbol].append(
+                {
+                    "shares": shares,
+                    "cost_per_share": total_cost / shares,
+                }
+            )
+            continue
+
+        if action != "SELL":
+            continue
+
+        proceeds = float(trade.get("proceeds", shares * price - commission - slippage_cost) or 0)
+        proceeds_per_share = proceeds / shares
+        remaining = shares
+
+        while remaining > 0 and open_lots[symbol]:
+            lot = open_lots[symbol][0]
+            matched_shares = min(remaining, lot["shares"])
+            bucket["realized_pnl"] += matched_shares * (proceeds_per_share - lot["cost_per_share"])
+            lot["shares"] -= matched_shares
+            remaining -= matched_shares
+            if lot["shares"] <= 0:
+                open_lots[symbol].popleft()
+
+    for symbol, lots in open_lots.items():
+        current_price = float(latest_prices.get(symbol, 0) or 0)
+        for lot in lots:
+            if current_price <= 0:
+                continue
+            buckets[symbol]["unrealized_pnl"] += lot["shares"] * (current_price - lot["cost_per_share"])
+
+    attribution: list[dict[str, Any]] = []
+    symbols = set(buckets.keys()) | set(final_positions.keys())
+    for symbol in symbols:
+        bucket = buckets[symbol]
+        ending_shares = float(final_positions.get(symbol, 0) or 0)
+        ending_price = float(latest_prices.get(symbol, 0) or 0)
+        total_pnl = bucket["realized_pnl"] + bucket["unrealized_pnl"]
+        attribution.append(
+            {
+                "component": symbol,
+                "realized_pnl": bucket["realized_pnl"],
+                "unrealized_pnl": bucket["unrealized_pnl"],
+                "total_pnl": total_pnl,
+                "contribution_pct": (total_pnl / initial_capital * 100) if initial_capital else 0.0,
+                "commissions": bucket["commissions"],
+                "slippage_cost": bucket["slippage_cost"],
+                "gross_notional": bucket["gross_notional"],
+                "ending_shares": ending_shares,
+                "ending_market_value": ending_shares * ending_price,
+            }
+        )
+
+    attribution.sort(key=lambda row: abs(row["contribution_pct"]), reverse=True)
+    return attribution
+
+
+def build_tearsheet(results: dict[str, Any]) -> dict[str, Any]:
+    """Assemble a reusable institutional-style tearsheet payload."""
+    benchmark_metrics = results.get("benchmark_metrics") or {}
+    cost_summary = results.get("cost_summary") or {}
+    attribution = results.get("attribution") or []
+    top_contributors = sorted(attribution, key=lambda row: row.get("contribution_pct", 0), reverse=True)[:5]
+    biggest_detractors = sorted(attribution, key=lambda row: row.get("contribution_pct", 0))[:5]
+
+    return {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "overview": {
+            "initial_capital": results.get("initial_capital"),
+            "final_value": results.get("final_value"),
+            "total_return": results.get("total_return"),
+            "annualized_return": results.get("annualized_return"),
+            "sharpe_ratio": results.get("sharpe_ratio"),
+            "max_drawdown": results.get("max_drawdown"),
+            "total_trades": results.get("total_trades"),
+        },
+        "benchmark": benchmark_metrics,
+        "costs": cost_summary,
+        "top_contributors": top_contributors,
+        "biggest_detractors": biggest_detractors,
+    }
 
 
 def _queue_put(queue_obj, value):
@@ -267,10 +579,17 @@ def run_backtest(strategy_code, market_data, config, progress_queue, log_queue):
 
         strategy_class = strategy_classes[0]
         strategy = strategy_class()
-        portfolio = SimplePortfolio(config.get("initial_capital", 100000))
+        commission_rate = float(config.get("commission", 0.0) or 0.0)
+        slippage_bps = float(config.get("slippage_bps", config.get("slippage", 0.0)) or 0.0)
+        portfolio = SimplePortfolio(
+            config.get("initial_capital", 100000),
+            commission_rate=commission_rate,
+            slippage_bps=slippage_bps,
+        )
 
         _queue_put(log_queue, f"Started backtest: {getattr(strategy, 'name', 'Unknown Strategy')}")
         _queue_put(log_queue, f"Initial capital: ${portfolio.initial_cash:,.2f}")
+        _queue_put(log_queue, f"Execution costs: commission={commission_rate:.4f}, slippage={slippage_bps:.2f} bps")
 
         total_bars = len(market_data)
         equity_curve = []
@@ -310,6 +629,14 @@ def run_backtest(strategy_code, market_data, config, progress_queue, log_queue):
                 else (portfolio_value - portfolio.initial_cash) / portfolio.initial_cash * 100
             )
 
+            exposures = {}
+            if portfolio_value > 0:
+                exposures = {
+                    symbol: (shares * latest_prices.get(symbol, 0)) / portfolio_value
+                    for symbol, shares in portfolio.positions.items()
+                    if latest_prices.get(symbol, 0) is not None
+                }
+
             equity_curve.append(
                 {
                     "timestamp": row["timestamp"],
@@ -319,6 +646,7 @@ def run_backtest(strategy_code, market_data, config, progress_queue, log_queue):
                     "position_value": position_value,
                     "returns": cumulative_return_pct,
                     "period_return": period_return,
+                    "exposures": exposures,
                 }
             )
             previous_value = portfolio_value
@@ -331,22 +659,62 @@ def run_backtest(strategy_code, market_data, config, progress_queue, log_queue):
 
         final_value = equity_curve[-1]["value"]
         total_return = (final_value - portfolio.initial_cash) / portfolio.initial_cash * 100
+        annualized_return = calculate_annualized_return_pct(equity_curve)
         sharpe_ratio = calculate_sharpe_ratio(equity_curve)
         max_drawdown = calculate_max_drawdown(equity_curve) * 100
+        win_rate = calculate_closed_trade_win_rate(portfolio.trades)
 
-        return {
+        benchmark_symbol = config.get("benchmark_symbol")
+        benchmark_curve = build_buy_and_hold_benchmark_curve(market_data, benchmark_symbol, portfolio.initial_cash)
+        benchmark_metrics = calculate_benchmark_metrics(equity_curve, benchmark_curve) if benchmark_curve else {}
+        if benchmark_symbol and not benchmark_curve:
+            _queue_put(log_queue, f"Benchmark symbol {benchmark_symbol} was not present in the loaded market data; benchmark metrics were skipped.")
+
+        cost_summary = calculate_trading_cost_summary(portfolio.trades, portfolio.initial_cash, final_value)
+        attribution = calculate_symbol_attribution(
+            portfolio.trades,
+            portfolio.positions,
+            latest_prices,
+            portfolio.initial_cash,
+        )
+
+        results = {
             "equity_curve": equity_curve,
+            "benchmark_curve": benchmark_curve or [],
             "trades": portfolio.trades,
             "initial_capital": portfolio.initial_cash,
             "final_value": final_value,
             "total_return": total_return,
+            "annualized_return": annualized_return,
             "sharpe_ratio": sharpe_ratio,
             "max_drawdown": max_drawdown,
             "total_trades": len(portfolio.trades),
             "final_cash": portfolio.cash,
             "final_positions": portfolio.positions,
             "logs": all_logs,
+            "benchmark_symbol": benchmark_symbol,
+            "benchmark_metrics": benchmark_metrics,
+            "cost_summary": cost_summary,
+            "attribution": attribution,
+            "total_commissions": cost_summary["total_commissions"],
+            "total_slippage_cost": cost_summary["total_slippage_cost"],
+            "win_rate": win_rate,
         }
+        results["metrics_summary"] = {
+            "initial_capital": portfolio.initial_cash,
+            "final_value": final_value,
+            "total_return": total_return,
+            "annualized_return": annualized_return,
+            "sharpe_ratio": sharpe_ratio,
+            "max_drawdown": max_drawdown,
+            "total_trades": len(portfolio.trades),
+            "win_rate": 0.0 if win_rate is None else win_rate,
+            "total_commissions": cost_summary["total_commissions"],
+            "total_slippage_cost": cost_summary["total_slippage_cost"],
+            **benchmark_metrics,
+        }
+        results["tearsheet"] = build_tearsheet(results)
+        return results
     except Exception as exc:
         _queue_put(log_queue, f"FATAL ERROR: {str(exc)}")
         return None

--- a/ui/pages/advanced_analytics.py
+++ b/ui/pages/advanced_analytics.py
@@ -32,6 +32,18 @@ def _equity_df(results: dict) -> Optional[pd.DataFrame]:
     return df
 
 
+def _benchmark_df(results: dict) -> Optional[pd.DataFrame]:
+    raw = results.get("benchmark_curve", [])
+    if not raw:
+        return None
+    df = pd.DataFrame(raw)
+    if "timestamp" not in df.columns or "value" not in df.columns:
+        return None
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df = df.sort_values("timestamp").set_index("timestamp")
+    return df
+
+
 def _daily_returns(eq: pd.DataFrame) -> pd.Series:
     """Compute daily simple returns from an equity DataFrame."""
     return eq["value"].pct_change().dropna()
@@ -73,7 +85,7 @@ def show():
         _show_heatmaps(eq, results)
 
     with tab_rolling:
-        _show_rolling_statistics(eq)
+        _show_rolling_statistics(eq, results)
 
     with tab_compare:
         _show_compare_runs()
@@ -261,7 +273,7 @@ def _drawdown_heatmap(eq: pd.DataFrame):
 # Rolling Statistics
 # ---------------------------------------------------------------------------
 
-def _show_rolling_statistics(eq: pd.DataFrame):
+def _show_rolling_statistics(eq: pd.DataFrame, results: dict):
     st.subheader("📈 Rolling Statistics")
 
     rets = _daily_returns(eq)
@@ -269,8 +281,16 @@ def _show_rolling_statistics(eq: pd.DataFrame):
         st.info("Need ≥ 30 trading days for rolling statistics.")
         return
 
+    benchmark_eq = _benchmark_df(results)
+    benchmark_name = (results.get("benchmark_metrics") or {}).get("benchmark_symbol") or results.get("benchmark_symbol")
+
     # Configurable window
-    col_cfg1, col_cfg2 = st.columns(2)
+    if benchmark_eq is not None:
+        col_cfg1, col_cfg2 = st.columns(2)
+    else:
+        col_cfg1 = st.container()
+        col_cfg2 = None
+
     with col_cfg1:
         window = st.selectbox(
             "Rolling window (days)",
@@ -278,13 +298,11 @@ def _show_rolling_statistics(eq: pd.DataFrame):
             index=0,
             help="Number of trading days for the rolling window.",
         )
-    with col_cfg2:
-        benchmark_ret_annual = st.number_input(
-            "Benchmark annual return (%) for beta",
-            value=10.0,
-            step=1.0,
-            help="Used to generate a synthetic benchmark for beta calculation.",
-        )
+    if col_cfg2 is not None:
+        with col_cfg2:
+            st.caption(f"Using actual benchmark series: {benchmark_name}")
+    else:
+        st.caption("Load benchmark bars into the run to unlock actual rolling beta and benchmark-relative analytics.")
 
     # --- Rolling Sharpe ---
     rolling_mean = rets.rolling(window).mean()
@@ -295,21 +313,19 @@ def _show_rolling_statistics(eq: pd.DataFrame):
     rolling_vol = rolling_std * np.sqrt(252) * 100
 
     # Percentile bands for volatility
-    vol_median = rolling_vol.median()
     vol_p25 = rolling_vol.quantile(0.25)
     vol_p75 = rolling_vol.quantile(0.75)
 
-    # --- Rolling Beta (vs synthetic benchmark) ---
-    np.random.seed(42)
-    bench_daily = benchmark_ret_annual / 100 / 252
-    bench_vol = rolling_vol.median() / 100 / np.sqrt(252) if vol_median > 0 else 0.01
-    bench_returns = pd.Series(
-        np.random.normal(bench_daily, bench_vol, size=len(rets)),
-        index=rets.index,
-    )
-    rolling_cov = rets.rolling(window).cov(bench_returns)
-    rolling_bench_var = bench_returns.rolling(window).var()
-    rolling_beta = rolling_cov / rolling_bench_var
+    # --- Rolling Beta (vs actual benchmark when available) ---
+    rolling_beta = pd.Series(index=rets.index, dtype=float)
+    if benchmark_eq is not None:
+        bench_rets = _daily_returns(benchmark_eq)
+        aligned = pd.concat([rets.rename("strategy"), bench_rets.rename("benchmark")], axis=1, join="inner").dropna()
+        if not aligned.empty:
+            rolling_cov = aligned["strategy"].rolling(window).cov(aligned["benchmark"])
+            rolling_bench_var = aligned["benchmark"].rolling(window).var()
+            rolling_beta = (rolling_cov / rolling_bench_var).replace([np.inf, -np.inf], np.nan)
+            rolling_beta = rolling_beta.reindex(rets.index)
 
     # --- Rolling Max Drawdown ---
     rolling_max_dd = pd.Series(index=eq.index, dtype=float)
@@ -417,7 +433,7 @@ def _show_rolling_statistics(eq: pd.DataFrame):
             f"{rolling_sharpe.iloc[-1]:.2f}" if not np.isnan(rolling_sharpe.iloc[-1]) else "N/A",
             f"{rolling_vol.mean():.1f}%",
             f"{rolling_vol.iloc[-1]:.1f}%" if not np.isnan(rolling_vol.iloc[-1]) else "N/A",
-            f"{rolling_beta.mean():.2f}",
+            "N/A" if rolling_beta.dropna().empty else f"{rolling_beta.dropna().mean():.2f}",
             f"{rolling_max_dd.min():.1f}%",
         ],
     }
@@ -654,6 +670,68 @@ def _show_export(eq: pd.DataFrame, results: dict):
             file_name="glowback_summary.json",
             mime="application/json",
         )
+
+        tearsheet = results.get("tearsheet") or {}
+        if tearsheet:
+            st.download_button(
+                "⬇️ Download Institutional Tearsheet (JSON)",
+                data=json.dumps(tearsheet, indent=2, default=str),
+                file_name="glowback_tearsheet.json",
+                mime="application/json",
+            )
+
+            benchmark_metrics = results.get("benchmark_metrics") or {}
+            cost_summary = results.get("cost_summary") or {}
+            attribution = results.get("attribution") or []
+            beta = benchmark_metrics.get("beta")
+            alpha = benchmark_metrics.get("alpha")
+            tracking_error = benchmark_metrics.get("tracking_error")
+            information_ratio = benchmark_metrics.get("information_ratio")
+            lines = [
+                "# GlowBack Institutional Tearsheet",
+                "",
+                f"Generated: {datetime.utcnow().isoformat()}Z",
+                "",
+                "## Overview",
+                f"- Final value: ${results.get('final_value', 0.0):,.2f}",
+                f"- Total return: {results.get('total_return', 0.0):.2f}%",
+                f"- Annualized return: {results.get('annualized_return', 0.0):.2f}%",
+                f"- Sharpe ratio: {results.get('sharpe_ratio', 0.0):.2f}",
+                f"- Max drawdown: {results.get('max_drawdown', 0.0):.2f}%",
+                "",
+                "## Benchmark",
+                f"- Benchmark: {benchmark_metrics.get('benchmark_symbol') or results.get('benchmark_symbol') or 'N/A'}",
+                f"- Beta: {'N/A' if beta is None else format(beta, '.2f')}",
+                f"- Alpha: {'N/A' if alpha is None else format(alpha, '.2f') + '%'}",
+                f"- Tracking error: {'N/A' if tracking_error is None else format(tracking_error, '.2f') + '%'}",
+                f"- Information ratio: {'N/A' if information_ratio is None else format(information_ratio, '.2f')}",
+                f"- Excess return: {benchmark_metrics.get('excess_return', 0.0):.2f}%",
+                "",
+                "## Cost Drag",
+                f"- Total commissions: ${cost_summary.get('total_commissions', 0.0):,.2f}",
+                f"- Total slippage drag: ${cost_summary.get('total_slippage_cost', 0.0):,.2f}",
+                f"- Cost drag vs initial capital: {cost_summary.get('cost_drag_pct_initial', 0.0):.2f}%",
+                f"- Turnover: {cost_summary.get('turnover_multiple', 0.0):.2f}x initial capital",
+                "",
+                "## Attribution",
+            ]
+            if attribution:
+                lines.extend(
+                    [
+                        f"- {row.get('component')}: {row.get('contribution_pct', 0.0):.2f}% contribution "
+                        f"(${row.get('total_pnl', 0.0):,.2f} total P&L)"
+                        for row in attribution
+                    ]
+                )
+            else:
+                lines.append("- No realized attribution available.")
+
+            st.download_button(
+                "⬇️ Download Institutional Tearsheet (Markdown)",
+                data="\n".join(lines),
+                file_name="glowback_tearsheet.md",
+                mime="text/markdown",
+            )
 
     st.markdown("---")
     st.markdown("**🖨️ PDF Report**")

--- a/ui/pages/backtest_runner.py
+++ b/ui/pages/backtest_runner.py
@@ -55,14 +55,19 @@ def show():
             
             col1, col2 = st.columns(2)
             with col1:
-                start_date = st.date_input("Start Date", value=None)
-                commission_override = st.number_input("Commission Override", value=0.001, format="%.4f")
+                st.date_input("Start Date", value=None, key="backtest_start_date")
+                st.number_input("Commission Override", value=0.001, format="%.4f", key="backtest_commission_override")
             
             with col2:
-                end_date = st.date_input("End Date", value=None)
-                slippage_override = st.number_input("Slippage Override (bps)", value=5)
+                st.date_input("End Date", value=None, key="backtest_end_date")
+                st.number_input("Slippage Override (bps)", value=5, key="backtest_slippage_override")
             
-            benchmark_symbol = st.text_input("Benchmark Symbol", value="SPY", help="Symbol to compare against")
+            st.text_input(
+                "Benchmark Symbol",
+                value="SPY",
+                help="Use a symbol present in the loaded market data to compute actual benchmark-relative metrics.",
+                key="backtest_benchmark_symbol",
+            )
             
             submitted = st.form_submit_button("🚀 Run Backtest", type="primary")
     
@@ -116,8 +121,24 @@ def run_backtest_execution():
         
         # Prepare data and run backtest
         market_data = st.session_state.market_data.copy()
+        if st.session_state.get("backtest_start_date") is not None:
+            market_data = market_data[market_data["timestamp"] >= pd.Timestamp(st.session_state.backtest_start_date)]
+        if st.session_state.get("backtest_end_date") is not None:
+            market_data = market_data[market_data["timestamp"] <= pd.Timestamp(st.session_state.backtest_end_date)]
+        market_data = market_data.sort_values(["timestamp", "symbol"]).reset_index(drop=True)
+
+        if market_data.empty:
+            st.error("❌ No market data left after applying the selected date range.")
+            st.session_state.backtest_running = False
+            return
+
         strategy_code = st.session_state.strategy_code
-        config = st.session_state.strategy_config
+        config = {
+            **st.session_state.strategy_config,
+            "commission": float(st.session_state.get("backtest_commission_override", st.session_state.strategy_config.get("commission", 0.0)) or 0.0),
+            "slippage_bps": float(st.session_state.get("backtest_slippage_override", st.session_state.strategy_config.get("slippage", 0.0)) or 0.0),
+            "benchmark_symbol": (st.session_state.get("backtest_benchmark_symbol") or "").strip().upper() or None,
+        }
         
         # Create queues for communication
         progress_queue = queue.Queue()
@@ -177,7 +198,15 @@ def run_backtest_execution():
             status_text.text("✅ Backtest completed!")
             
             # Show success message
-            st.success(f"🎉 Backtest completed! Final value: ${result['final_value']:,.2f}")
+            benchmark_metrics = result.get("benchmark_metrics") or {}
+            if benchmark_metrics:
+                st.success(
+                    f"🎉 Backtest completed! Final value: ${result['final_value']:,.2f} · "
+                    f"Excess return vs {benchmark_metrics.get('benchmark_symbol') or result.get('benchmark_symbol')}: "
+                    f"{benchmark_metrics.get('excess_return', 0.0):.2f}%"
+                )
+            else:
+                st.success(f"🎉 Backtest completed! Final value: ${result['final_value']:,.2f}")
             
         else:
             st.error("❌ Backtest failed. Check the logs for details.")
@@ -207,8 +236,11 @@ def show_quick_results():
     
     st.subheader("📊 Quick Results")
     
+    benchmark_metrics = results.get('benchmark_metrics') or {}
+    cost_summary = results.get('cost_summary') or {}
+
     # Key metrics
-    col1, col2, col3, col4 = st.columns(4)
+    col1, col2, col3, col4, col5 = st.columns(5)
     
     with col1:
         st.metric("Total Return", f"{results['total_return']:.2f}%")
@@ -221,6 +253,13 @@ def show_quick_results():
     
     with col4:
         st.metric("Total Trades", results['total_trades'])
+
+    with col5:
+        information_ratio = benchmark_metrics.get('information_ratio')
+        if benchmark_metrics and information_ratio is not None:
+            st.metric("Information Ratio", f"{information_ratio:.2f}")
+        else:
+            st.metric("Cost Drag", f"{cost_summary.get('cost_drag_pct_initial', 0.0):.2f}%")
     
     # Final portfolio
     col1, col2 = st.columns(2)
@@ -231,6 +270,14 @@ def show_quick_results():
         if results['final_positions']:
             for symbol, shares in results['final_positions'].items():
                 st.write(f"{symbol}: {shares} shares")
+
+        if benchmark_metrics:
+            st.write("**Benchmark Snapshot:**")
+            benchmark_name = benchmark_metrics.get('benchmark_symbol') or results.get('benchmark_symbol')
+            st.write(f"Benchmark: {benchmark_name}")
+            st.write(f"Beta: {benchmark_metrics.get('beta', 0.0):.2f}" if benchmark_metrics.get('beta') is not None else "Beta: N/A")
+            st.write(f"Alpha: {benchmark_metrics.get('alpha', 0.0):.2f}%" if benchmark_metrics.get('alpha') is not None else "Alpha: N/A")
+            st.write(f"Excess Return: {benchmark_metrics.get('excess_return', 0.0):.2f}%")
     
     with col2:
         st.write("**Trade Summary:**")
@@ -240,6 +287,9 @@ def show_quick_results():
             sell_trades = len(trades_df[trades_df['action'] == 'SELL'])
             st.write(f"Buy orders: {buy_trades}")
             st.write(f"Sell orders: {sell_trades}")
+            st.write(f"Commissions: ${cost_summary.get('total_commissions', 0.0):,.2f}")
+            st.write(f"Slippage drag: ${cost_summary.get('total_slippage_cost', 0.0):,.2f}")
+            st.write(f"Turnover: {cost_summary.get('turnover_multiple', 0.0):.2f}x initial capital")
     
     # Quick actions
     col1, col2, col3 = st.columns(3)

--- a/ui/pages/portfolio_analyzer.py
+++ b/ui/pages/portfolio_analyzer.py
@@ -49,33 +49,50 @@ def show_performance_analysis():
     
     with col1:
         st.markdown("**🎯 Performance Attribution**")
-        
-        # Calculate performance components
-        total_return = results['total_return']
-        
-        # Simplified attribution (in reality, this would be more complex)
-        attribution_data = {
-            "Component": ["Asset Selection", "Market Timing", "Cash Allocation", "Trading Costs"],
-            "Contribution (%)": [
-                total_return * 0.6,  # Simplified
-                total_return * 0.3,
-                total_return * 0.1,
-                -abs(total_return * 0.02)  # Cost drag
-            ]
-        }
-        
+
+        attribution_rows = results.get('attribution') or []
+        cost_summary = results.get('cost_summary') or {}
+        benchmark_metrics = results.get('benchmark_metrics') or {}
+
+        attribution_data = [
+            {
+                "Component": row.get("component", "Unknown"),
+                "Contribution (%)": row.get("contribution_pct", 0.0),
+            }
+            for row in attribution_rows
+        ]
+        if cost_summary:
+            attribution_data.append(
+                {
+                    "Component": "Trading Costs",
+                    "Contribution (%)": -cost_summary.get("cost_drag_pct_initial", 0.0),
+                }
+            )
+
         attr_df = pd.DataFrame(attribution_data)
-        
-        fig = px.bar(
-            attr_df,
-            x="Component",
-            y="Contribution (%)",
-            color="Contribution (%)",
-            color_continuous_scale="RdYlGn",
-            title="Performance Attribution"
-        )
-        
-        st.plotly_chart(fig, use_container_width=True)
+        if not attr_df.empty:
+            fig = px.bar(
+                attr_df,
+                x="Component",
+                y="Contribution (%)",
+                color="Contribution (%)",
+                color_continuous_scale="RdYlGn",
+                title="Performance Attribution",
+            )
+            st.plotly_chart(fig, use_container_width=True)
+        else:
+            st.info("Run a backtest with executed trades to see attribution.")
+
+        if benchmark_metrics:
+            beta = benchmark_metrics.get('beta')
+            alpha = benchmark_metrics.get('alpha')
+            information_ratio = benchmark_metrics.get('information_ratio')
+            st.caption(
+                f"Benchmark: {benchmark_metrics.get('benchmark_symbol') or results.get('benchmark_symbol')} · "
+                f"Beta {'N/A' if beta is None else f'{beta:.2f}'} · "
+                f"Alpha {'N/A' if alpha is None else f'{alpha:.2f}%'} · "
+                f"IR {'N/A' if information_ratio is None else f'{information_ratio:.2f}'}"
+            )
     
     with col2:
         st.markdown("**📅 Period Analysis**")

--- a/ui/pages/results_dashboard.py
+++ b/ui/pages/results_dashboard.py
@@ -60,6 +60,7 @@ def show_performance_overview(results):
     st.subheader("🎯 Performance Overview")
 
     equity_curve = prepare_equity_curve_frame(results['equity_curve'])
+    benchmark_metrics = results.get('benchmark_metrics') or {}
     period_returns = calculate_period_return_series(equity_curve).dropna()
     win_rate = calculate_closed_trade_win_rate(results.get('trades', []))
     annualized_return = calculate_annualized_return_pct(equity_curve)
@@ -140,8 +141,10 @@ def show_performance_overview(results):
                 "Drawdown Duration",
                 "Value at Risk (95%)",
                 "Expected Shortfall",
-                "Beta (vs Market)",
+                "Beta (vs Benchmark)",
                 "Alpha (Annual)",
+                "Tracking Error",
+                "Information Ratio",
             ],
             "Value": [
                 f"{results['sharpe_ratio']:.2f}",
@@ -151,8 +154,10 @@ def show_performance_overview(results):
                 f"{period_returns[period_returns <= period_returns.quantile(0.05)].mean() * 100:.2f}%"
                 if len(period_returns) > 0 and not period_returns[period_returns <= period_returns.quantile(0.05)].empty
                 else "N/A",
-                "N/A",
-                "N/A",
+                "N/A" if benchmark_metrics.get('beta') is None else f"{benchmark_metrics['beta']:.2f}",
+                "N/A" if benchmark_metrics.get('alpha') is None else f"{benchmark_metrics['alpha']:.2f}%",
+                "N/A" if benchmark_metrics.get('tracking_error') is None else f"{benchmark_metrics['tracking_error']:.2f}%",
+                "N/A" if benchmark_metrics.get('information_ratio') is None else f"{benchmark_metrics['information_ratio']:.2f}",
             ],
         }
 
@@ -236,6 +241,22 @@ def show_performance_charts(results):
     fig.update_yaxes(title_text="Drawdown (%)", row=3, col=1)
 
     st.plotly_chart(fig, use_container_width=True)
+
+    benchmark_curve = prepare_equity_curve_frame(results.get('benchmark_curve', []))
+    if not benchmark_curve.empty and {'timestamp', 'value'}.issubset(benchmark_curve.columns):
+        benchmark_chart = benchmark_curve[['timestamp', 'value']].rename(columns={'value': 'benchmark_value'})
+        comparison = equity_curve[['timestamp', 'value']].merge(benchmark_chart, on='timestamp', how='inner')
+        if len(comparison) > 1:
+            comparison['strategy_index'] = comparison['value'] / comparison['value'].iloc[0] * 100
+            comparison['benchmark_index'] = comparison['benchmark_value'] / comparison['benchmark_value'].iloc[0] * 100
+            benchmark_name = (results.get('benchmark_metrics') or {}).get('benchmark_symbol') or results.get('benchmark_symbol') or 'Benchmark'
+
+            st.markdown("**📏 Strategy vs Benchmark**")
+            comp_fig = go.Figure()
+            comp_fig.add_trace(go.Scatter(x=comparison['timestamp'], y=comparison['strategy_index'], mode='lines', name='Strategy'))
+            comp_fig.add_trace(go.Scatter(x=comparison['timestamp'], y=comparison['benchmark_index'], mode='lines', name=benchmark_name))
+            comp_fig.update_layout(height=350, yaxis_title='Indexed Value (Start = 100)')
+            st.plotly_chart(comp_fig, use_container_width=True)
 
     col1, col2 = st.columns(2)
 

--- a/ui/tests/test_backtest_core.py
+++ b/ui/tests/test_backtest_core.py
@@ -113,6 +113,75 @@ class BuyAndHoldTwoSymbols:
             ])
         )
 
+    def test_run_backtest_surfaces_real_benchmark_metrics_and_cost_drag(self):
+        strategy_code = """
+class BuyThenSell:
+    name = "Buy Then Sell"
+
+    def on_bar(self, bar, portfolio):
+        if portfolio.get_position(bar.symbol) == 0:
+            portfolio.buy(bar.symbol, 5, bar.close, bar.timestamp)
+        elif bar.close >= 110:
+            portfolio.sell(bar.symbol, portfolio.get_position(bar.symbol), bar.close, bar.timestamp)
+        return []
+"""
+        market_data = pd.DataFrame(
+            [
+                {
+                    'timestamp': pd.Timestamp('2026-01-01'),
+                    'symbol': 'AAPL',
+                    'open': 100.0,
+                    'high': 100.0,
+                    'low': 100.0,
+                    'close': 100.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+                {
+                    'timestamp': pd.Timestamp('2026-01-02'),
+                    'symbol': 'AAPL',
+                    'open': 110.0,
+                    'high': 110.0,
+                    'low': 110.0,
+                    'close': 110.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+                {
+                    'timestamp': pd.Timestamp('2026-01-03'),
+                    'symbol': 'AAPL',
+                    'open': 108.0,
+                    'high': 108.0,
+                    'low': 108.0,
+                    'close': 108.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+            ]
+        )
+
+        results = run_backtest(
+            strategy_code,
+            market_data,
+            {
+                'initial_capital': 1000.0,
+                'commission': 0.001,
+                'slippage_bps': 5,
+                'benchmark_symbol': 'AAPL',
+            },
+            queue.Queue(),
+            queue.Queue(),
+        )
+
+        self.assertIsNotNone(results)
+        self.assertEqual(results['benchmark_symbol'], 'AAPL')
+        self.assertTrue(results['benchmark_curve'])
+        self.assertIn('beta', results['benchmark_metrics'])
+        self.assertGreater(results['cost_summary']['total_commissions'], 0.0)
+        self.assertGreater(results['cost_summary']['total_slippage_cost'], 0.0)
+        self.assertTrue(results['attribution'])
+        self.assertIn('overview', results['tearsheet'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- wire the Streamlit backtest runner's benchmark input into actual result payloads instead of leaving benchmark analytics disconnected
- replace placeholder/synthetic attribution with real trade-aware cost drag, per-symbol contribution, benchmark-relative metrics, and institutional tearsheet exports in the UI path
- extend the FastAPI mock adapter/result schema to return benchmark curves + tearsheets as well, and cover the new behavior with regression tests/docs

## Testing
- `python3 -m compileall ui api`
- `python3 -m unittest discover -s ui/tests -v`
- `rm -rf .pydeps-test && python3 -m pip install -q --target ./.pydeps-test -r api/requirements.txt httpx && PYTHONPATH="$(pwd)/.pydeps-test:$PWD" python3 -m unittest discover -s api/tests -v && rm -rf .pydeps-test`
- `mkdocs build --strict`

Fixes #92
