### PR TITLE
Fix #102: add replayable backtest run manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ dependencies = [
  "gb-types",
  "rust_decimal",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/api/app/adapter.py
+++ b/api/app/adapter.py
@@ -418,6 +418,7 @@ class RealEngineAdapter:
                 logs=result_payload.get("logs", []),
                 final_cash=result_payload.get("final_cash"),
                 final_positions=result_payload.get("final_positions", {}),
+                manifest=result_payload.get("manifest"),
             )
             await self._store.set_result(run_id, result)
         except Exception as exc:  # pragma: no cover - safety net

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -126,3 +126,4 @@ class BacktestResult(BaseModel):
     logs: list[str] = Field(default_factory=list)
     final_cash: float | None = None
     final_positions: dict[str, float] = Field(default_factory=dict)
+    manifest: dict[str, Any] | None = None

--- a/api/tests/test_backtest_adapter.py
+++ b/api/tests/test_backtest_adapter.py
@@ -51,6 +51,66 @@ class RealEngineAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "logs": ["Engine-backed backtest completed"],
                 "final_cash": 5000.0,
                 "final_positions": {"AAPL": 10.0},
+                "manifest": {
+                    "manifest_version": "1.0",
+                    "generated_at": "2026-04-28T00:00:00Z",
+                    "engine": {"crate_name": "gb-engine", "version": "0.1.0"},
+                    "strategy": {
+                        "strategy_id": "buy_and_hold",
+                        "name": "buy_and_hold",
+                        "parameters": {},
+                        "code_hash": None,
+                    },
+                    "dataset": {
+                        "data_source": "sample",
+                        "resolution": "day",
+                        "start_date": "2024-01-01T00:00:00Z",
+                        "end_date": "2024-12-31T00:00:00Z",
+                        "symbols": ["AAPL"],
+                        "bar_counts": {"AAPL": 252},
+                        "total_bars": 252,
+                    },
+                    "execution": {
+                        "initial_capital": 100000.0,
+                        "commission_bps": 1.5,
+                        "slippage_bps": 4.0,
+                        "latency_ms": 250,
+                        "commission_percentage": 0.00015,
+                        "minimum_commission": 1.0,
+                        "slippage_model": {"Linear": {"basis_points": 4}},
+                        "latency_model": {"Fixed": {"milliseconds": 250}},
+                        "market_impact_model": {"SquareRoot": {"factor": "0.0001"}},
+                        "data_settings": {
+                            "data_source": "sample",
+                            "adjust_for_splits": True,
+                            "adjust_for_dividends": True,
+                            "fill_gaps": False,
+                            "survivor_bias_free": True,
+                            "max_bars_in_memory": 10000,
+                        },
+                    },
+                    "replay_request": {
+                        "symbols": ["AAPL"],
+                        "start_date": "2024-01-01T00:00:00Z",
+                        "end_date": "2024-12-31T00:00:00Z",
+                        "resolution": "day",
+                        "strategy_name": "buy_and_hold",
+                        "strategy_params": {},
+                        "initial_capital": 100000.0,
+                        "data_source": "sample",
+                        "commission_bps": 1.5,
+                        "slippage_bps": 4.0,
+                        "latency_ms": 250,
+                        "run_name": "API Backtest replay",
+                    },
+                    "metric_snapshot": {
+                        "final_value": 101250.0,
+                        "total_return": 1.25,
+                        "max_drawdown": 0.0,
+                        "sharpe_ratio": 0.42,
+                        "total_trades": 1,
+                    },
+                },
             },
         ) as mocked_run:
             await adapter.run(status_obj.run_id, request)
@@ -79,6 +139,8 @@ class RealEngineAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.final_cash, 5000.0)
         self.assertEqual(result.final_positions, {"AAPL": 10.0})
         self.assertEqual(result.trades[0]["action"], "BUY")
+        self.assertIsNotNone(result.manifest)
+        self.assertEqual(result.manifest["replay_request"]["strategy_name"], "buy_and_hold")
 
 
 if __name__ == "__main__":

--- a/api/tests/test_experiment_registry.py
+++ b/api/tests/test_experiment_registry.py
@@ -40,6 +40,66 @@ class ExperimentRegistryTests(unittest.IsolatedAsyncioTestCase):
                 trades=[],
                 exposures=[],
                 logs=["completed"],
+                manifest={
+                    "manifest_version": "1.0",
+                    "generated_at": "2026-01-05T00:00:00Z",
+                    "engine": {"crate_name": "gb-engine", "version": "0.1.0"},
+                    "strategy": {
+                        "strategy_id": "buy_and_hold",
+                        "name": "buy_and_hold",
+                        "parameters": {},
+                        "code_hash": None,
+                    },
+                    "dataset": {
+                        "data_source": "sample",
+                        "resolution": "day",
+                        "start_date": "2026-01-01T00:00:00Z",
+                        "end_date": "2026-01-05T00:00:00Z",
+                        "symbols": ["AAPL"],
+                        "bar_counts": {"AAPL": 5},
+                        "total_bars": 5,
+                    },
+                    "execution": {
+                        "initial_capital": 100000.0,
+                        "commission_bps": 0.0,
+                        "slippage_bps": 5.0,
+                        "latency_ms": 100,
+                        "commission_percentage": 0.0,
+                        "minimum_commission": 1.0,
+                        "slippage_model": {"Linear": {"basis_points": 5}},
+                        "latency_model": {"Fixed": {"milliseconds": 100}},
+                        "market_impact_model": {"SquareRoot": {"factor": "0.0001"}},
+                        "data_settings": {
+                            "data_source": "sample",
+                            "adjust_for_splits": True,
+                            "adjust_for_dividends": True,
+                            "fill_gaps": False,
+                            "survivor_bias_free": True,
+                            "max_bars_in_memory": 10000,
+                        },
+                    },
+                    "replay_request": {
+                        "symbols": ["AAPL"],
+                        "start_date": "2026-01-01T00:00:00Z",
+                        "end_date": "2026-01-05T00:00:00Z",
+                        "resolution": "day",
+                        "strategy_name": "buy_and_hold",
+                        "strategy_params": {},
+                        "initial_capital": 100000.0,
+                        "data_source": "sample",
+                        "commission_bps": 0.0,
+                        "slippage_bps": 5.0,
+                        "latency_ms": 100,
+                        "run_name": "Registry Replay",
+                    },
+                    "metric_snapshot": {
+                        "final_value": 101234.5,
+                        "total_return": 1.2345,
+                        "max_drawdown": 0.0,
+                        "sharpe_ratio": 0.0,
+                        "total_trades": 0,
+                    },
+                },
             ),
         )
 
@@ -52,6 +112,7 @@ class ExperimentRegistryTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(persisted_result)
         self.assertEqual(persisted_status.state, RunState.completed)
         self.assertEqual(persisted_result.metrics_summary["final_value"], 101234.5)
+        self.assertEqual(persisted_result.manifest["dataset"]["total_bars"], 5)
         self.assertGreaterEqual(len(events), 3)
 
     async def test_registry_persists_strategy_snapshots_with_hashes(self) -> None:

--- a/api/tests/test_run_manifest.py
+++ b/api/tests/test_run_manifest.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from glowback_runtime import compare_manifest_metrics, replay_manifest, validate_run_manifest
+
+
+class RunManifestTests(unittest.TestCase):
+    def _manifest(self) -> dict:
+        return {
+            "manifest_version": "1.0",
+            "generated_at": "2026-04-28T00:00:00Z",
+            "engine": {"crate_name": "gb-engine", "version": "0.1.0"},
+            "strategy": {
+                "strategy_id": "buy_and_hold",
+                "name": "buy_and_hold",
+                "parameters": {},
+                "code_hash": None,
+            },
+            "dataset": {
+                "data_source": "sample",
+                "resolution": "day",
+                "start_date": "2024-01-01T00:00:00Z",
+                "end_date": "2024-01-10T00:00:00Z",
+                "symbols": ["AAPL"],
+                "bar_counts": {"AAPL": 10},
+                "total_bars": 10,
+            },
+            "execution": {
+                "initial_capital": 100000.0,
+                "commission_bps": 5.0,
+                "slippage_bps": 5.0,
+                "latency_ms": 100,
+                "commission_percentage": 0.0005,
+                "minimum_commission": 1.0,
+                "slippage_model": {"Linear": {"basis_points": 5}},
+                "latency_model": {"Fixed": {"milliseconds": 100}},
+                "market_impact_model": {"SquareRoot": {"factor": "0.0001"}},
+                "data_settings": {
+                    "data_source": "sample",
+                    "adjust_for_splits": True,
+                    "adjust_for_dividends": True,
+                    "fill_gaps": False,
+                    "survivor_bias_free": True,
+                    "max_bars_in_memory": 10000,
+                },
+            },
+            "replay_request": {
+                "symbols": ["AAPL"],
+                "start_date": "2024-01-01T00:00:00Z",
+                "end_date": "2024-01-10T00:00:00Z",
+                "resolution": "day",
+                "strategy_name": "buy_and_hold",
+                "strategy_params": {},
+                "initial_capital": 100000.0,
+                "data_source": "sample",
+                "commission_bps": 5.0,
+                "slippage_bps": 5.0,
+                "latency_ms": 100,
+                "run_name": "Manifest Replay",
+            },
+            "metric_snapshot": {
+                "final_value": 101500.0,
+                "total_return": 1.5,
+                "max_drawdown": 0.25,
+                "sharpe_ratio": 1.1,
+                "total_trades": 3,
+            },
+        }
+
+    def test_validate_run_manifest_rejects_missing_required_fields(self) -> None:
+        manifest = self._manifest()
+        manifest.pop("replay_request")
+
+        with self.assertRaisesRegex(ValueError, "replay_request"):
+            validate_run_manifest(manifest)
+
+    def test_replay_manifest_uses_replay_request_and_compares_metrics(self) -> None:
+        manifest = self._manifest()
+        with mock.patch(
+            "glowback_runtime.run_backtest",
+            return_value={
+                "final_value": 101500.0,
+                "total_return": 1.5,
+                "max_drawdown": 0.25,
+                "sharpe_ratio": 1.1,
+                "total_trades": 3,
+                "metrics_summary": {
+                    "final_value": 101500.0,
+                    "total_return": 1.5,
+                    "max_drawdown": 0.25,
+                    "sharpe_ratio": 1.1,
+                    "total_trades": 3,
+                },
+            },
+        ) as mocked_run:
+            replay_payload = replay_manifest(manifest)
+            comparison = compare_manifest_metrics(manifest, replay_payload)
+
+        mocked_run.assert_called_once_with(**manifest["replay_request"])
+        self.assertTrue(comparison["within_tolerance"])
+        self.assertEqual(comparison["deltas"]["final_value"], 0.0)
+        self.assertEqual(comparison["deltas"]["total_trades"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/gb-engine/Cargo.toml
+++ b/crates/gb-engine/Cargo.toml
@@ -13,6 +13,7 @@ gb-types = { path = "../gb-types" }
 gb-data = { path = "../gb-data" }
 tokio = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/gb-engine/src/engine.rs
+++ b/crates/gb-engine/src/engine.rs
@@ -5,14 +5,47 @@ use chrono::{DateTime, Duration, Utc};
 use gb_data::DataManager;
 use gb_types::{
     BacktestConfig, BacktestError, BacktestResult, Bar, EquityCurvePoint, Fill, GbResult,
-    LatencyModel, MarketDataBuffer, MarketEvent, Order, Portfolio, Side, SlippageModel, Strategy,
-    StrategyContext, StrategyMetrics, Symbol, TradeRecord,
+    LatencyModel, MarketDataBuffer, MarketEvent, Order, Portfolio, ReplayRequestManifest,
+    RunDatasetManifest, RunEngineManifest, RunExecutionManifest, RunManifest, RunMetricSnapshot,
+    RunStrategyManifest, Side, SlippageModel, Strategy, StrategyContext, StrategyMetrics, Symbol,
+    TradeRecord,
 };
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
 const STRATEGY_MARKET_DATA_WINDOW: usize = 100;
+
+fn decimal_to_f64(value: Decimal) -> f64 {
+    value.to_f64().unwrap_or(0.0)
+}
+
+fn execution_commission_bps(settings: &gb_types::ExecutionSettings) -> Option<f64> {
+    Some(decimal_to_f64(
+        settings.commission_percentage * Decimal::from(10_000),
+    ))
+}
+
+fn execution_slippage_bps(model: &SlippageModel) -> Option<f64> {
+    match model {
+        SlippageModel::None => Some(0.0),
+        SlippageModel::Fixed { basis_points } | SlippageModel::Linear { basis_points } => {
+            Some(*basis_points as f64)
+        }
+        SlippageModel::VolumeWeighted { min_bps, .. } => Some(*min_bps as f64),
+        SlippageModel::SquareRoot { .. } => None,
+    }
+}
+
+fn execution_latency_ms(model: &LatencyModel) -> Option<u64> {
+    match model {
+        LatencyModel::None => Some(0),
+        LatencyModel::Fixed { milliseconds } => Some(*milliseconds),
+        LatencyModel::Random { min_ms, .. } => Some(*min_ms),
+        LatencyModel::VenueSpecific { .. } => None,
+    }
+}
 
 /// Enhanced backtesting engine with event-driven simulation
 pub struct Engine {
@@ -537,6 +570,96 @@ impl Engine {
         Ok(())
     }
 
+    fn build_run_manifest(&self, result: &BacktestResult) -> RunManifest {
+        let strategy_config = self.strategy.get_config();
+        let symbols = self
+            .config
+            .symbols
+            .iter()
+            .map(|symbol| symbol.symbol.clone())
+            .collect::<Vec<_>>();
+        let bar_counts = self
+            .market_data
+            .iter()
+            .map(|(symbol, bars)| (symbol.symbol.clone(), bars.len()))
+            .collect::<HashMap<_, _>>();
+        let total_bars = bar_counts.values().sum();
+        let execution_settings = &self.config.execution_settings;
+        let performance_metrics = result.performance_metrics.as_ref();
+        let strategy_metrics = result.strategy_metrics.as_ref();
+
+        RunManifest {
+            manifest_version: "1.0".to_string(),
+            generated_at: Utc::now(),
+            engine: RunEngineManifest {
+                crate_name: "gb-engine".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            strategy: RunStrategyManifest {
+                strategy_id: strategy_config.strategy_id.clone(),
+                name: strategy_config.name.clone(),
+                parameters: strategy_config.parameters.clone(),
+                code_hash: None,
+            },
+            dataset: RunDatasetManifest {
+                data_source: self.config.data_settings.data_source.clone(),
+                resolution: format!("{:?}", self.config.resolution).to_ascii_lowercase(),
+                start_date: self.config.start_date,
+                end_date: self.config.end_date,
+                symbols: symbols.clone(),
+                bar_counts,
+                total_bars,
+            },
+            execution: RunExecutionManifest {
+                initial_capital: decimal_to_f64(self.config.initial_capital),
+                commission_bps: execution_commission_bps(execution_settings),
+                slippage_bps: execution_slippage_bps(&execution_settings.slippage_model),
+                latency_ms: execution_latency_ms(&execution_settings.latency_model),
+                commission_percentage: decimal_to_f64(execution_settings.commission_percentage),
+                minimum_commission: decimal_to_f64(execution_settings.minimum_commission),
+                slippage_model: execution_settings.slippage_model.clone(),
+                latency_model: execution_settings.latency_model.clone(),
+                market_impact_model: execution_settings.market_impact_model.clone(),
+                data_settings: self.config.data_settings.clone(),
+            },
+            replay_request: ReplayRequestManifest {
+                symbols,
+                start_date: self.config.start_date,
+                end_date: self.config.end_date,
+                resolution: format!("{:?}", self.config.resolution).to_ascii_lowercase(),
+                strategy_name: strategy_config.strategy_id.clone(),
+                strategy_params: strategy_config.parameters.clone(),
+                initial_capital: decimal_to_f64(self.config.initial_capital),
+                data_source: self.config.data_settings.data_source.clone(),
+                commission_bps: execution_commission_bps(execution_settings),
+                slippage_bps: execution_slippage_bps(&execution_settings.slippage_model),
+                latency_ms: execution_latency_ms(&execution_settings.latency_model),
+                run_name: Some(self.config.name.clone()),
+            },
+            metric_snapshot: RunMetricSnapshot {
+                final_value: decimal_to_f64(self.portfolio.total_equity),
+                total_return: performance_metrics
+                    .map(|metrics| decimal_to_f64(metrics.total_return) * 100.0)
+                    .unwrap_or_else(|| decimal_to_f64(self.portfolio.get_total_return()) * 100.0),
+                max_drawdown: performance_metrics
+                    .map(|metrics| decimal_to_f64(metrics.max_drawdown) * 100.0)
+                    .unwrap_or_else(|| decimal_to_f64(self.strategy_metrics.max_drawdown) * 100.0),
+                sharpe_ratio: performance_metrics
+                    .and_then(|metrics| metrics.sharpe_ratio)
+                    .map(decimal_to_f64)
+                    .or_else(|| {
+                        strategy_metrics
+                            .and_then(|metrics| metrics.sharpe_ratio)
+                            .map(decimal_to_f64)
+                    })
+                    .unwrap_or(0.0),
+                total_trades: strategy_metrics
+                    .map(|metrics| metrics.total_trades)
+                    .unwrap_or(self.trade_log.len() as u64),
+            },
+        }
+    }
+
     /// Finalize backtest results
     async fn finalize_results(&mut self, result: &mut BacktestResult) -> GbResult<()> {
         // Get strategy metrics and merge with engine metrics
@@ -624,6 +747,7 @@ impl Engine {
             &self.portfolio,
             &self.trade_log,
         ));
+        result.manifest = Some(self.build_run_manifest(result));
 
         info!("Final portfolio value: {}", self.portfolio.total_equity);
         info!("Total return: {:.2}%", total_return * Decimal::from(100));

--- a/crates/gb-engine/src/lib.rs
+++ b/crates/gb-engine/src/lib.rs
@@ -201,7 +201,8 @@ impl BacktestEngine {
 mod tests {
     use super::*;
     use chrono::{Duration, Utc};
-    use gb_types::{Resolution, StrategyConfig, Symbol};
+    use gb_types::{BuyAndHoldStrategy, Resolution, RunManifest, StrategyConfig, Symbol};
+    use rust_decimal::prelude::FromPrimitive;
     use rust_decimal::Decimal;
 
     /// Create a test configuration
@@ -218,6 +219,146 @@ mod tests {
         config.data_settings.data_source = "sample".to_string();
 
         config
+    }
+
+    fn replay_config_from_manifest(manifest: &RunManifest) -> BacktestConfig {
+        let replay = &manifest.replay_request;
+        let mut strategy_config =
+            StrategyConfig::new(replay.strategy_name.clone(), replay.strategy_name.clone());
+        strategy_config.parameters = replay.strategy_params.clone();
+        strategy_config.symbols = replay
+            .symbols
+            .iter()
+            .map(|symbol| Symbol::equity(symbol))
+            .collect();
+        strategy_config.initial_capital =
+            Decimal::from_f64(replay.initial_capital).unwrap_or_else(|| Decimal::from(100000));
+
+        let mut config = BacktestConfig::new(
+            replay
+                .run_name
+                .clone()
+                .unwrap_or_else(|| "Manifest Replay".to_string()),
+            strategy_config.clone(),
+        );
+        config.start_date = replay.start_date;
+        config.end_date = replay.end_date;
+        config.initial_capital =
+            Decimal::from_f64(replay.initial_capital).unwrap_or_else(|| Decimal::from(100000));
+        config.resolution = match replay.resolution.as_str() {
+            "minute" => Resolution::Minute,
+            "hour" => Resolution::Hour,
+            _ => Resolution::Day,
+        };
+        config.symbols = replay
+            .symbols
+            .iter()
+            .map(|symbol| Symbol::equity(symbol))
+            .collect();
+        config.strategy_config = strategy_config;
+        config.data_settings.data_source = replay.data_source.clone();
+
+        if let Some(commission_bps) = replay.commission_bps {
+            if let Some(decimal) = Decimal::from_f64(commission_bps / 10_000.0) {
+                config.execution_settings.commission_percentage = decimal;
+            }
+        }
+        if let Some(slippage_bps) = replay.slippage_bps {
+            config.execution_settings.slippage_model = gb_types::SlippageModel::Linear {
+                basis_points: slippage_bps.round() as u32,
+            };
+        }
+        if let Some(latency_ms) = replay.latency_ms {
+            config.execution_settings.latency_model = gb_types::LatencyModel::Fixed {
+                milliseconds: latency_ms,
+            };
+        }
+
+        config
+    }
+
+    fn strategy_from_manifest(manifest: &RunManifest) -> Box<dyn gb_types::Strategy> {
+        let replay = &manifest.replay_request;
+        match replay.strategy_name.as_str() {
+            "buy_and_hold" => Box::new(BuyAndHoldStrategy::new()),
+            "ma_crossover" | "moving_average_crossover" => {
+                let short_period = replay
+                    .strategy_params
+                    .get("short_period")
+                    .and_then(|value| serde_json::from_value::<usize>(value.clone()).ok())
+                    .unwrap_or(10);
+                let long_period = replay
+                    .strategy_params
+                    .get("long_period")
+                    .and_then(|value| serde_json::from_value::<usize>(value.clone()).ok())
+                    .unwrap_or(20);
+                Box::new(gb_types::MovingAverageCrossoverStrategy::new(
+                    short_period,
+                    long_period,
+                ))
+            }
+            "momentum" => {
+                let lookback_period = replay
+                    .strategy_params
+                    .get("lookback_period")
+                    .and_then(|value| serde_json::from_value::<usize>(value.clone()).ok())
+                    .unwrap_or(10);
+                let momentum_threshold = replay
+                    .strategy_params
+                    .get("momentum_threshold")
+                    .and_then(|value| serde_json::from_value::<f64>(value.clone()).ok())
+                    .unwrap_or(0.05);
+                Box::new(gb_types::MomentumStrategy::new(
+                    lookback_period,
+                    momentum_threshold,
+                ))
+            }
+            "mean_reversion" => {
+                let lookback_period = replay
+                    .strategy_params
+                    .get("lookback_period")
+                    .and_then(|value| serde_json::from_value::<usize>(value.clone()).ok())
+                    .unwrap_or(20);
+                let entry_threshold = replay
+                    .strategy_params
+                    .get("entry_threshold")
+                    .and_then(|value| serde_json::from_value::<f64>(value.clone()).ok())
+                    .unwrap_or(2.0);
+                let exit_threshold = replay
+                    .strategy_params
+                    .get("exit_threshold")
+                    .and_then(|value| serde_json::from_value::<f64>(value.clone()).ok())
+                    .unwrap_or(1.0);
+                Box::new(gb_types::MeanReversionStrategy::new(
+                    lookback_period,
+                    entry_threshold,
+                    exit_threshold,
+                ))
+            }
+            "rsi" => {
+                let lookback_period = replay
+                    .strategy_params
+                    .get("lookback_period")
+                    .and_then(|value| serde_json::from_value::<usize>(value.clone()).ok())
+                    .unwrap_or(14);
+                let oversold_threshold = replay
+                    .strategy_params
+                    .get("oversold_threshold")
+                    .and_then(|value| serde_json::from_value::<f64>(value.clone()).ok())
+                    .unwrap_or(30.0);
+                let overbought_threshold = replay
+                    .strategy_params
+                    .get("overbought_threshold")
+                    .and_then(|value| serde_json::from_value::<f64>(value.clone()).ok())
+                    .unwrap_or(70.0);
+                Box::new(gb_types::RsiStrategy::new(
+                    lookback_period,
+                    oversold_threshold,
+                    overbought_threshold,
+                ))
+            }
+            other => panic!("unsupported manifest replay strategy: {other}"),
+        }
     }
 
     #[tokio::test]
@@ -371,6 +512,46 @@ mod tests {
         let portfolio = backtest_result.final_portfolio.as_ref().unwrap();
         // Portfolio should have been updated (either positions or cash changed)
         assert!(portfolio.total_equity > Decimal::ZERO);
+    }
+
+    #[tokio::test]
+    async fn test_run_manifest_replays_buy_and_hold_with_matching_metrics() {
+        let mut config = create_test_config();
+        config.symbols = vec![Symbol::equity("AAPL")];
+        config.start_date = Utc::now() - Duration::days(10);
+        config.end_date = Utc::now();
+
+        let mut engine = BacktestEngine::new(config).await.unwrap();
+        let result = engine
+            .run_with_strategy(Box::new(BuyAndHoldStrategy::new()))
+            .await
+            .unwrap();
+        let manifest = result
+            .manifest
+            .clone()
+            .expect("completed runs should include a manifest");
+
+        assert_eq!(manifest.replay_request.strategy_name, "buy_and_hold");
+        assert!(manifest.dataset.total_bars > 0);
+
+        let replay_config = replay_config_from_manifest(&manifest);
+        let replay_strategy = strategy_from_manifest(&manifest);
+        let mut replay_engine = BacktestEngine::new(replay_config).await.unwrap();
+        let replay_result = replay_engine
+            .run_with_strategy(replay_strategy)
+            .await
+            .unwrap();
+        let replay_manifest = replay_result
+            .manifest
+            .expect("replay run should include a manifest");
+
+        let original = manifest.metric_snapshot;
+        let replay = replay_manifest.metric_snapshot;
+        assert!((original.final_value - replay.final_value).abs() < 1e-6);
+        assert!((original.total_return - replay.total_return).abs() < 1e-6);
+        assert!((original.max_drawdown - replay.max_drawdown).abs() < 1e-6);
+        assert!((original.sharpe_ratio - replay.sharpe_ratio).abs() < 1e-6);
+        assert_eq!(original.total_trades, replay.total_trades);
     }
 
     #[tokio::test]

--- a/crates/gb-python/src/lib.rs
+++ b/crates/gb-python/src/lib.rs
@@ -383,10 +383,7 @@ fn run_builtin_strategy(
     let strategy = build_builtin_strategy(&strategy_name, &strategy_config)?;
 
     let runtime = tokio::runtime::Runtime::new().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "Failed to create async runtime: {}",
-            e
-        ))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to create async runtime: {}", e))
     })?;
 
     let mut engine = runtime
@@ -401,10 +398,7 @@ fn run_builtin_strategy(
     let result = runtime
         .block_on(async { engine.run_with_strategy(strategy).await })
         .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "Backtest execution failed: {}",
-                e
-            ))
+            pyo3::exceptions::PyRuntimeError::new_err(format!("Backtest execution failed: {}", e))
         })?;
 
     Ok(PyBacktestResult::from_backtest_result(result))
@@ -768,6 +762,7 @@ struct PyBacktestResult {
     logs: Vec<String>,
     final_cash: f64,
     final_positions: std::collections::HashMap<String, f64>,
+    manifest: Option<serde_json::Value>,
 }
 
 impl PyBacktestResult {
@@ -963,6 +958,11 @@ impl PyBacktestResult {
             })
             .collect::<Vec<_>>();
 
+        let manifest = result
+            .manifest
+            .as_ref()
+            .and_then(|manifest| serde_json::to_value(manifest).ok());
+
         let total_trades = metrics_summary
             .get("total_trades")
             .copied()
@@ -986,6 +986,7 @@ impl PyBacktestResult {
             logs,
             final_cash,
             final_positions,
+            manifest,
         }
     }
 }
@@ -1075,6 +1076,23 @@ impl PyBacktestResult {
     #[getter]
     fn final_positions(&self, py: Python) -> PyResult<PyObject> {
         Ok(self.final_positions.clone().into_pyobject(py)?.into())
+    }
+
+    #[getter]
+    fn manifest(&self, py: Python) -> PyResult<PyObject> {
+        match &self.manifest {
+            Some(manifest) => {
+                let json = py.import("json")?;
+                let payload = serde_json::to_string(manifest).map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to serialize run manifest: {}",
+                        error
+                    ))
+                })?;
+                Ok(json.call_method1("loads", (payload,))?.into())
+            }
+            None => Ok(py.None()),
+        }
     }
 
     /// Convert the equity curve to a pandas DataFrame (Jupyter-friendly)

--- a/crates/gb-types/src/backtest.rs
+++ b/crates/gb-types/src/backtest.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
-use crate::market::{Symbol, Resolution};
+use crate::market::{Resolution, Symbol};
 use crate::portfolio::Portfolio;
 use crate::strategy::{StrategyConfig, StrategyMetrics};
 
@@ -46,23 +46,23 @@ impl BacktestConfig {
             created_at: Utc::now(),
         }
     }
-    
+
     pub fn with_symbols(mut self, symbols: Vec<Symbol>) -> Self {
         self.symbols = symbols;
         self
     }
-    
+
     pub fn with_date_range(mut self, start: DateTime<Utc>, end: DateTime<Utc>) -> Self {
         self.start_date = start;
         self.end_date = end;
         self
     }
-    
+
     pub fn with_capital(mut self, capital: Decimal) -> Self {
         self.initial_capital = capital;
         self
     }
-    
+
     pub fn with_resolution(mut self, resolution: Resolution) -> Self {
         self.resolution = resolution;
         self
@@ -85,10 +85,12 @@ impl Default for ExecutionSettings {
         Self {
             commission_per_share: Decimal::new(1, 3), // $0.001 per share
             commission_percentage: Decimal::new(5, 4), // 0.05%
-            minimum_commission: Decimal::new(1, 0), // $1.00 minimum
+            minimum_commission: Decimal::new(1, 0),   // $1.00 minimum
             slippage_model: SlippageModel::Linear { basis_points: 5 },
             latency_model: LatencyModel::Fixed { milliseconds: 100 },
-            market_impact_model: MarketImpactModel::SquareRoot { factor: Decimal::new(1, 4) },
+            market_impact_model: MarketImpactModel::SquareRoot {
+                factor: Decimal::new(1, 4),
+            },
         }
     }
 }
@@ -145,6 +147,83 @@ impl Default for DataSettings {
     }
 }
 
+/// Replayable run-manifest contract for deterministic backtest lineage.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunManifest {
+    pub manifest_version: String,
+    pub generated_at: DateTime<Utc>,
+    pub engine: RunEngineManifest,
+    pub strategy: RunStrategyManifest,
+    pub dataset: RunDatasetManifest,
+    pub execution: RunExecutionManifest,
+    pub replay_request: ReplayRequestManifest,
+    pub metric_snapshot: RunMetricSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunEngineManifest {
+    pub crate_name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunStrategyManifest {
+    pub strategy_id: String,
+    pub name: String,
+    pub parameters: HashMap<String, serde_json::Value>,
+    pub code_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunDatasetManifest {
+    pub data_source: String,
+    pub resolution: String,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+    pub symbols: Vec<String>,
+    pub bar_counts: HashMap<String, usize>,
+    pub total_bars: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunExecutionManifest {
+    pub initial_capital: f64,
+    pub commission_bps: Option<f64>,
+    pub slippage_bps: Option<f64>,
+    pub latency_ms: Option<u64>,
+    pub commission_percentage: f64,
+    pub minimum_commission: f64,
+    pub slippage_model: SlippageModel,
+    pub latency_model: LatencyModel,
+    pub market_impact_model: MarketImpactModel,
+    pub data_settings: DataSettings,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReplayRequestManifest {
+    pub symbols: Vec<String>,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+    pub resolution: String,
+    pub strategy_name: String,
+    pub strategy_params: HashMap<String, serde_json::Value>,
+    pub initial_capital: f64,
+    pub data_source: String,
+    pub commission_bps: Option<f64>,
+    pub slippage_bps: Option<f64>,
+    pub latency_ms: Option<u64>,
+    pub run_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunMetricSnapshot {
+    pub final_value: f64,
+    pub total_return: f64,
+    pub max_drawdown: f64,
+    pub sharpe_ratio: f64,
+    pub total_trades: u64,
+}
+
 /// Backtest execution status
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BacktestStatus {
@@ -171,6 +250,7 @@ pub struct BacktestResult {
     pub trade_log: Vec<TradeRecord>,
     pub error_message: Option<String>,
     pub metadata: HashMap<String, serde_json::Value>,
+    pub manifest: Option<RunManifest>,
 }
 
 impl BacktestResult {
@@ -189,26 +269,27 @@ impl BacktestResult {
             trade_log: Vec::new(),
             error_message: None,
             metadata: HashMap::new(),
+            manifest: None,
         }
     }
-    
+
     pub fn mark_started(&mut self) {
         self.status = BacktestStatus::Running;
         self.start_time = Utc::now();
     }
-    
+
     pub fn mark_completed(&mut self, portfolio: Portfolio, metrics: StrategyMetrics) {
         let end_time = Utc::now();
         self.status = BacktestStatus::Completed;
         self.end_time = Some(end_time);
         self.duration_seconds = Some((end_time - self.start_time).num_seconds() as u64);
-        
+
         // Calculate performance metrics
         self.performance_metrics = Some(PerformanceMetrics::calculate(&portfolio));
         self.final_portfolio = Some(portfolio);
         self.strategy_metrics = Some(metrics);
     }
-    
+
     pub fn mark_failed(&mut self, error: String) {
         self.status = BacktestStatus::Failed;
         self.end_time = Some(Utc::now());
@@ -247,7 +328,7 @@ pub struct PerformanceMetrics {
 impl PerformanceMetrics {
     pub fn calculate(portfolio: &Portfolio) -> Self {
         let daily_returns = &portfolio.daily_returns;
-        
+
         Self {
             total_return: portfolio.get_total_return(),
             annualized_return: Self::calculate_annualized_return(daily_returns),
@@ -259,8 +340,8 @@ impl PerformanceMetrics {
             max_drawdown_duration_days: Self::calculate_max_drawdown_duration(daily_returns),
             var_95: Self::calculate_var_95(daily_returns),
             cvar_95: Self::calculate_cvar_95(daily_returns),
-            beta: None,          // Requires benchmark data
-            alpha: None,         // Requires benchmark data
+            beta: None,              // Requires benchmark data
+            alpha: None,             // Requires benchmark data
             information_ratio: None, // Requires benchmark data
             skewness: Self::calculate_skewness(daily_returns),
             kurtosis: Self::calculate_kurtosis(daily_returns),
@@ -278,7 +359,7 @@ impl PerformanceMetrics {
     /// Calculate performance metrics with trade data
     pub fn calculate_with_trades(portfolio: &Portfolio, trades: &[TradeRecord]) -> Self {
         let mut metrics = Self::calculate(portfolio);
-        
+
         // Add trade-based metrics
         if !trades.is_empty() {
             metrics.total_trades = trades.len() as u64;
@@ -289,10 +370,10 @@ impl PerformanceMetrics {
             metrics.largest_win = Self::calculate_largest_win(trades);
             metrics.largest_loss = Self::calculate_largest_loss(trades);
         }
-        
+
         metrics
     }
-    
+
     fn calculate_annualized_return(daily_returns: &[crate::portfolio::DailyReturn]) -> Decimal {
         if daily_returns.is_empty() {
             return Decimal::ZERO;
@@ -314,25 +395,25 @@ impl PerformanceMetrics {
         let annualized = base.powf(1.0 / years) - 1.0;
         Decimal::from_f64_retain(annualized).unwrap_or_default()
     }
-    
+
     fn calculate_volatility(daily_returns: &[crate::portfolio::DailyReturn]) -> Decimal {
         if daily_returns.len() < 2 {
             return Decimal::ZERO;
         }
-        
-        let returns: Vec<Decimal> = daily_returns.iter()
-            .map(|r| r.daily_return)
-            .collect();
-            
+
+        let returns: Vec<Decimal> = daily_returns.iter().map(|r| r.daily_return).collect();
+
         let mean = returns.iter().sum::<Decimal>() / Decimal::from(returns.len());
-        let variance = returns.iter()
+        let variance = returns
+            .iter()
             .map(|r| {
                 let diff = *r - mean;
                 let diff_f64 = diff.to_f64().unwrap_or(0.0);
                 Decimal::from_f64_retain(diff_f64 * diff_f64).unwrap_or_default()
             })
-            .sum::<Decimal>() / Decimal::from(returns.len() - 1);
-            
+            .sum::<Decimal>()
+            / Decimal::from(returns.len() - 1);
+
         let variance_f64 = variance.to_f64().unwrap_or(0.0);
         let std_dev = Decimal::from_f64_retain(variance_f64.sqrt()).unwrap_or_default();
         let annualization_factor = Decimal::from_f64_retain((252.0_f64).sqrt()).unwrap_or_default();
@@ -340,16 +421,20 @@ impl PerformanceMetrics {
     }
 
     /// Calculate Sortino ratio (like Sharpe but only considers downside volatility)
-    fn calculate_sortino_ratio(daily_returns: &[crate::portfolio::DailyReturn], risk_free_rate: Decimal) -> Option<Decimal> {
+    fn calculate_sortino_ratio(
+        daily_returns: &[crate::portfolio::DailyReturn],
+        risk_free_rate: Decimal,
+    ) -> Option<Decimal> {
         if daily_returns.is_empty() {
             return None;
         }
 
         let annual_return = Self::calculate_annualized_return(daily_returns);
         let daily_risk_free = risk_free_rate / Decimal::from(252);
-        
+
         // Calculate downside deviation (only negative returns)
-        let downside_returns: Vec<Decimal> = daily_returns.iter()
+        let downside_returns: Vec<Decimal> = daily_returns
+            .iter()
             .map(|r| r.daily_return - daily_risk_free)
             .filter(|&r| r < Decimal::ZERO)
             .collect();
@@ -358,18 +443,21 @@ impl PerformanceMetrics {
             return Some(Decimal::from(9999)); // No downside volatility
         }
 
-        let downside_variance = downside_returns.iter()
+        let downside_variance = downside_returns
+            .iter()
             .map(|&r| {
                 let r_f64 = r.to_f64().unwrap_or(0.0);
                 Decimal::from_f64_retain(r_f64 * r_f64).unwrap_or_default()
             })
-            .sum::<Decimal>() / Decimal::from(downside_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(downside_returns.len());
 
-        let downside_std = Decimal::from_f64_retain(
-            downside_variance.to_f64().unwrap_or(0.0).sqrt()
-        ).unwrap_or_default();
-        
-        let annualized_downside_std = downside_std * Decimal::from_f64_retain((252.0_f64).sqrt()).unwrap_or_default();
+        let downside_std =
+            Decimal::from_f64_retain(downside_variance.to_f64().unwrap_or(0.0).sqrt())
+                .unwrap_or_default();
+
+        let annualized_downside_std =
+            downside_std * Decimal::from_f64_retain((252.0_f64).sqrt()).unwrap_or_default();
 
         if annualized_downside_std > Decimal::ZERO {
             Some((annual_return - risk_free_rate) / annualized_downside_std)
@@ -379,7 +467,10 @@ impl PerformanceMetrics {
     }
 
     /// Calculate Calmar ratio (annualized return / max drawdown)
-    fn calculate_calmar_ratio(daily_returns: &[crate::portfolio::DailyReturn], max_drawdown: Decimal) -> Option<Decimal> {
+    fn calculate_calmar_ratio(
+        daily_returns: &[crate::portfolio::DailyReturn],
+        max_drawdown: Decimal,
+    ) -> Option<Decimal> {
         if max_drawdown <= Decimal::ZERO {
             return None;
         }
@@ -389,7 +480,9 @@ impl PerformanceMetrics {
     }
 
     /// Calculate maximum drawdown duration in days
-    fn calculate_max_drawdown_duration(daily_returns: &[crate::portfolio::DailyReturn]) -> Option<u32> {
+    fn calculate_max_drawdown_duration(
+        daily_returns: &[crate::portfolio::DailyReturn],
+    ) -> Option<u32> {
         if daily_returns.is_empty() {
             return None;
         }
@@ -408,7 +501,11 @@ impl PerformanceMetrics {
             }
         }
 
-        if max_duration > 0 { Some(max_duration) } else { None }
+        if max_duration > 0 {
+            Some(max_duration)
+        } else {
+            None
+        }
     }
 
     /// Calculate Value at Risk (95% confidence)
@@ -417,15 +514,13 @@ impl PerformanceMetrics {
             return None; // Need sufficient data
         }
 
-        let mut returns: Vec<Decimal> = daily_returns.iter()
-            .map(|r| r.daily_return)
-            .collect();
-        
+        let mut returns: Vec<Decimal> = daily_returns.iter().map(|r| r.daily_return).collect();
+
         returns.sort();
-        
+
         let index = (returns.len() as f64 * 0.05) as usize; // 5th percentile
         let var = -returns[index]; // VaR is positive loss
-        
+
         Some(var)
     }
 
@@ -435,15 +530,13 @@ impl PerformanceMetrics {
             return None;
         }
 
-        let mut returns: Vec<Decimal> = daily_returns.iter()
-            .map(|r| r.daily_return)
-            .collect();
-        
+        let mut returns: Vec<Decimal> = daily_returns.iter().map(|r| r.daily_return).collect();
+
         returns.sort();
-        
+
         let index = (returns.len() as f64 * 0.05) as usize;
         let tail_returns = &returns[..=index];
-        
+
         if tail_returns.is_empty() {
             return None;
         }
@@ -458,32 +551,39 @@ impl PerformanceMetrics {
             return None;
         }
 
-        let mean = daily_returns.iter()
+        let mean = daily_returns
+            .iter()
             .map(|r| r.daily_return)
-            .sum::<Decimal>() / Decimal::from(daily_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(daily_returns.len());
 
-        let variance = daily_returns.iter()
+        let variance = daily_returns
+            .iter()
             .map(|r| {
                 let diff = r.daily_return - mean;
                 let diff_f64 = diff.to_f64().unwrap_or(0.0);
                 Decimal::from_f64_retain(diff_f64 * diff_f64).unwrap_or_default()
             })
-            .sum::<Decimal>() / Decimal::from(daily_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(daily_returns.len());
 
-        let std_dev = Decimal::from_f64_retain(variance.to_f64().unwrap_or(0.0).sqrt()).unwrap_or_default();
-        
+        let std_dev =
+            Decimal::from_f64_retain(variance.to_f64().unwrap_or(0.0).sqrt()).unwrap_or_default();
+
         if std_dev <= Decimal::ZERO {
             return None;
         }
 
-        let skewness = daily_returns.iter()
+        let skewness = daily_returns
+            .iter()
             .map(|r| {
                 let diff = r.daily_return - mean;
                 let standardized = diff / std_dev;
                 let standardized_f64 = standardized.to_f64().unwrap_or(0.0);
                 Decimal::from_f64_retain(standardized_f64.powi(3)).unwrap_or_default()
             })
-            .sum::<Decimal>() / Decimal::from(daily_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(daily_returns.len());
 
         Some(skewness)
     }
@@ -494,32 +594,39 @@ impl PerformanceMetrics {
             return None;
         }
 
-        let mean = daily_returns.iter()
+        let mean = daily_returns
+            .iter()
             .map(|r| r.daily_return)
-            .sum::<Decimal>() / Decimal::from(daily_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(daily_returns.len());
 
-        let variance = daily_returns.iter()
+        let variance = daily_returns
+            .iter()
             .map(|r| {
                 let diff = r.daily_return - mean;
                 let diff_f64 = diff.to_f64().unwrap_or(0.0);
                 Decimal::from_f64_retain(diff_f64 * diff_f64).unwrap_or_default()
             })
-            .sum::<Decimal>() / Decimal::from(daily_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(daily_returns.len());
 
-        let std_dev = Decimal::from_f64_retain(variance.to_f64().unwrap_or(0.0).sqrt()).unwrap_or_default();
-        
+        let std_dev =
+            Decimal::from_f64_retain(variance.to_f64().unwrap_or(0.0).sqrt()).unwrap_or_default();
+
         if std_dev <= Decimal::ZERO {
             return None;
         }
 
-        let kurtosis = daily_returns.iter()
+        let kurtosis = daily_returns
+            .iter()
             .map(|r| {
                 let diff = r.daily_return - mean;
                 let standardized = diff / std_dev;
                 let standardized_f64 = standardized.to_f64().unwrap_or(0.0);
                 Decimal::from_f64_retain(standardized_f64.powi(4)).unwrap_or_default()
             })
-            .sum::<Decimal>() / Decimal::from(daily_returns.len());
+            .sum::<Decimal>()
+            / Decimal::from(daily_returns.len());
 
         Some(kurtosis - Decimal::from(3)) // Excess kurtosis
     }
@@ -530,7 +637,8 @@ impl PerformanceMetrics {
             return Decimal::ZERO;
         }
 
-        let winning_trades = trades.iter()
+        let winning_trades = trades
+            .iter()
             .filter(|trade| trade.pnl.unwrap_or(Decimal::ZERO) > Decimal::ZERO)
             .count();
 
@@ -539,12 +647,14 @@ impl PerformanceMetrics {
 
     /// Calculate profit factor (gross profit / gross loss)
     fn calculate_profit_factor(trades: &[TradeRecord]) -> Option<Decimal> {
-        let gross_profit: Decimal = trades.iter()
+        let gross_profit: Decimal = trades
+            .iter()
             .filter_map(|trade| trade.pnl)
             .filter(|&pnl| pnl > Decimal::ZERO)
             .sum();
 
-        let gross_loss: Decimal = trades.iter()
+        let gross_loss: Decimal = trades
+            .iter()
             .filter_map(|trade| trade.pnl)
             .filter(|&pnl| pnl < Decimal::ZERO)
             .map(|pnl| pnl.abs())
@@ -561,7 +671,8 @@ impl PerformanceMetrics {
 
     /// Calculate average winning trade
     fn calculate_average_win(trades: &[TradeRecord]) -> Decimal {
-        let winning_trades: Vec<Decimal> = trades.iter()
+        let winning_trades: Vec<Decimal> = trades
+            .iter()
             .filter_map(|trade| trade.pnl)
             .filter(|&pnl| pnl > Decimal::ZERO)
             .collect();
@@ -575,7 +686,8 @@ impl PerformanceMetrics {
 
     /// Calculate average losing trade
     fn calculate_average_loss(trades: &[TradeRecord]) -> Decimal {
-        let losing_trades: Vec<Decimal> = trades.iter()
+        let losing_trades: Vec<Decimal> = trades
+            .iter()
             .filter_map(|trade| trade.pnl)
             .filter(|&pnl| pnl < Decimal::ZERO)
             .collect();
@@ -589,7 +701,8 @@ impl PerformanceMetrics {
 
     /// Calculate largest winning trade
     fn calculate_largest_win(trades: &[TradeRecord]) -> Decimal {
-        trades.iter()
+        trades
+            .iter()
             .filter_map(|trade| trade.pnl)
             .filter(|&pnl| pnl > Decimal::ZERO)
             .max()
@@ -598,7 +711,8 @@ impl PerformanceMetrics {
 
     /// Calculate largest losing trade
     fn calculate_largest_loss(trades: &[TradeRecord]) -> Decimal {
-        trades.iter()
+        trades
+            .iter()
             .filter_map(|trade| trade.pnl)
             .filter(|&pnl| pnl < Decimal::ZERO)
             .min()
@@ -640,12 +754,31 @@ pub struct TradeRecord {
 /// Backtest event for real-time monitoring
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum BacktestEvent {
-    Started { backtest_id: BacktestId, config: BacktestConfig },
-    Progress { backtest_id: BacktestId, progress_pct: f64, current_date: DateTime<Utc> },
-    EquityUpdate { backtest_id: BacktestId, point: EquityCurvePoint },
-    TradeExecuted { backtest_id: BacktestId, trade: TradeRecord },
-    Completed { backtest_id: BacktestId, result: BacktestResult },
-    Failed { backtest_id: BacktestId, error: String },
+    Started {
+        backtest_id: BacktestId,
+        config: BacktestConfig,
+    },
+    Progress {
+        backtest_id: BacktestId,
+        progress_pct: f64,
+        current_date: DateTime<Utc>,
+    },
+    EquityUpdate {
+        backtest_id: BacktestId,
+        point: EquityCurvePoint,
+    },
+    TradeExecuted {
+        backtest_id: BacktestId,
+        trade: TradeRecord,
+    },
+    Completed {
+        backtest_id: BacktestId,
+        result: BacktestResult,
+    },
+    Failed {
+        backtest_id: BacktestId,
+        error: String,
+    },
 }
 
 #[cfg(test)]
@@ -655,8 +788,13 @@ mod tests {
     use chrono::{Duration, Utc};
     use rust_decimal::prelude::ToPrimitive;
     use rust_decimal::Decimal;
+    use serde_json::json;
 
-    fn make_daily_return_with_value(base: chrono::DateTime<Utc>, day_offset: i64, value: i64) -> DailyReturn {
+    fn make_daily_return_with_value(
+        base: chrono::DateTime<Utc>,
+        day_offset: i64,
+        value: i64,
+    ) -> DailyReturn {
         DailyReturn {
             date: base + Duration::days(day_offset),
             portfolio_value: Decimal::from(value),
@@ -665,7 +803,11 @@ mod tests {
         }
     }
 
-    fn make_daily_return(base: chrono::DateTime<Utc>, day_offset: i64, cumulative_return: f64) -> DailyReturn {
+    fn make_daily_return(
+        base: chrono::DateTime<Utc>,
+        day_offset: i64,
+        cumulative_return: f64,
+    ) -> DailyReturn {
         DailyReturn {
             date: base + Duration::days(day_offset),
             portfolio_value: Decimal::from(100_000),
@@ -739,5 +881,124 @@ mod tests {
     fn annualized_return_empty_is_zero() {
         let annualized = PerformanceMetrics::calculate_annualized_return(&[]);
         assert_eq!(annualized, Decimal::ZERO);
+    }
+
+    #[test]
+    fn run_manifest_round_trips_through_json() {
+        let manifest = RunManifest {
+            manifest_version: "1.0".to_string(),
+            generated_at: Utc::now(),
+            engine: RunEngineManifest {
+                crate_name: "gb-engine".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            strategy: RunStrategyManifest {
+                strategy_id: "buy_and_hold".to_string(),
+                name: "buy_and_hold".to_string(),
+                parameters: HashMap::from([("lookback".to_string(), json!(20))]),
+                code_hash: None,
+            },
+            dataset: RunDatasetManifest {
+                data_source: "sample".to_string(),
+                resolution: "day".to_string(),
+                start_date: Utc::now() - Duration::days(10),
+                end_date: Utc::now(),
+                symbols: vec!["AAPL".to_string()],
+                bar_counts: HashMap::from([("AAPL".to_string(), 10usize)]),
+                total_bars: 10,
+            },
+            execution: RunExecutionManifest {
+                initial_capital: 100000.0,
+                commission_bps: Some(5.0),
+                slippage_bps: Some(3.0),
+                latency_ms: Some(50),
+                commission_percentage: 0.0005,
+                minimum_commission: 0.0,
+                slippage_model: SlippageModel::Linear { basis_points: 3 },
+                latency_model: LatencyModel::Fixed { milliseconds: 50 },
+                market_impact_model: MarketImpactModel::None,
+                data_settings: DataSettings::default(),
+            },
+            replay_request: ReplayRequestManifest {
+                symbols: vec!["AAPL".to_string()],
+                start_date: Utc::now() - Duration::days(10),
+                end_date: Utc::now(),
+                resolution: "day".to_string(),
+                strategy_name: "buy_and_hold".to_string(),
+                strategy_params: HashMap::new(),
+                initial_capital: 100000.0,
+                data_source: "sample".to_string(),
+                commission_bps: Some(5.0),
+                slippage_bps: Some(3.0),
+                latency_ms: Some(50),
+                run_name: Some("Replay Run".to_string()),
+            },
+            metric_snapshot: RunMetricSnapshot {
+                final_value: 101000.0,
+                total_return: 1.0,
+                max_drawdown: 0.5,
+                sharpe_ratio: 1.2,
+                total_trades: 3,
+            },
+        };
+
+        let encoded = serde_json::to_value(&manifest).unwrap();
+        let decoded: RunManifest = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, manifest);
+    }
+
+    #[test]
+    fn run_manifest_requires_replay_request() {
+        let payload = json!({
+            "manifest_version": "1.0",
+            "generated_at": "2026-04-28T00:00:00Z",
+            "engine": {"crate_name": "gb-engine", "version": "0.1.0"},
+            "strategy": {
+                "strategy_id": "buy_and_hold",
+                "name": "buy_and_hold",
+                "parameters": {},
+                "code_hash": null
+            },
+            "dataset": {
+                "data_source": "sample",
+                "resolution": "day",
+                "start_date": "2026-01-01T00:00:00Z",
+                "end_date": "2026-01-05T00:00:00Z",
+                "symbols": ["AAPL"],
+                "bar_counts": {"AAPL": 5},
+                "total_bars": 5
+            },
+            "execution": {
+                "initial_capital": 100000.0,
+                "commission_bps": 5.0,
+                "slippage_bps": 3.0,
+                "latency_ms": 50,
+                "commission_percentage": 0.0005,
+                "minimum_commission": 0.0,
+                "slippage_model": {"Linear": {"basis_points": 3}},
+                "latency_model": {"Fixed": {"milliseconds": 50}},
+                "market_impact_model": "None",
+                "data_settings": {
+                    "data_source": "sample",
+                    "adjust_for_splits": true,
+                    "adjust_for_dividends": true,
+                    "fill_gaps": false,
+                    "survivor_bias_free": true,
+                    "max_bars_in_memory": 10000
+                }
+            },
+            "metric_snapshot": {
+                "final_value": 101000.0,
+                "total_return": 1.0,
+                "max_drawdown": 0.5,
+                "sharpe_ratio": 1.2,
+                "total_trades": 3
+            }
+        });
+
+        let error = serde_json::from_value::<RunManifest>(payload)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("replay_request"));
     }
 }

--- a/docs/api/fastapi.md
+++ b/docs/api/fastapi.md
@@ -148,7 +148,30 @@ POST /backtests
   },
   "logs": [],
   "final_cash": 50000.0,
-  "final_positions": {"AAPL": 6333.3333}
+  "final_positions": {"AAPL": 6333.3333},
+  "manifest": {
+    "manifest_version": "1.0",
+    "engine": {"crate_name": "gb-engine", "version": "0.1.0"},
+    "dataset": {
+      "data_source": "sample",
+      "resolution": "day",
+      "symbols": ["AAPL", "MSFT"],
+      "total_bars": 504
+    },
+    "replay_request": {
+      "symbols": ["AAPL", "MSFT"],
+      "strategy_name": "buy_and_hold",
+      "resolution": "day",
+      "data_source": "sample"
+    },
+    "metric_snapshot": {
+      "final_value": 1012345.67,
+      "total_return": 1.23,
+      "max_drawdown": 0.65,
+      "sharpe_ratio": 0.84,
+      "total_trades": 0
+    }
+  }
 }
 ```
 
@@ -169,6 +192,7 @@ Additional top-level result fields include:
 - `benchmark_symbol`, `benchmark_curve`
 - `portfolio_construction`, `portfolio_diagnostics`, `constraint_hits`
 - `tearsheet`
+- `manifest` (deterministic run lineage + replay request)
 
 Notes:
 - `returns`, `daily_return`, `max_drawdown`, and `volatility` are expressed as percentages.
@@ -188,4 +212,5 @@ Notes:
 - Request `data_source: "sample"` for the built-in sample provider, or `data_source: "csv"` plus `csv_data_path` for local CSV bundles.
 - Benchmark-relative metrics are computed from the returned strategy and benchmark curves, and portfolio-construction fields remain part of the API contract and result payloads when available.
 - `/optimizations` uses the same real `gb-python` execution path for built-in strategies.
+- The `manifest` payload is designed to be replayed locally with `glowback_runtime.replay_manifest(...)`; see the "Reproducing a Run" tutorial.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -75,6 +75,8 @@ for point in result.equity_curve[:5]:
 
 Contains the results of a backtest run.
 
+- `manifest`: Replayable run-lineage payload with engine version, dataset summary,
+  execution settings, replay request, and headline metrics.
 - `metrics_summary`: Dictionary of performance metrics. Common keys include:
   - `initial_capital`, `final_value`
   - `total_return`, `annualized_return`, `volatility`
@@ -94,6 +96,7 @@ curve = result.to_dataframe(index="timestamp")
 metrics = result.metrics_dataframe()
 summary = result.summary(plot=True, index="timestamp")
 ax = result.plot_equity()
+manifest = result.manifest
 ```
 
 ### `DataManager` (alias: `PyDataManager`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Run manifests + replayability:** Engine-backed API backtests now emit a typed `manifest` contract with dataset lineage, execution settings, replay-ready request payloads, and headline metric snapshots; Python/runtime helpers can replay the manifest locally and compare results against the captured metrics.
 - **Experiment durability:** GlowBack now persists Streamlit strategy snapshots, completed UI backtest runs, and API backtest history in a shared SQLite-backed experiment registry so saved strategies, comparison runs, and historical `/backtests` listings survive restarts and remain exportable/deletable intentionally.
 - **Engine scaling:** `gb-engine` now keeps per-symbol `StrategyContext` market buffers incrementally, reuses the live context across hot-path callbacks, and ships a Criterion benchmark covering representative 10-symbol/6-month and 50-symbol/1-year workloads instead of rebuilding full-history buffers on every callback.
 - **Catalog durability:** `gb-data` now reloads persisted `symbol_metadata` rows when `DataCatalog` starts, so symbol listings, metadata lookups, and catalog stats survive process restarts instead of disappearing from the in-memory cache.

--- a/docs/tutorials/reproducing-a-run.md
+++ b/docs/tutorials/reproducing-a-run.md
@@ -1,0 +1,51 @@
+# Reproducing a Run
+
+GlowBack backtest results now include a `manifest` payload that captures the
+engine version, dataset fingerprint, execution knobs, and a replayable request
+shape for the run.
+
+## Fetch a completed run
+
+```bash
+curl -s \
+  -H "X-API-Key: $API_KEY" \
+  http://localhost:8000/backtests/<run-id>/results > run-result.json
+```
+
+The response contains a top-level `manifest` object.
+
+## Replay locally
+
+Use the shared Python runtime helper to rerun the exact backtest request encoded
+in the manifest:
+
+```python
+import json
+from pathlib import Path
+
+from glowback_runtime import compare_manifest_metrics, replay_manifest
+
+result = json.loads(Path("run-result.json").read_text())
+manifest = result["manifest"]
+replay = replay_manifest(manifest)
+comparison = compare_manifest_metrics(manifest, replay, tolerance=1e-6)
+
+print(comparison)
+```
+
+## What gets captured
+
+The current manifest slice includes:
+
+- engine crate + version
+- strategy id/name + parameter payload
+- data source, symbol universe, resolution, date range, and per-symbol bar counts
+- execution knobs used by the engine-backed API path
+- a replay-ready request payload
+- headline metrics for replay comparison
+
+## Tolerances
+
+For the current built-in strategy replay path, the documented expectation is an
+exact match on the captured headline metrics when replaying deterministic sample
+or CSV-backed runs. The helper uses a default absolute tolerance of `1e-6`.

--- a/glowback_runtime.py
+++ b/glowback_runtime.py
@@ -18,6 +18,36 @@ SUPPORTED_STRATEGIES: dict[str, str] = {
     "rsi": "rsi",
 }
 
+_MANIFEST_REQUIRED_FIELDS = (
+    "manifest_version",
+    "generated_at",
+    "engine",
+    "strategy",
+    "dataset",
+    "execution",
+    "replay_request",
+    "metric_snapshot",
+)
+
+_REPLAY_REQUIRED_FIELDS = (
+    "symbols",
+    "start_date",
+    "end_date",
+    "resolution",
+    "strategy_name",
+    "strategy_params",
+    "initial_capital",
+    "data_source",
+)
+
+_METRIC_SNAPSHOT_KEYS = (
+    "final_value",
+    "total_return",
+    "max_drawdown",
+    "sharpe_ratio",
+    "total_trades",
+)
+
 
 def normalize_strategy_name(name: str | None) -> str:
     raw = (name or "buy_and_hold").strip().lower()
@@ -47,6 +77,74 @@ def _load_glowback():
             "`maturin develop -m crates/gb-python/Cargo.toml` from the repo root."
         ) from exc
     return glowback
+
+
+def validate_run_manifest(manifest: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(manifest, dict):
+        raise ValueError("run manifest must be a dictionary")
+
+    missing = [field for field in _MANIFEST_REQUIRED_FIELDS if field not in manifest]
+    if missing:
+        raise ValueError(f"run manifest missing required fields: {', '.join(missing)}")
+
+    replay_request = manifest.get("replay_request")
+    if not isinstance(replay_request, dict):
+        raise ValueError("run manifest replay_request must be an object")
+
+    replay_missing = [field for field in _REPLAY_REQUIRED_FIELDS if field not in replay_request]
+    if replay_missing:
+        raise ValueError(
+            f"run manifest replay_request missing required fields: {', '.join(replay_missing)}"
+        )
+
+    metric_snapshot = manifest.get("metric_snapshot")
+    if not isinstance(metric_snapshot, dict):
+        raise ValueError("run manifest metric_snapshot must be an object")
+
+    metric_missing = [field for field in _METRIC_SNAPSHOT_KEYS if field not in metric_snapshot]
+    if metric_missing:
+        raise ValueError(
+            f"run manifest metric_snapshot missing required fields: {', '.join(metric_missing)}"
+        )
+
+    return manifest
+
+
+def replay_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    validated = validate_run_manifest(manifest)
+    replay_request = dict(validated["replay_request"])
+    return run_backtest(**replay_request)
+
+
+def compare_manifest_metrics(
+    manifest: dict[str, Any],
+    replay_payload: dict[str, Any],
+    *,
+    tolerance: float = 1e-6,
+) -> dict[str, Any]:
+    validated = validate_run_manifest(manifest)
+    metric_snapshot = validated["metric_snapshot"]
+    deltas: dict[str, float] = {}
+    within_tolerance = True
+
+    for key in _METRIC_SNAPSHOT_KEYS:
+        expected = float(metric_snapshot[key])
+        if key == "total_trades":
+            actual = float(replay_payload.get(key, replay_payload.get("metrics_summary", {}).get(key, 0.0)))
+        else:
+            actual = float(
+                replay_payload.get(key, replay_payload.get("metrics_summary", {}).get(key, 0.0))
+            )
+        delta = actual - expected
+        deltas[key] = delta
+        if abs(delta) > tolerance:
+            within_tolerance = False
+
+    return {
+        "within_tolerance": within_tolerance,
+        "tolerance": tolerance,
+        "deltas": deltas,
+    }
 
 
 def run_backtest(
@@ -96,6 +194,7 @@ def run_backtest(
     logs = list(result.logs)
     final_positions = dict(result.final_positions)
     final_cash = float(result.final_cash)
+    manifest = dict(result.manifest) if result.manifest is not None else None
 
     payload: dict[str, Any] = {
         "metrics_summary": metrics_summary,
@@ -105,6 +204,7 @@ def run_backtest(
         "logs": logs,
         "final_cash": final_cash,
         "final_positions": final_positions,
+        "manifest": manifest,
     }
     payload.update(metrics_summary)
     payload.setdefault("initial_capital", float(initial_capital))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Strategy Templates: tutorials/strategy-templates.md
       - Notebook Workflow: tutorials/notebook.md
       - UI Workflow: tutorials/ui-workflow.md
+      - Reproducing a Run: tutorials/reproducing-a-run.md
   - Examples: examples/index.md
   - Deployment: deployment.md
   - Architecture: architecture.md


### PR DESCRIPTION
## Summary
- add a typed replayable `RunManifest` lineage model to engine backtest results
- expose manifests through the Python bindings and API/runtime surfaces, plus replay helpers/tests
- document how to reproduce a run from the captured manifest payload

## Testing
- cargo test -p gb-types -p gb-engine -p gb-python
- python -m unittest api.tests.test_backtest_adapter api.tests.test_experiment_registry api.tests.test_run_manifest
- mkdocs build --strict
