### PR TITLE
Fix #90: add target-weight portfolio construction workflow

### DIFF
--- a/api/app/adapter.py
+++ b/api/app/adapter.py
@@ -113,12 +113,127 @@ def _calculate_benchmark_metrics(
     }
 
 
+def _build_sample_portfolio_diagnostics(
+    equity_curve: list[dict],
+    portfolio_config: dict[str, object] | None,
+) -> tuple[list[dict], list[dict], dict[str, float | str | dict[str, float]], list[dict[str, object]]]:
+    if not portfolio_config:
+        return [], [], {}, []
+
+    raw_target_weights = {
+        str(symbol).strip().upper(): float(weight)
+        for symbol, weight in dict(portfolio_config.get("target_weights") or {}).items()
+        if str(symbol).strip() and float(weight) > 0
+    }
+    total_weight = sum(raw_target_weights.values())
+    if total_weight <= 0:
+        return [], [], {}, []
+
+    normalized_weights = {
+        symbol: weight / total_weight for symbol, weight in raw_target_weights.items()
+    }
+    cash_floor_pct = float(portfolio_config.get("cash_floor_pct") or 0.0)
+    investable_weight = max(0.0, 1.0 - cash_floor_pct / 100.0)
+    capped_target_weights = {
+        symbol: weight * investable_weight for symbol, weight in normalized_weights.items()
+    }
+
+    constraint_hits: list[dict[str, object]] = []
+    max_weight_pct = portfolio_config.get("max_weight_pct")
+    if max_weight_pct is not None:
+        max_weight_fraction = float(max_weight_pct) / 100.0
+        for symbol, weight in list(capped_target_weights.items()):
+            if weight > max_weight_fraction:
+                constraint_hits.append(
+                    {
+                        "type": "max_weight_cap",
+                        "symbol": symbol,
+                        "requested_weight_pct": round(weight * 100, 2),
+                        "applied_weight_pct": round(max_weight_fraction * 100, 2),
+                    }
+                )
+                capped_target_weights[symbol] = max_weight_fraction
+
+    schedule = str(portfolio_config.get("rebalance_frequency") or "weekly")
+    cadence = {"daily": 1, "weekly": 5, "monthly": 21}.get(schedule, 5)
+    max_turnover_pct = float(portfolio_config.get("max_turnover_pct") or 0.0)
+    drift_threshold_pct = float(portfolio_config.get("drift_threshold_pct") or 0.0)
+
+    diagnostics: list[dict] = []
+    turnover_samples: list[float] = []
+    symbols = list(capped_target_weights)
+
+    for index, point in enumerate(equity_curve):
+        is_rebalance = index == 0 or index % cadence == 0
+        realized_weights = dict(capped_target_weights)
+        if not is_rebalance:
+            for symbol_index, symbol in enumerate(symbols):
+                drift = min(0.03, 0.004 * ((index % cadence) + 1))
+                signed_drift = drift if symbol_index % 2 == 0 else -drift
+                realized_weights[symbol] = max(capped_target_weights[symbol] + signed_drift, 0.0)
+            total_realized = sum(realized_weights.values())
+            if total_realized > investable_weight and total_realized > 0:
+                scale = investable_weight / total_realized
+                realized_weights = {symbol: weight * scale for symbol, weight in realized_weights.items()}
+
+        drift_map = {
+            symbol: realized_weights.get(symbol, 0.0) - capped_target_weights.get(symbol, 0.0)
+            for symbol in set(capped_target_weights) | set(realized_weights)
+        }
+        max_abs_drift_pct = max((abs(value) * 100 for value in drift_map.values()), default=0.0)
+        turnover_pct = 0.0 if not is_rebalance else (100.0 if index == 0 else min(max_turnover_pct or 12.5, 20.0))
+        turnover_samples.append(turnover_pct)
+
+        if not is_rebalance and drift_threshold_pct and max_abs_drift_pct >= drift_threshold_pct:
+            is_rebalance = True
+            turnover_pct = min(max_turnover_pct or 15.0, 25.0)
+            turnover_samples[-1] = turnover_pct
+            realized_weights = dict(capped_target_weights)
+            drift_map = {symbol: 0.0 for symbol in drift_map}
+            max_abs_drift_pct = 0.0
+
+        cash_weight_pct = max(0.0, 100.0 - sum(realized_weights.values()) * 100)
+        diagnostics.append(
+            {
+                "timestamp": point["timestamp"],
+                "target_weights": {symbol: round(weight * 100, 2) for symbol, weight in capped_target_weights.items()},
+                "realized_weights": {symbol: round(weight * 100, 2) for symbol, weight in realized_weights.items()},
+                "drift_by_symbol_pct": {symbol: round(weight * 100, 2) for symbol, weight in drift_map.items()},
+                "max_abs_drift_pct": round(max_abs_drift_pct, 2),
+                "turnover_pct": round(turnover_pct, 2),
+                "rebalanced": is_rebalance,
+                "rebalance_reason": "initial_allocation" if index == 0 else (f"{schedule}_schedule" if is_rebalance else "drift_monitor"),
+                "cash_weight_pct": round(cash_weight_pct, 2),
+                "portfolio_value": round(float(point["value"]), 2),
+                "constraint_hits": [],
+            }
+        )
+
+    portfolio_summary = {
+        "method": "target_weights",
+        "rebalance_frequency": schedule,
+        "cash_floor_pct": cash_floor_pct,
+        "max_weight_pct": float(max_weight_pct) if max_weight_pct is not None else None,
+        "max_turnover_pct": float(max_turnover_pct) if max_turnover_pct else None,
+        "drift_threshold_pct": float(drift_threshold_pct) if drift_threshold_pct else None,
+        "target_weights": {symbol: round(weight * 100, 2) for symbol, weight in capped_target_weights.items()},
+    }
+    portfolio_metrics = {
+        "portfolio_rebalances": float(sum(1 for row in diagnostics if row["rebalanced"])),
+        "average_turnover_pct": float(sum(turnover_samples) / len(turnover_samples)) if turnover_samples else 0.0,
+        "max_weight_drift_pct": float(max((row["max_abs_drift_pct"] for row in diagnostics), default=0.0)),
+        "constraint_hit_count": float(len(constraint_hits)),
+    }
+    return diagnostics, constraint_hits, portfolio_summary, portfolio_metrics
+
+
 def _build_sample_results(
     initial_capital: float,
     start_date: datetime,
     end_date: datetime,
     benchmark_symbol: str | None,
-) -> tuple[list[dict], list[dict], dict, dict]:
+    portfolio_config: dict[str, object] | None = None,
+) -> tuple[list[dict], list[dict], dict, dict, list[dict], list[dict], dict]:
     equity_curve, daily_returns = _build_sample_curve(
         initial_capital=initial_capital,
         start_date=start_date,
@@ -203,6 +318,11 @@ def _build_sample_results(
         "total_notional": 0.0,
     }
 
+    portfolio_diagnostics, constraint_hits, portfolio_summary, portfolio_metrics = _build_sample_portfolio_diagnostics(
+        equity_curve,
+        portfolio_config,
+    )
+
     metrics_summary = {
         "initial_capital": initial_capital,
         "final_value": equity_curve[-1]["value"],
@@ -226,6 +346,7 @@ def _build_sample_results(
         "largest_win": 0.0,
         "largest_loss": 0.0,
         "total_commissions": 0.0,
+        **portfolio_metrics,
         **benchmark_metrics,
     }
 
@@ -238,12 +359,13 @@ def _build_sample_results(
             "max_drawdown": max_drawdown,
         },
         "benchmark": benchmark_metrics,
+        "portfolio": portfolio_summary,
         "costs": cost_summary,
         "top_contributors": [],
         "biggest_detractors": [],
     }
 
-    return equity_curve, benchmark_curve, metrics_summary, tearsheet
+    return equity_curve, benchmark_curve, metrics_summary, tearsheet, portfolio_diagnostics, constraint_hits, portfolio_summary
 
 
 class MockEngineAdapter:
@@ -260,11 +382,13 @@ class MockEngineAdapter:
                 await self._store.update_progress(run_id, progress, message=f"Step {step}/{total_steps}")
 
             benchmark_symbol = request.benchmark_symbol or (request.symbols[0] if request.symbols else "SPY")
-            equity_curve, benchmark_curve, metrics_summary, tearsheet = _build_sample_results(
+            portfolio_config = request.portfolio_construction.model_dump() if request.portfolio_construction else None
+            equity_curve, benchmark_curve, metrics_summary, tearsheet, portfolio_diagnostics, constraint_hits, portfolio_summary = _build_sample_results(
                 request.initial_capital,
                 request.start_date,
                 request.end_date,
                 benchmark_symbol,
+                portfolio_config,
             )
 
             result = BacktestResult(
@@ -275,6 +399,9 @@ class MockEngineAdapter:
                 benchmark_symbol=benchmark_symbol,
                 trades=[],
                 exposures=[],
+                portfolio_construction=portfolio_summary,
+                portfolio_diagnostics=portfolio_diagnostics,
+                constraint_hits=constraint_hits,
                 tearsheet=tearsheet,
                 logs=[f"Mock run completed against benchmark {benchmark_symbol}"],
             )

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class StrategyConfig(BaseModel):
@@ -24,6 +24,41 @@ class ExecutionConfig(BaseModel):
     latency_ms: int | None = Field(default=None, description="Latency in milliseconds")
 
 
+class PortfolioConstructionConfig(BaseModel):
+    method: str = Field(default="target_weights", pattern=r"^target_weights$")
+    target_weights: dict[str, float] = Field(default_factory=dict, description="Symbol -> weight fraction")
+    rebalance_frequency: str = Field(
+        default="weekly",
+        description="daily|weekly|monthly",
+        pattern=r"^(daily|weekly|monthly)$",
+    )
+    drift_threshold_pct: float | None = Field(default=None, ge=0.0, le=100.0)
+    max_weight_pct: float | None = Field(default=None, gt=0.0, le=100.0)
+    max_turnover_pct: float | None = Field(default=None, ge=0.0, le=500.0)
+    cash_floor_pct: float = Field(default=0.0, ge=0.0, le=95.0)
+    max_drawdown_pct: float | None = Field(default=None, gt=0.0, le=100.0)
+
+    @model_validator(mode="after")
+    def validate_target_weights(self) -> "PortfolioConstructionConfig":
+        cleaned: dict[str, float] = {}
+        total_weight = 0.0
+        for raw_symbol, raw_weight in self.target_weights.items():
+            symbol = str(raw_symbol).strip().upper()
+            weight = float(raw_weight)
+            if not symbol or weight <= 0:
+                continue
+            cleaned[symbol] = weight
+            total_weight += weight
+
+        if not cleaned:
+            raise ValueError("portfolio_construction.target_weights must include at least one positive symbol weight")
+        if total_weight <= 0:
+            raise ValueError("portfolio_construction.target_weights must sum to a positive value")
+
+        self.target_weights = cleaned
+        return self
+
+
 class BacktestRequest(BaseModel):
     symbols: list[str] = Field(min_length=1, max_length=100)
     start_date: datetime
@@ -39,6 +74,7 @@ class BacktestRequest(BaseModel):
     currency: str = Field(default="USD", min_length=3, max_length=5, pattern=r"^[A-Z]{3,5}$")
     timezone: str = Field(default="UTC", max_length=64)
     benchmark_symbol: str | None = Field(default=None, min_length=1, max_length=16)
+    portfolio_construction: PortfolioConstructionConfig | None = None
 
 
 class RunState(str, Enum):
@@ -81,5 +117,8 @@ class BacktestResult(BaseModel):
     benchmark_symbol: str | None = None
     trades: list[dict[str, Any]] = Field(default_factory=list)
     exposures: list[dict[str, Any]] = Field(default_factory=list)
+    portfolio_construction: dict[str, Any] = Field(default_factory=dict)
+    portfolio_diagnostics: list[dict[str, Any]] = Field(default_factory=list)
+    constraint_hits: list[dict[str, Any]] = Field(default_factory=list)
     tearsheet: dict[str, Any] = Field(default_factory=dict)
     logs: list[str] = Field(default_factory=list)

--- a/api/tests/test_backtest_adapter.py
+++ b/api/tests/test_backtest_adapter.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 import unittest
 
 from api.app.adapter import MockEngineAdapter
-from api.app.models import BacktestRequest
+from api.app.models import BacktestRequest, PortfolioConstructionConfig
 from api.app.store import RunStore
 
 
@@ -17,6 +17,12 @@ class BacktestAdapterTests(unittest.IsolatedAsyncioTestCase):
             start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
             end_date=datetime(2024, 3, 1, tzinfo=timezone.utc),
             benchmark_symbol="SPY",
+            portfolio_construction=PortfolioConstructionConfig(
+                target_weights={"AAPL": 1.0},
+                rebalance_frequency="weekly",
+                cash_floor_pct=5.0,
+                max_turnover_pct=50.0,
+            ),
         )
 
         status_obj = await store.create_run(request)
@@ -31,6 +37,9 @@ class BacktestAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("information_ratio", result.metrics_summary)
         self.assertIn("benchmark", result.tearsheet)
         self.assertEqual(result.tearsheet["benchmark"]["benchmark_symbol"], "SPY")
+        self.assertEqual(result.portfolio_construction.get("rebalance_frequency"), "weekly")
+        self.assertTrue(result.portfolio_diagnostics)
+        self.assertIn("constraint_hit_count", result.metrics_summary)
 
 
 if __name__ == "__main__":

--- a/docs/api/fastapi.md
+++ b/docs/api/fastapi.md
@@ -51,13 +51,23 @@ The gateway also sets basic security headers (`X-Content-Type-Options`, `X-Frame
 ```json
 POST /backtests
 {
-  "symbols": ["AAPL"],
+  "symbols": ["AAPL", "MSFT"],
   "start_date": "2024-01-01T00:00:00Z",
   "end_date": "2024-12-31T23:59:59Z",
   "resolution": "day",
   "strategy": {"name": "buy_and_hold"},
   "execution": {"slippage_bps": 1.0, "commission_bps": 0.5},
-  "benchmark_symbol": "SPY"
+  "benchmark_symbol": "SPY",
+  "portfolio_construction": {
+    "method": "target_weights",
+    "target_weights": {"AAPL": 0.6, "MSFT": 0.4},
+    "rebalance_frequency": "weekly",
+    "drift_threshold_pct": 5.0,
+    "max_weight_pct": 40.0,
+    "max_turnover_pct": 50.0,
+    "cash_floor_pct": 5.0,
+    "max_drawdown_pct": 20.0
+  }
 }
 ```
 
@@ -105,9 +115,33 @@ POST /backtests
   ],
   "trades": [],
   "exposures": [],
+  "portfolio_construction": {
+    "method": "target_weights",
+    "rebalance_frequency": "weekly",
+    "target_weights": {"AAPL": 57.0, "MSFT": 38.0},
+    "cash_floor_pct": 5.0,
+    "max_weight_pct": 40.0,
+    "max_turnover_pct": 50.0,
+    "drift_threshold_pct": 5.0,
+    "max_drawdown_pct": 20.0
+  },
+  "portfolio_diagnostics": [
+    {
+      "timestamp": "2024-01-01T00:00:00+00:00",
+      "target_weights": {"AAPL": 57.0, "MSFT": 38.0},
+      "realized_weights": {"AAPL": 57.0, "MSFT": 38.0},
+      "max_abs_drift_pct": 0.0,
+      "turnover_pct": 50.0,
+      "rebalanced": true,
+      "rebalance_reason": "initial_allocation",
+      "cash_weight_pct": 5.0
+    }
+  ],
+  "constraint_hits": [],
   "tearsheet": {
     "overview": {"final_value": 1012345.67},
     "benchmark": {"beta": 0.94, "alpha": 1.85, "information_ratio": 0.42},
+    "portfolio": {"method": "target_weights", "rebalance_frequency": "weekly"},
     "costs": {"total_cost_drag": 0.0}
   },
   "logs": []
@@ -124,10 +158,12 @@ Common `metrics_summary` keys include:
 - `total_trades`, `win_rate`, `profit_factor`
 - `average_win`, `average_loss`, `largest_win`, `largest_loss`
 - `total_commissions`
+- portfolio construction metrics such as `portfolio_rebalances`, `average_turnover_pct`, `max_weight_drift_pct`, and `constraint_hit_count`
 - benchmark-relative metrics such as `beta`, `alpha`, `tracking_error`, `information_ratio`, and `excess_return`
 
 Additional top-level result fields include:
 - `benchmark_symbol`, `benchmark_curve`
+- `portfolio_construction`, `portfolio_diagnostics`, `constraint_hits`
 - `tearsheet`
 
 Notes:
@@ -146,4 +182,5 @@ Notes:
 - Storage is in‑memory; restarting the service clears runs.
 - The mock engine emits progress updates and a sample result.
 - Benchmark-relative metrics are computed from the returned strategy and benchmark curves, not placeholder percentages.
+- Portfolio construction requests are accepted directly in the API surface so the same target-weight spec can flow between UI, API payloads, and saved results.
 - Replace the mock adapter with `gb-python` bindings or a CLI bridge in Phase 2.

--- a/docs/tutorials/ui-workflow.md
+++ b/docs/tutorials/ui-workflow.md
@@ -3,7 +3,7 @@
 ## Steps
 
 1. **Load data** in the Data Loader page.
-2. **Create a strategy** in the Strategy Editor.
+2. **Create a strategy** in the Strategy Editor, or skip strategy sizing entirely and use target-weight portfolio construction in the Backtest Runner.
 3. **Run backtest** in the Backtest Runner.
 4. **Review results** in Results Dashboard and Portfolio Analyzer.
 5. **Deep-dive analytics** in the Advanced Analytics page.
@@ -39,10 +39,21 @@ Sweep two parameters across a grid and visualise the impact on return, Sharpe, d
 
 Toggle **🌙 Dark Mode** in the sidebar for a dark colour scheme.
 
+## Portfolio Construction Workflow
+
+The Backtest Runner now supports a **target-weight portfolio construction** mode for multi-symbol research:
+
+- Enter target weights as `SYMBOL=percent` pairs, for example `AAPL=60, MSFT=40`.
+- Choose a rebalance schedule: `daily`, `weekly`, or `monthly`.
+- Add guardrails for drift, max position weight, max turnover per rebalance, cash floor, and a drawdown-triggered de-risking threshold.
+- Review realized weights, drift, turnover, cash buffer, rebalance reasons, and constraint hits in the **Portfolio Analyzer** tab.
+- Benchmark-relative analytics remain available when the benchmark symbol is present in the loaded market data.
+
 ## Tips
 
 - Start with sample data to validate logic quickly.
 - Save configurations for reproducibility.
 - Include benchmark bars in the loaded dataset to unlock real beta/alpha/information-ratio analytics.
+- Use portfolio construction mode when you want reusable allocation policy + rebalance diagnostics instead of ad hoc strategy sizing.
 - Export results or tearsheets for offline analysis.
 - Use the *Compare Runs* tab to evaluate strategies against each other.

--- a/ui/backtest_core.py
+++ b/ui/backtest_core.py
@@ -533,11 +533,459 @@ def calculate_symbol_attribution(
     return attribution
 
 
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _round_share_quantity(shares: float) -> float:
+    if shares <= 0:
+        return 0.0
+    return math.floor(shares * 1_000_000) / 1_000_000
+
+
+def _calculate_weight_map(
+    positions: dict[str, float],
+    latest_prices: dict[str, float],
+    portfolio_value: float,
+) -> dict[str, float]:
+    if portfolio_value <= 0:
+        return {}
+
+    return {
+        symbol: float(shares * latest_prices.get(symbol, 0.0) / portfolio_value)
+        for symbol, shares in positions.items()
+        if latest_prices.get(symbol, 0.0) > 0 and shares != 0
+    }
+
+
+def _normalize_portfolio_construction_config(
+    raw_config: dict[str, Any] | None,
+    market_data: pd.DataFrame,
+) -> dict[str, Any] | None:
+    if not raw_config or not raw_config.get("enabled"):
+        return None
+
+    available_symbols = {
+        str(symbol).strip().upper()
+        for symbol in market_data.get("symbol", pd.Series(dtype=str)).dropna().tolist()
+    }
+    cleaned_weights: dict[str, float] = {}
+    validation_errors: list[str] = []
+    for raw_symbol, raw_weight in dict(raw_config.get("target_weights") or {}).items():
+        symbol = str(raw_symbol).strip().upper()
+        weight = _coerce_float(raw_weight)
+        if not symbol or weight <= 0:
+            continue
+        if available_symbols and symbol not in available_symbols:
+            validation_errors.append(f"Target weight symbol {symbol} is not present in the loaded market data.")
+            continue
+        cleaned_weights[symbol] = weight
+
+    total_weight = sum(cleaned_weights.values())
+    if total_weight <= 0:
+        return {
+            "enabled": True,
+            "validation_errors": validation_errors or ["Portfolio construction requires at least one positive target weight."],
+            "target_weights": {},
+        }
+
+    normalized = {symbol: weight / total_weight for symbol, weight in cleaned_weights.items()}
+    cash_floor_fraction = min(max(_coerce_float(raw_config.get("cash_floor_pct")) / 100.0, 0.0), 0.95)
+    investable_fraction = max(0.0, 1.0 - cash_floor_fraction)
+    max_weight_fraction = None
+    if raw_config.get("max_weight_pct") not in (None, ""):
+        max_weight_fraction = min(max(_coerce_float(raw_config.get("max_weight_pct")) / 100.0, 0.0), 1.0)
+
+    target_weights: dict[str, float] = {}
+    upfront_constraint_hits: list[dict[str, Any]] = []
+    for symbol, weight in normalized.items():
+        scaled_weight = weight * investable_fraction
+        if max_weight_fraction is not None and scaled_weight > max_weight_fraction:
+            upfront_constraint_hits.append(
+                {
+                    "type": "max_weight_cap",
+                    "symbol": symbol,
+                    "requested_weight_pct": round(scaled_weight * 100, 2),
+                    "applied_weight_pct": round(max_weight_fraction * 100, 2),
+                }
+            )
+            scaled_weight = max_weight_fraction
+        target_weights[symbol] = scaled_weight
+
+    return {
+        "enabled": True,
+        "method": "target_weights",
+        "target_weights": target_weights,
+        "rebalance_frequency": str(raw_config.get("rebalance_frequency") or "weekly").lower(),
+        "drift_threshold": min(max(_coerce_float(raw_config.get("drift_threshold_pct")) / 100.0, 0.0), 1.0),
+        "max_weight": max_weight_fraction,
+        "max_turnover": min(max(_coerce_float(raw_config.get("max_turnover_pct")) / 100.0, 0.0), 5.0),
+        "cash_floor": cash_floor_fraction,
+        "max_drawdown": min(max(_coerce_float(raw_config.get("max_drawdown_pct")) / 100.0, 0.0), 1.0),
+        "validation_errors": validation_errors,
+        "upfront_constraint_hits": upfront_constraint_hits,
+        "target_weights_pct": {symbol: round(weight * 100, 2) for symbol, weight in target_weights.items()},
+    }
+
+
+def _rebalance_due(
+    last_rebalance_at: pd.Timestamp | None,
+    current_timestamp: pd.Timestamp,
+    frequency: str,
+) -> bool:
+    if last_rebalance_at is None:
+        return True
+    if frequency == "daily":
+        return current_timestamp.normalize() > last_rebalance_at.normalize()
+    if frequency == "monthly":
+        return current_timestamp.to_period("M") != last_rebalance_at.to_period("M")
+    return current_timestamp.to_period("W") != last_rebalance_at.to_period("W")
+
+
+def _apply_target_weight_rebalance(
+    portfolio: SimplePortfolio,
+    latest_prices: dict[str, float],
+    target_weights: dict[str, float],
+    timestamp: pd.Timestamp,
+    max_turnover: float | None,
+    log_queue,
+) -> tuple[float, list[dict[str, Any]]]:
+    portfolio_value = portfolio.calculate_value(latest_prices)
+    if portfolio_value <= 0:
+        return 0.0, []
+
+    desired_shares: dict[str, float] = {}
+    for symbol, target_weight in target_weights.items():
+        price = _coerce_float(latest_prices.get(symbol))
+        if price <= 0:
+            continue
+        desired_shares[symbol] = (portfolio_value * target_weight) / price
+
+    symbols = set(portfolio.positions) | set(desired_shares)
+    planned_deltas: dict[str, float] = {
+        symbol: desired_shares.get(symbol, 0.0) - _coerce_float(portfolio.positions.get(symbol))
+        for symbol in symbols
+    }
+    planned_turnover_notional = sum(
+        abs(delta) * _coerce_float(latest_prices.get(symbol))
+        for symbol, delta in planned_deltas.items()
+        if _coerce_float(latest_prices.get(symbol)) > 0
+    )
+
+    scale = 1.0
+    constraint_hits: list[dict[str, Any]] = []
+    if max_turnover and planned_turnover_notional > 0:
+        allowed_turnover = portfolio_value * max_turnover
+        if planned_turnover_notional > allowed_turnover:
+            scale = allowed_turnover / planned_turnover_notional
+            constraint_hits.append(
+                {
+                    "type": "turnover_cap",
+                    "requested_turnover_pct": round(planned_turnover_notional / portfolio_value * 100, 2),
+                    "applied_turnover_pct": round(max_turnover * 100, 2),
+                }
+            )
+
+    trade_start_index = len(portfolio.trades)
+
+    for symbol in sorted(symbols):
+        delta = planned_deltas.get(symbol, 0.0)
+        price = _coerce_float(latest_prices.get(symbol))
+        if delta >= 0 or price <= 0:
+            continue
+        shares_to_sell = min(_round_share_quantity(abs(delta) * scale), _coerce_float(portfolio.positions.get(symbol)))
+        if shares_to_sell > 0:
+            portfolio.sell(symbol, shares_to_sell, price, timestamp)
+            _queue_put(log_queue, f"{timestamp:%Y-%m-%d}: Rebalanced SELL {shares_to_sell:.4f} {symbol} @ {price:.2f}")
+
+    for symbol in sorted(symbols):
+        delta = planned_deltas.get(symbol, 0.0)
+        price = _coerce_float(latest_prices.get(symbol))
+        if delta <= 0 or price <= 0:
+            continue
+        target_shares = _round_share_quantity(delta * scale)
+        if target_shares <= 0:
+            continue
+        per_share_cost = price * (1 + portfolio._slippage_multiplier()) * (1 + portfolio.commission_rate)
+        affordable_shares = portfolio.cash / per_share_cost if per_share_cost > 0 else 0.0
+        shares_to_buy = _round_share_quantity(min(target_shares, affordable_shares))
+        if shares_to_buy > 0:
+            portfolio.buy(symbol, shares_to_buy, price, timestamp)
+            _queue_put(log_queue, f"{timestamp:%Y-%m-%d}: Rebalanced BUY {shares_to_buy:.4f} {symbol} @ {price:.2f}")
+
+    actual_turnover_notional = sum(
+        _coerce_float(trade.get("gross_notional"))
+        for trade in portfolio.trades[trade_start_index:]
+    )
+    turnover_pct = actual_turnover_notional / portfolio_value * 100 if portfolio_value > 0 else 0.0
+    return turnover_pct, constraint_hits
+
+
+def _finalize_backtest_results(
+    market_data: pd.DataFrame,
+    portfolio: SimplePortfolio,
+    equity_curve: list[dict[str, Any]],
+    latest_prices: dict[str, float],
+    all_logs: list[str],
+    benchmark_symbol: str | None,
+    portfolio_construction: dict[str, Any] | None = None,
+    portfolio_diagnostics: list[dict[str, Any]] | None = None,
+    constraint_hits: list[dict[str, Any]] | None = None,
+    log_queue=None,
+) -> dict[str, Any]:
+    final_value = equity_curve[-1]["value"]
+    total_return = (final_value - portfolio.initial_cash) / portfolio.initial_cash * 100
+    annualized_return = calculate_annualized_return_pct(equity_curve)
+    sharpe_ratio = calculate_sharpe_ratio(equity_curve)
+    max_drawdown = calculate_max_drawdown(equity_curve) * 100
+    win_rate = calculate_closed_trade_win_rate(portfolio.trades)
+
+    benchmark_curve = build_buy_and_hold_benchmark_curve(market_data, benchmark_symbol, portfolio.initial_cash)
+    benchmark_metrics = calculate_benchmark_metrics(equity_curve, benchmark_curve) if benchmark_curve else {}
+    if benchmark_symbol and not benchmark_curve:
+        _queue_put(log_queue, f"Benchmark symbol {benchmark_symbol} was not present in the loaded market data; benchmark metrics were skipped.")
+
+    cost_summary = calculate_trading_cost_summary(portfolio.trades, portfolio.initial_cash, final_value)
+    attribution = calculate_symbol_attribution(
+        portfolio.trades,
+        portfolio.positions,
+        latest_prices,
+        portfolio.initial_cash,
+    )
+
+    diagnostics = portfolio_diagnostics or []
+    constraint_events = constraint_hits or []
+    portfolio_metrics = {}
+    if diagnostics:
+        rebalances = [row for row in diagnostics if row.get("rebalanced")]
+        portfolio_metrics = {
+            "portfolio_rebalances": float(len(rebalances)),
+            "average_turnover_pct": float(np.mean([row.get("turnover_pct", 0.0) for row in diagnostics])) if diagnostics else 0.0,
+            "max_weight_drift_pct": float(max((row.get("max_abs_drift_pct", 0.0) for row in diagnostics), default=0.0)),
+            "constraint_hit_count": float(len(constraint_events)),
+        }
+
+    results = {
+        "equity_curve": equity_curve,
+        "benchmark_curve": benchmark_curve or [],
+        "trades": portfolio.trades,
+        "exposures": diagnostics,
+        "portfolio_construction": portfolio_construction or {},
+        "portfolio_diagnostics": diagnostics,
+        "constraint_hits": constraint_events,
+        "initial_capital": portfolio.initial_cash,
+        "final_value": final_value,
+        "total_return": total_return,
+        "annualized_return": annualized_return,
+        "sharpe_ratio": sharpe_ratio,
+        "max_drawdown": max_drawdown,
+        "total_trades": len(portfolio.trades),
+        "final_cash": portfolio.cash,
+        "final_positions": portfolio.positions,
+        "logs": all_logs,
+        "benchmark_symbol": benchmark_symbol,
+        "benchmark_metrics": benchmark_metrics,
+        "cost_summary": cost_summary,
+        "attribution": attribution,
+        "total_commissions": cost_summary["total_commissions"],
+        "total_slippage_cost": cost_summary["total_slippage_cost"],
+        "win_rate": win_rate,
+    }
+    results["metrics_summary"] = {
+        "initial_capital": portfolio.initial_cash,
+        "final_value": final_value,
+        "total_return": total_return,
+        "annualized_return": annualized_return,
+        "sharpe_ratio": sharpe_ratio,
+        "max_drawdown": max_drawdown,
+        "total_trades": len(portfolio.trades),
+        "win_rate": 0.0 if win_rate is None else win_rate,
+        "total_commissions": cost_summary["total_commissions"],
+        "total_slippage_cost": cost_summary["total_slippage_cost"],
+        **portfolio_metrics,
+        **benchmark_metrics,
+    }
+    results["tearsheet"] = build_tearsheet(results)
+    return results
+
+
+def _run_portfolio_construction_backtest(market_data, config, portfolio_config, progress_queue, log_queue):
+    commission_rate = float(config.get("commission", 0.0) or 0.0)
+    slippage_bps = float(config.get("slippage_bps", config.get("slippage", 0.0)) or 0.0)
+    portfolio = SimplePortfolio(
+        config.get("initial_capital", 100000),
+        commission_rate=commission_rate,
+        slippage_bps=slippage_bps,
+    )
+
+    _queue_put(log_queue, "Started backtest: Portfolio Construction (target weights)")
+    _queue_put(log_queue, f"Initial capital: ${portfolio.initial_cash:,.2f}")
+    _queue_put(log_queue, f"Execution costs: commission={commission_rate:.4f}, slippage={slippage_bps:.2f} bps")
+
+    validation_errors = portfolio_config.get("validation_errors") or []
+    if not portfolio_config.get("target_weights"):
+        for error in validation_errors or ["Portfolio construction requires at least one valid target weight."]:
+            _queue_put(log_queue, f"ERROR: {error}")
+        return None
+
+    all_logs: list[str] = []
+    for warning in validation_errors:
+        _queue_put(log_queue, f"WARNING: {warning}")
+        all_logs.append(f"WARNING: {warning}")
+    latest_prices: dict[str, float] = {}
+    equity_curve: list[dict[str, Any]] = []
+    portfolio_diagnostics: list[dict[str, Any]] = []
+    constraint_hits: list[dict[str, Any]] = []
+    previous_value = float(portfolio.initial_cash)
+    last_rebalance_at: pd.Timestamp | None = None
+    peak_value = float(portfolio.initial_cash)
+
+    for hit in portfolio_config.get("upfront_constraint_hits") or []:
+        stamped_hit = {"timestamp": pd.Timestamp(market_data["timestamp"].min()), **hit}
+        constraint_hits.append(stamped_hit)
+
+    grouped = list(market_data.sort_values(["timestamp", "symbol"]).groupby("timestamp", sort=True))
+    total_steps = len(grouped)
+    if total_steps == 0:
+        _queue_put(log_queue, "ERROR: No market data available for portfolio construction backtest")
+        return None
+
+    for index, (timestamp, rows) in enumerate(grouped, start=1):
+        current_timestamp = pd.Timestamp(timestamp)
+        for row in rows.itertuples(index=False):
+            latest_prices[str(row.symbol)] = float(row.close)
+
+        portfolio_value_before = portfolio.calculate_value(latest_prices)
+        peak_value = max(peak_value, portfolio_value_before)
+        drawdown_pct = ((peak_value - portfolio_value_before) / peak_value * 100) if peak_value > 0 else 0.0
+        current_weights = _calculate_weight_map(portfolio.positions, latest_prices, portfolio_value_before)
+        drift_map = {
+            symbol: current_weights.get(symbol, 0.0) - portfolio_config["target_weights"].get(symbol, 0.0)
+            for symbol in set(current_weights) | set(portfolio_config["target_weights"])
+        }
+        max_abs_drift_pct = max((abs(weight) * 100 for weight in drift_map.values()), default=0.0)
+
+        rebalance_reason = None
+        effective_target_weights = dict(portfolio_config["target_weights"])
+        step_constraint_hits: list[dict[str, Any]] = []
+        max_drawdown_fraction = portfolio_config.get("max_drawdown") or 0.0
+        if max_drawdown_fraction and drawdown_pct >= max_drawdown_fraction * 100 and portfolio.positions:
+            effective_target_weights = {}
+            rebalance_reason = "drawdown_guard"
+            step_constraint_hits.append(
+                {
+                    "timestamp": current_timestamp,
+                    "type": "max_drawdown_guard",
+                    "observed_drawdown_pct": round(drawdown_pct, 2),
+                    "limit_pct": round(max_drawdown_fraction * 100, 2),
+                }
+            )
+        elif _rebalance_due(last_rebalance_at, current_timestamp, portfolio_config.get("rebalance_frequency", "weekly")):
+            rebalance_reason = "initial_allocation" if last_rebalance_at is None else f"{portfolio_config.get('rebalance_frequency', 'weekly')}_schedule"
+        elif portfolio_config.get("drift_threshold") and max_abs_drift_pct >= portfolio_config["drift_threshold"] * 100:
+            rebalance_reason = "drift_threshold"
+
+        turnover_pct = 0.0
+        if rebalance_reason is not None:
+            turnover_pct, turnover_hits = _apply_target_weight_rebalance(
+                portfolio,
+                latest_prices,
+                effective_target_weights,
+                current_timestamp,
+                portfolio_config.get("max_turnover"),
+                log_queue,
+            )
+            step_constraint_hits.extend({"timestamp": current_timestamp, **hit} for hit in turnover_hits)
+            last_rebalance_at = current_timestamp
+
+        portfolio_value_after = portfolio.calculate_value(latest_prices)
+        peak_value = max(peak_value, portfolio_value_after)
+        realized_weights = _calculate_weight_map(portfolio.positions, latest_prices, portfolio_value_after)
+        realized_drift_map = {
+            symbol: realized_weights.get(symbol, 0.0) - portfolio_config["target_weights"].get(symbol, 0.0)
+            for symbol in set(realized_weights) | set(portfolio_config["target_weights"])
+        }
+        realized_max_abs_drift_pct = max((abs(weight) * 100 for weight in realized_drift_map.values()), default=0.0)
+        position_value = portfolio.calculate_position_value(latest_prices)
+        period_return = 0.0 if previous_value == 0 else (portfolio_value_after - previous_value) / previous_value
+        cumulative_return_pct = (
+            0.0
+            if portfolio.initial_cash == 0
+            else (portfolio_value_after - portfolio.initial_cash) / portfolio.initial_cash * 100
+        )
+
+        equity_curve.append(
+            {
+                "timestamp": current_timestamp,
+                "value": portfolio_value_after,
+                "cash": portfolio.cash,
+                "positions": sum(portfolio.positions.values()),
+                "position_value": position_value,
+                "returns": cumulative_return_pct,
+                "period_return": period_return,
+                "exposures": realized_weights,
+            }
+        )
+        previous_value = portfolio_value_after
+
+        portfolio_diagnostics.append(
+            {
+                "timestamp": current_timestamp,
+                "portfolio_value": portfolio_value_after,
+                "target_weights": {symbol: round(weight * 100, 2) for symbol, weight in portfolio_config["target_weights"].items()},
+                "realized_weights": {symbol: round(weight * 100, 2) for symbol, weight in realized_weights.items()},
+                "drift_by_symbol_pct": {symbol: round(weight * 100, 2) for symbol, weight in realized_drift_map.items()},
+                "max_abs_drift_pct": round(realized_max_abs_drift_pct, 2),
+                "turnover_pct": round(turnover_pct, 2),
+                "rebalanced": rebalance_reason is not None,
+                "rebalance_reason": rebalance_reason,
+                "cash_weight_pct": round((portfolio.cash / portfolio_value_after * 100) if portfolio_value_after > 0 else 0.0, 2),
+                "drawdown_pct": round(((peak_value - portfolio_value_after) / peak_value * 100) if peak_value > 0 else 0.0, 2),
+                "constraint_hits": step_constraint_hits,
+            }
+        )
+        constraint_hits.extend(step_constraint_hits)
+
+        progress = index / total_steps
+        _queue_put(progress_queue, progress)
+        time.sleep(0.01)
+
+    _queue_put(log_queue, "Backtest completed!")
+    all_logs.extend([f"Portfolio construction method: {portfolio_config.get('method', 'target_weights')}" if portfolio_config else ""])
+    benchmark_symbol = config.get("benchmark_symbol")
+    portfolio_summary = {
+        "method": portfolio_config.get("method", "target_weights"),
+        "rebalance_frequency": portfolio_config.get("rebalance_frequency", "weekly"),
+        "target_weights": portfolio_config.get("target_weights_pct") or {symbol: round(weight * 100, 2) for symbol, weight in portfolio_config.get("target_weights", {}).items()},
+        "cash_floor_pct": round((portfolio_config.get("cash_floor") or 0.0) * 100, 2),
+        "max_weight_pct": None if portfolio_config.get("max_weight") is None else round(portfolio_config["max_weight"] * 100, 2),
+        "max_turnover_pct": None if not portfolio_config.get("max_turnover") else round(portfolio_config["max_turnover"] * 100, 2),
+        "drift_threshold_pct": None if not portfolio_config.get("drift_threshold") else round(portfolio_config["drift_threshold"] * 100, 2),
+        "max_drawdown_pct": None if not portfolio_config.get("max_drawdown") else round(portfolio_config["max_drawdown"] * 100, 2),
+    }
+    return _finalize_backtest_results(
+        market_data,
+        portfolio,
+        equity_curve,
+        latest_prices,
+        [line for line in all_logs if line],
+        benchmark_symbol,
+        portfolio_construction=portfolio_summary,
+        portfolio_diagnostics=portfolio_diagnostics,
+        constraint_hits=constraint_hits,
+        log_queue=log_queue,
+    )
+
+
 def build_tearsheet(results: dict[str, Any]) -> dict[str, Any]:
     """Assemble a reusable institutional-style tearsheet payload."""
     benchmark_metrics = results.get("benchmark_metrics") or {}
     cost_summary = results.get("cost_summary") or {}
     attribution = results.get("attribution") or []
+    portfolio_summary = results.get("portfolio_construction") or {}
     top_contributors = sorted(attribution, key=lambda row: row.get("contribution_pct", 0), reverse=True)[:5]
     biggest_detractors = sorted(attribution, key=lambda row: row.get("contribution_pct", 0))[:5]
 
@@ -553,6 +1001,7 @@ def build_tearsheet(results: dict[str, Any]) -> dict[str, Any]:
             "total_trades": results.get("total_trades"),
         },
         "benchmark": benchmark_metrics,
+        "portfolio": portfolio_summary,
         "costs": cost_summary,
         "top_contributors": top_contributors,
         "biggest_detractors": biggest_detractors,
@@ -567,6 +1016,10 @@ def _queue_put(queue_obj, value):
 def run_backtest(strategy_code, market_data, config, progress_queue, log_queue):
     """Run a simple UI backtest in a worker thread."""
     try:
+        portfolio_config = _normalize_portfolio_construction_config(config.get("portfolio_construction"), market_data)
+        if portfolio_config is not None:
+            return _run_portfolio_construction_backtest(market_data, config, portfolio_config, progress_queue, log_queue)
+
         namespace = {}
         exec(strategy_code, namespace)
 
@@ -657,64 +1110,15 @@ def run_backtest(strategy_code, market_data, config, progress_queue, log_queue):
 
         _queue_put(log_queue, "Backtest completed!")
 
-        final_value = equity_curve[-1]["value"]
-        total_return = (final_value - portfolio.initial_cash) / portfolio.initial_cash * 100
-        annualized_return = calculate_annualized_return_pct(equity_curve)
-        sharpe_ratio = calculate_sharpe_ratio(equity_curve)
-        max_drawdown = calculate_max_drawdown(equity_curve) * 100
-        win_rate = calculate_closed_trade_win_rate(portfolio.trades)
-
-        benchmark_symbol = config.get("benchmark_symbol")
-        benchmark_curve = build_buy_and_hold_benchmark_curve(market_data, benchmark_symbol, portfolio.initial_cash)
-        benchmark_metrics = calculate_benchmark_metrics(equity_curve, benchmark_curve) if benchmark_curve else {}
-        if benchmark_symbol and not benchmark_curve:
-            _queue_put(log_queue, f"Benchmark symbol {benchmark_symbol} was not present in the loaded market data; benchmark metrics were skipped.")
-
-        cost_summary = calculate_trading_cost_summary(portfolio.trades, portfolio.initial_cash, final_value)
-        attribution = calculate_symbol_attribution(
-            portfolio.trades,
-            portfolio.positions,
+        return _finalize_backtest_results(
+            market_data,
+            portfolio,
+            equity_curve,
             latest_prices,
-            portfolio.initial_cash,
+            all_logs,
+            config.get("benchmark_symbol"),
+            log_queue=log_queue,
         )
-
-        results = {
-            "equity_curve": equity_curve,
-            "benchmark_curve": benchmark_curve or [],
-            "trades": portfolio.trades,
-            "initial_capital": portfolio.initial_cash,
-            "final_value": final_value,
-            "total_return": total_return,
-            "annualized_return": annualized_return,
-            "sharpe_ratio": sharpe_ratio,
-            "max_drawdown": max_drawdown,
-            "total_trades": len(portfolio.trades),
-            "final_cash": portfolio.cash,
-            "final_positions": portfolio.positions,
-            "logs": all_logs,
-            "benchmark_symbol": benchmark_symbol,
-            "benchmark_metrics": benchmark_metrics,
-            "cost_summary": cost_summary,
-            "attribution": attribution,
-            "total_commissions": cost_summary["total_commissions"],
-            "total_slippage_cost": cost_summary["total_slippage_cost"],
-            "win_rate": win_rate,
-        }
-        results["metrics_summary"] = {
-            "initial_capital": portfolio.initial_cash,
-            "final_value": final_value,
-            "total_return": total_return,
-            "annualized_return": annualized_return,
-            "sharpe_ratio": sharpe_ratio,
-            "max_drawdown": max_drawdown,
-            "total_trades": len(portfolio.trades),
-            "win_rate": 0.0 if win_rate is None else win_rate,
-            "total_commissions": cost_summary["total_commissions"],
-            "total_slippage_cost": cost_summary["total_slippage_cost"],
-            **benchmark_metrics,
-        }
-        results["tearsheet"] = build_tearsheet(results)
-        return results
     except Exception as exc:
         _queue_put(log_queue, f"FATAL ERROR: {str(exc)}")
         return None

--- a/ui/pages/backtest_runner.py
+++ b/ui/pages/backtest_runner.py
@@ -11,6 +11,39 @@ import streamlit as st
 
 from backtest_core import run_backtest
 
+
+def _loaded_symbols() -> list[str]:
+    if not st.session_state.get("data_loaded"):
+        return []
+    market_data = st.session_state.get("market_data")
+    if market_data is None or market_data.empty or "symbol" not in market_data.columns:
+        return []
+    return sorted({str(symbol).strip().upper() for symbol in market_data["symbol"].dropna().tolist() if str(symbol).strip()})
+
+
+def _default_target_weights_text() -> str:
+    symbols = _loaded_symbols()[:4]
+    if not symbols:
+        return "AAPL=60, MSFT=40"
+    equal_weight = round(100 / len(symbols), 2)
+    return ", ".join(f"{symbol}={equal_weight}" for symbol in symbols)
+
+
+def _parse_target_weights(raw_text: str) -> dict[str, float]:
+    target_weights: dict[str, float] = {}
+    for chunk in raw_text.replace("\n", ",").split(","):
+        if not chunk.strip():
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Invalid target weight entry '{chunk.strip()}'. Use SYMBOL=percent.")
+        symbol, raw_weight = chunk.split("=", 1)
+        normalized_symbol = symbol.strip().upper()
+        weight_pct = float(raw_weight.strip())
+        if not normalized_symbol or weight_pct <= 0:
+            continue
+        target_weights[normalized_symbol] = weight_pct / 100.0
+    return target_weights
+
 def show():
     """Main backtest runner page"""
     
@@ -33,9 +66,12 @@ def show():
             st.write(f"  • Bars: {len(df)}")
             st.write(f"  • Period: {df['timestamp'].min().date()} to {df['timestamp'].max().date()}")
         
-        # Check strategy
-        strategy_status = "✅ Ready" if 'strategy_code' in st.session_state else "❌ No Strategy"
-        st.write(f"**Strategy Code:** {strategy_status}")
+        # Check strategy / portfolio construction mode
+        if st.session_state.get("enable_portfolio_construction"):
+            st.write("**Strategy Code:** ℹ️ Optional (portfolio construction mode)")
+        else:
+            strategy_status = "✅ Ready" if 'strategy_code' in st.session_state else "❌ No Strategy"
+            st.write(f"**Strategy Code:** {strategy_status}")
         
         # Check config
         config_status = "✅ Ready" if st.session_state.strategy_config else "❌ No Config"
@@ -68,7 +104,33 @@ def show():
                 help="Use a symbol present in the loaded market data to compute actual benchmark-relative metrics.",
                 key="backtest_benchmark_symbol",
             )
-            
+
+            st.markdown("**Portfolio Construction (optional)**")
+            st.checkbox(
+                "Use target-weight portfolio construction",
+                value=st.session_state.get("enable_portfolio_construction", False),
+                help="Define portfolio weights, rebalance rules, and risk constraints instead of relying on strategy sizing.",
+                key="enable_portfolio_construction",
+            )
+            if st.session_state.get("enable_portfolio_construction"):
+                st.caption("Enter weights as percent allocations, e.g. `AAPL=60, MSFT=40`.")
+                st.text_area(
+                    "Target Weights",
+                    value=st.session_state.get("portfolio_target_weights_input") or _default_target_weights_text(),
+                    key="portfolio_target_weights_input",
+                    height=80,
+                )
+                port_col1, port_col2, port_col3 = st.columns(3)
+                with port_col1:
+                    st.selectbox("Rebalance Frequency", ["daily", "weekly", "monthly"], key="portfolio_rebalance_frequency")
+                    st.number_input("Cash Floor (%)", min_value=0.0, max_value=95.0, value=5.0, step=1.0, key="portfolio_cash_floor_pct")
+                with port_col2:
+                    st.number_input("Drift Threshold (%)", min_value=0.0, max_value=100.0, value=5.0, step=1.0, key="portfolio_drift_threshold_pct")
+                    st.number_input("Max Weight (%)", min_value=1.0, max_value=100.0, value=40.0, step=1.0, key="portfolio_max_weight_pct")
+                with port_col3:
+                    st.number_input("Max Turnover / Rebalance (%)", min_value=0.0, max_value=500.0, value=50.0, step=5.0, key="portfolio_max_turnover_pct")
+                    st.number_input("Drawdown Guardrail (%)", min_value=0.0, max_value=100.0, value=20.0, step=1.0, key="portfolio_max_drawdown_pct")
+
             submitted = st.form_submit_button("🚀 Run Backtest", type="primary")
     
     # Backtest execution
@@ -92,7 +154,8 @@ def run_backtest_execution():
         st.error("❌ No market data loaded. Please go to Data Loader first.")
         return
     
-    if 'strategy_code' not in st.session_state:
+    portfolio_mode = bool(st.session_state.get("enable_portfolio_construction"))
+    if not portfolio_mode and 'strategy_code' not in st.session_state:
         st.error("❌ No strategy code found. Please go to Strategy Editor first.")
         return
     
@@ -132,12 +195,36 @@ def run_backtest_execution():
             st.session_state.backtest_running = False
             return
 
-        strategy_code = st.session_state.strategy_code
+        strategy_code = st.session_state.get("strategy_code", "")
+        portfolio_construction = None
+        if portfolio_mode:
+            try:
+                target_weights = _parse_target_weights(st.session_state.get("portfolio_target_weights_input") or "")
+            except ValueError as exc:
+                st.error(f"❌ {exc}")
+                st.session_state.backtest_running = False
+                return
+            if not target_weights:
+                st.error("❌ Enter at least one positive target weight in portfolio construction mode.")
+                st.session_state.backtest_running = False
+                return
+            portfolio_construction = {
+                "enabled": True,
+                "target_weights": target_weights,
+                "rebalance_frequency": st.session_state.get("portfolio_rebalance_frequency") or "weekly",
+                "drift_threshold_pct": float(st.session_state.get("portfolio_drift_threshold_pct") or 0.0),
+                "max_weight_pct": float(st.session_state.get("portfolio_max_weight_pct") or 0.0),
+                "max_turnover_pct": float(st.session_state.get("portfolio_max_turnover_pct") or 0.0),
+                "cash_floor_pct": float(st.session_state.get("portfolio_cash_floor_pct") or 0.0),
+                "max_drawdown_pct": float(st.session_state.get("portfolio_max_drawdown_pct") or 0.0),
+            }
+
         config = {
             **st.session_state.strategy_config,
             "commission": float(st.session_state.get("backtest_commission_override", st.session_state.strategy_config.get("commission", 0.0)) or 0.0),
             "slippage_bps": float(st.session_state.get("backtest_slippage_override", st.session_state.strategy_config.get("slippage", 0.0)) or 0.0),
             "benchmark_symbol": (st.session_state.get("backtest_benchmark_symbol") or "").strip().upper() or None,
+            "portfolio_construction": portfolio_construction,
         }
         
         # Create queues for communication
@@ -199,14 +286,20 @@ def run_backtest_execution():
             
             # Show success message
             benchmark_metrics = result.get("benchmark_metrics") or {}
+            portfolio_summary = result.get("portfolio_construction") or {}
             if benchmark_metrics:
-                st.success(
+                message = (
                     f"🎉 Backtest completed! Final value: ${result['final_value']:,.2f} · "
                     f"Excess return vs {benchmark_metrics.get('benchmark_symbol') or result.get('benchmark_symbol')}: "
                     f"{benchmark_metrics.get('excess_return', 0.0):.2f}%"
                 )
             else:
-                st.success(f"🎉 Backtest completed! Final value: ${result['final_value']:,.2f}")
+                message = f"🎉 Backtest completed! Final value: ${result['final_value']:,.2f}"
+            if portfolio_summary:
+                message += (
+                    f" · Rebalances: {int(result.get('metrics_summary', {}).get('portfolio_rebalances', 0))}"
+                )
+            st.success(message)
             
         else:
             st.error("❌ Backtest failed. Check the logs for details.")
@@ -238,6 +331,8 @@ def show_quick_results():
     
     benchmark_metrics = results.get('benchmark_metrics') or {}
     cost_summary = results.get('cost_summary') or {}
+    portfolio_summary = results.get('portfolio_construction') or {}
+    portfolio_metrics = results.get('metrics_summary') or {}
 
     # Key metrics
     col1, col2, col3, col4, col5 = st.columns(5)
@@ -255,11 +350,14 @@ def show_quick_results():
         st.metric("Total Trades", results['total_trades'])
 
     with col5:
-        information_ratio = benchmark_metrics.get('information_ratio')
-        if benchmark_metrics and information_ratio is not None:
-            st.metric("Information Ratio", f"{information_ratio:.2f}")
+        if portfolio_summary:
+            st.metric("Rebalances", int(portfolio_metrics.get('portfolio_rebalances', 0)))
         else:
-            st.metric("Cost Drag", f"{cost_summary.get('cost_drag_pct_initial', 0.0):.2f}%")
+            information_ratio = benchmark_metrics.get('information_ratio')
+            if benchmark_metrics and information_ratio is not None:
+                st.metric("Information Ratio", f"{information_ratio:.2f}")
+            else:
+                st.metric("Cost Drag", f"{cost_summary.get('cost_drag_pct_initial', 0.0):.2f}%")
     
     # Final portfolio
     col1, col2 = st.columns(2)
@@ -280,16 +378,24 @@ def show_quick_results():
             st.write(f"Excess Return: {benchmark_metrics.get('excess_return', 0.0):.2f}%")
     
     with col2:
-        st.write("**Trade Summary:**")
-        if results['trades']:
-            trades_df = pd.DataFrame(results['trades'])
-            buy_trades = len(trades_df[trades_df['action'] == 'BUY'])
-            sell_trades = len(trades_df[trades_df['action'] == 'SELL'])
-            st.write(f"Buy orders: {buy_trades}")
-            st.write(f"Sell orders: {sell_trades}")
-            st.write(f"Commissions: ${cost_summary.get('total_commissions', 0.0):,.2f}")
-            st.write(f"Slippage drag: ${cost_summary.get('total_slippage_cost', 0.0):,.2f}")
-            st.write(f"Turnover: {cost_summary.get('turnover_multiple', 0.0):.2f}x initial capital")
+        if portfolio_summary:
+            st.write("**Portfolio Construction:**")
+            st.write(f"Method: {portfolio_summary.get('method', 'target_weights')}")
+            st.write(f"Rebalance: {portfolio_summary.get('rebalance_frequency', 'weekly')}")
+            st.write(f"Avg turnover: {portfolio_metrics.get('average_turnover_pct', 0.0):.2f}%")
+            st.write(f"Max drift: {portfolio_metrics.get('max_weight_drift_pct', 0.0):.2f}%")
+            st.write(f"Constraint hits: {int(portfolio_metrics.get('constraint_hit_count', 0))}")
+        else:
+            st.write("**Trade Summary:**")
+            if results['trades']:
+                trades_df = pd.DataFrame(results['trades'])
+                buy_trades = len(trades_df[trades_df['action'] == 'BUY'])
+                sell_trades = len(trades_df[trades_df['action'] == 'SELL'])
+                st.write(f"Buy orders: {buy_trades}")
+                st.write(f"Sell orders: {sell_trades}")
+                st.write(f"Commissions: ${cost_summary.get('total_commissions', 0.0):,.2f}")
+                st.write(f"Slippage drag: ${cost_summary.get('total_slippage_cost', 0.0):,.2f}")
+                st.write(f"Turnover: {cost_summary.get('turnover_multiple', 0.0):.2f}x initial capital")
     
     # Quick actions
     col1, col2, col3 = st.columns(3)

--- a/ui/pages/portfolio_analyzer.py
+++ b/ui/pages/portfolio_analyzer.py
@@ -307,75 +307,179 @@ def show_risk_analysis():
         st.plotly_chart(fig, use_container_width=True)
 
 def show_optimization_analysis():
-    """Show portfolio optimization analysis"""
-    st.subheader("🎯 Portfolio Optimization")
-    
-    st.info("🚧 Portfolio optimization features coming soon! This will include:")
-    
-    col1, col2 = st.columns(2)
-    
+    """Show portfolio construction and rebalancing diagnostics."""
+    st.subheader("🎯 Portfolio Construction & Rebalancing")
+
+    results = st.session_state.backtest_results
+    portfolio_summary = results.get('portfolio_construction') or {}
+    portfolio_metrics = results.get('metrics_summary') or {}
+    diagnostics = pd.DataFrame(results.get('portfolio_diagnostics') or [])
+    constraint_hits = results.get('constraint_hits') or []
+
+    if not portfolio_summary:
+        st.info(
+            "Run a backtest in target-weight portfolio construction mode to unlock rebalance schedules, "
+            "drift diagnostics, turnover controls, and constraint-hit reporting."
+        )
+        return
+
+    col1, col2, col3, col4 = st.columns(4)
     with col1:
-        st.markdown("""
-        **📊 Mean Reversion Optimization**
-        - Parameter sweep analysis
-        - Walk-forward optimization
-        - Out-of-sample testing
-        - Robust optimization methods
-        """)
-        
-        # Placeholder optimization interface
-        st.markdown("**⚙️ Optimization Settings**")
-        
-        param_to_optimize = st.selectbox(
-            "Parameter to Optimize",
-            ["Moving Average Period", "Position Size", "Stop Loss", "Take Profit"]
-        )
-        
-        optimization_method = st.selectbox(
-            "Optimization Method",
-            ["Grid Search", "Bayesian Optimization", "Genetic Algorithm"]
-        )
-        
-        col1a, col1b = st.columns(2)
-        with col1a:
-            min_value = st.number_input("Min Value", value=10)
-        with col1b:
-            max_value = st.number_input("Max Value", value=50)
-        
-        if st.button("🚀 Run Optimization"):
-            st.info("Optimization would run here with the selected parameters.")
-    
+        st.metric("Rebalances", int(portfolio_metrics.get('portfolio_rebalances', 0)))
     with col2:
-        st.markdown("""
-        **🎯 Risk Management**
-        - Position sizing optimization
-        - Kelly criterion calculation
-        - Risk parity allocation
-        - Maximum drawdown constraints
-        """)
-        
-        # Placeholder risk management tools
-        st.markdown("**⚖️ Risk Management Tools**")
-        
-        risk_target = st.slider("Target Volatility (%)", 5, 25, 15)
-        max_drawdown_limit = st.slider("Max Drawdown Limit (%)", 5, 50, 20)
-        
-        st.markdown("**💰 Position Sizing**")
-        kelly_fraction = st.slider("Kelly Fraction", 0.1, 1.0, 0.25, step=0.05)
-        
-        # Simple Kelly criterion calculation (placeholder)
-        if st.session_state.backtest_results:
-            total_return = st.session_state.backtest_results['total_return']
-            win_rate = 0.6  # Placeholder
-            avg_win = abs(total_return) * 1.5  # Placeholder
-            avg_loss = abs(total_return) * 0.8  # Placeholder
-            
-            if avg_loss > 0:
-                kelly_optimal = (win_rate * avg_win - (1 - win_rate) * avg_loss) / avg_win
-                st.write(f"**Optimal Kelly Fraction:** {kelly_optimal:.3f}")
-            
-        if st.button("📊 Calculate Optimal Allocation"):
-            st.info("Risk-adjusted allocation calculation would run here.")
+        st.metric("Avg Turnover", f"{portfolio_metrics.get('average_turnover_pct', 0.0):.2f}%")
+    with col3:
+        st.metric("Max Drift", f"{portfolio_metrics.get('max_weight_drift_pct', 0.0):.2f}%")
+    with col4:
+        st.metric("Constraint Hits", int(portfolio_metrics.get('constraint_hit_count', 0)))
+
+    target_weights = portfolio_summary.get('target_weights') or {}
+    target_df = pd.DataFrame(
+        [
+            {"Symbol": symbol, "Target Weight (%)": weight}
+            for symbol, weight in sorted(target_weights.items())
+        ]
+    )
+
+    col1, col2 = st.columns([1, 1])
+    with col1:
+        st.markdown("**🎯 Allocation Policy**")
+        if not target_df.empty:
+            st.dataframe(target_df, use_container_width=True, hide_index=True)
+        else:
+            st.info("No target weights captured for this run.")
+    with col2:
+        st.markdown("**⚙️ Policy Controls**")
+        st.write(f"Method: {portfolio_summary.get('method', 'target_weights')}")
+        st.write(f"Rebalance Frequency: {portfolio_summary.get('rebalance_frequency', 'weekly')}")
+        st.write(f"Cash Floor: {portfolio_summary.get('cash_floor_pct', 0.0):.2f}%")
+        st.write(
+            f"Max Weight: {portfolio_summary.get('max_weight_pct', 'N/A')}"
+            + ("%" if portfolio_summary.get('max_weight_pct') is not None else "")
+        )
+        st.write(
+            f"Drift Threshold: {portfolio_summary.get('drift_threshold_pct', 'N/A')}"
+            + ("%" if portfolio_summary.get('drift_threshold_pct') is not None else "")
+        )
+        st.write(
+            f"Max Turnover: {portfolio_summary.get('max_turnover_pct', 'N/A')}"
+            + ("%" if portfolio_summary.get('max_turnover_pct') is not None else "")
+        )
+        st.write(
+            f"Drawdown Guardrail: {portfolio_summary.get('max_drawdown_pct', 'N/A')}"
+            + ("%" if portfolio_summary.get('max_drawdown_pct') is not None else "")
+        )
+
+    if diagnostics.empty:
+        st.warning("No portfolio diagnostics were recorded for this run.")
+        return
+
+    diagnostics['timestamp'] = pd.to_datetime(diagnostics['timestamp'])
+
+    monitor_fig = make_subplots(
+        rows=2,
+        cols=1,
+        shared_xaxes=True,
+        subplot_titles=('Turnover & Drift', 'Drawdown & Cash Buffer'),
+        vertical_spacing=0.12,
+    )
+    monitor_fig.add_trace(
+        go.Bar(
+            x=diagnostics['timestamp'],
+            y=diagnostics['turnover_pct'],
+            name='Turnover (%)',
+            marker_color='#4C78A8',
+        ),
+        row=1,
+        col=1,
+    )
+    monitor_fig.add_trace(
+        go.Scatter(
+            x=diagnostics['timestamp'],
+            y=diagnostics['max_abs_drift_pct'],
+            mode='lines+markers',
+            name='Max drift (%)',
+            line=dict(color='#F58518'),
+        ),
+        row=1,
+        col=1,
+    )
+    monitor_fig.add_trace(
+        go.Scatter(
+            x=diagnostics['timestamp'],
+            y=diagnostics['drawdown_pct'],
+            mode='lines',
+            name='Drawdown (%)',
+            line=dict(color='#E45756'),
+        ),
+        row=2,
+        col=1,
+    )
+    monitor_fig.add_trace(
+        go.Scatter(
+            x=diagnostics['timestamp'],
+            y=diagnostics['cash_weight_pct'],
+            mode='lines',
+            name='Cash weight (%)',
+            line=dict(color='#72B7B2'),
+        ),
+        row=2,
+        col=1,
+    )
+    monitor_fig.update_layout(height=550, barmode='group')
+    st.plotly_chart(monitor_fig, use_container_width=True)
+
+    weight_rows = []
+    for row in diagnostics.itertuples(index=False):
+        target_map = getattr(row, 'target_weights', {}) or {}
+        realized_map = getattr(row, 'realized_weights', {}) or {}
+        for symbol in sorted(set(target_map) | set(realized_map)):
+            weight_rows.append(
+                {
+                    'timestamp': row.timestamp,
+                    'symbol': symbol,
+                    'target_weight_pct': target_map.get(symbol, 0.0),
+                    'realized_weight_pct': realized_map.get(symbol, 0.0),
+                }
+            )
+    weights_df = pd.DataFrame(weight_rows)
+    if not weights_df.empty:
+        st.markdown("**📊 Target vs Realized Weights**")
+        weights_fig = go.Figure()
+        for symbol, frame in weights_df.groupby('symbol'):
+            weights_fig.add_trace(
+                go.Scatter(
+                    x=frame['timestamp'],
+                    y=frame['realized_weight_pct'],
+                    mode='lines+markers',
+                    name=f'{symbol} realized',
+                )
+            )
+            weights_fig.add_trace(
+                go.Scatter(
+                    x=frame['timestamp'],
+                    y=frame['target_weight_pct'],
+                    mode='lines',
+                    name=f'{symbol} target',
+                    line=dict(dash='dash'),
+                )
+            )
+        weights_fig.update_layout(height=450, yaxis_title='Weight (%)')
+        st.plotly_chart(weights_fig, use_container_width=True)
+
+    rebalance_table = diagnostics.loc[
+        :, ['timestamp', 'rebalanced', 'rebalance_reason', 'turnover_pct', 'max_abs_drift_pct', 'cash_weight_pct']
+    ].copy()
+    rebalance_table['timestamp'] = rebalance_table['timestamp'].dt.strftime('%Y-%m-%d')
+    st.markdown("**🗓️ Rebalance Timeline**")
+    st.dataframe(rebalance_table, use_container_width=True, hide_index=True)
+
+    if constraint_hits:
+        st.markdown("**🧱 Constraint Hits**")
+        constraint_df = pd.DataFrame(constraint_hits)
+        if 'timestamp' in constraint_df.columns:
+            constraint_df['timestamp'] = pd.to_datetime(constraint_df['timestamp']).dt.strftime('%Y-%m-%d')
+        st.dataframe(constraint_df, use_container_width=True, hide_index=True)
 
 def show_scenario_analysis():
     """Show scenario analysis"""

--- a/ui/tests/test_backtest_core.py
+++ b/ui/tests/test_backtest_core.py
@@ -113,6 +113,82 @@ class BuyAndHoldTwoSymbols:
             ])
         )
 
+    def test_run_backtest_supports_target_weight_portfolio_construction(self):
+        market_data = pd.DataFrame(
+            [
+                {
+                    'timestamp': pd.Timestamp('2026-01-01'),
+                    'symbol': 'AAPL',
+                    'open': 100.0,
+                    'high': 100.0,
+                    'low': 100.0,
+                    'close': 100.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+                {
+                    'timestamp': pd.Timestamp('2026-01-01'),
+                    'symbol': 'MSFT',
+                    'open': 50.0,
+                    'high': 50.0,
+                    'low': 50.0,
+                    'close': 50.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+                {
+                    'timestamp': pd.Timestamp('2026-01-08'),
+                    'symbol': 'AAPL',
+                    'open': 110.0,
+                    'high': 110.0,
+                    'low': 110.0,
+                    'close': 110.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+                {
+                    'timestamp': pd.Timestamp('2026-01-08'),
+                    'symbol': 'MSFT',
+                    'open': 55.0,
+                    'high': 55.0,
+                    'low': 55.0,
+                    'close': 55.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+            ]
+        )
+
+        results = run_backtest(
+            '',
+            market_data,
+            {
+                'initial_capital': 1000.0,
+                'benchmark_symbol': 'AAPL',
+                'portfolio_construction': {
+                    'enabled': True,
+                    'target_weights': {'AAPL': 0.6, 'MSFT': 0.4},
+                    'rebalance_frequency': 'weekly',
+                    'cash_floor_pct': 0.0,
+                    'max_weight_pct': 70.0,
+                    'max_turnover_pct': 100.0,
+                    'drift_threshold_pct': 0.0,
+                    'max_drawdown_pct': 0.0,
+                },
+            },
+            queue.Queue(),
+            queue.Queue(),
+        )
+
+        self.assertIsNotNone(results)
+        self.assertTrue(results['portfolio_construction'])
+        self.assertTrue(results['portfolio_diagnostics'])
+        self.assertEqual(results['portfolio_construction']['rebalance_frequency'], 'weekly')
+        self.assertEqual(results['portfolio_diagnostics'][0]['rebalance_reason'], 'initial_allocation')
+        self.assertAlmostEqual(results['portfolio_diagnostics'][0]['target_weights']['AAPL'], 60.0, places=2)
+        self.assertGreater(results['metrics_summary']['portfolio_rebalances'], 0)
+        self.assertIn('portfolio', results['tearsheet'])
+
     def test_run_backtest_surfaces_real_benchmark_metrics_and_cost_drag(self):
         strategy_code = """
 class BuyThenSell:


### PR DESCRIPTION
## Summary
- add a first-class target-weight portfolio construction mode to the Streamlit backtest runner with rebalance schedules, drift thresholds, turnover caps, cash floors, max-weight limits, and drawdown guardrails
- surface realized weights, turnover, drift, cash buffer, and constraint-hit diagnostics in both UI backtest results and the FastAPI mock adapter so the same spec is available through UI/API payloads
- replace the Portfolio Analyzer placeholder with actual portfolio construction reporting and document the workflow in the UI/API docs

## Testing
- `python3 -m unittest ui.tests.test_backtest_core api.tests.test_backtest_adapter -v`
- `python3 -m compileall api ui`
- `rm -rf .pydeps-test && python3 -m pip install -q --target ./.pydeps-test -r api/requirements.txt httpx && PYTHONPATH="$(pwd)/.pydeps-test:$PWD" python3 -m unittest discover -s api/tests -v && rm -rf .pydeps-test`
- `mkdocs build --strict`

Fixes #90
