### PR TITLE
Fix #104: add execution lifecycle events and participation caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ High‑performance quantitative backtesting platform built in Rust with Python b
 
 GlowBack provides a fast, realistic backtesting engine with data management, storage, and analytics. It includes:
 
-- Event‑driven simulation engine with slippage/latency/commission models
+- Event‑driven simulation engine with slippage/latency/commission models, order lifecycle events, and participation-capped partial fills
 - Data ingestion (CSV, Alpha Vantage, explicit sample/demo data)
 - Arrow/Parquet columnar storage and SQLite metadata catalog
 - Strategy library (4 built‑in strategies)
@@ -51,7 +51,7 @@ Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress
 - Realistic market simulation with configurable market hours and resolution
 - Multi‑asset backtesting: equities and crypto (spot) with asset-class-aware fees, market hours, and fractional quantities
 - Portfolio accounting now marks positions with signed market value so short liabilities reduce equity correctly; `gb-types` ships deterministic accounting invariants coverage for long, short, fractional, and multi-asset books
-- Multi‑symbol backtesting with chronological event ordering
+- Multi‑symbol backtesting with chronological event ordering and auditable order submission/fill/cancel/expire traces
 - Performance analytics (Sharpe, Sortino, Calmar, CAGR, Max Drawdown, etc.)
 - Risk analytics (VaR, CVaR, skewness, kurtosis)
 - Strategy library: Buy & Hold, Moving Average Crossover, Momentum, Mean Reversion, RSI

--- a/api/app/adapter.py
+++ b/api/app/adapter.py
@@ -411,6 +411,7 @@ class RealEngineAdapter:
                 benchmark_symbol=benchmark_symbol,
                 trades=result_payload.get("trades", []),
                 exposures=result_payload.get("exposures", []),
+                order_events=result_payload.get("order_events", []),
                 portfolio_construction=result_payload.get("portfolio_construction") or requested_portfolio,
                 portfolio_diagnostics=result_payload.get("portfolio_diagnostics", []),
                 constraint_hits=result_payload.get("constraint_hits", []),

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -119,6 +119,7 @@ class BacktestResult(BaseModel):
     benchmark_symbol: str | None = None
     trades: list[dict[str, Any]] = Field(default_factory=list)
     exposures: list[dict[str, Any]] = Field(default_factory=list)
+    order_events: list[dict[str, Any]] = Field(default_factory=list)
     portfolio_construction: dict[str, Any] = Field(default_factory=dict)
     portfolio_diagnostics: list[dict[str, Any]] = Field(default_factory=list)
     constraint_hits: list[dict[str, Any]] = Field(default_factory=list)

--- a/crates/gb-engine/src/engine.rs
+++ b/crates/gb-engine/src/engine.rs
@@ -5,10 +5,10 @@ use chrono::{DateTime, Duration, Utc};
 use gb_data::DataManager;
 use gb_types::{
     BacktestConfig, BacktestError, BacktestResult, Bar, EquityCurvePoint, Fill, GbResult,
-    LatencyModel, MarketDataBuffer, MarketEvent, Order, Portfolio, ReplayRequestManifest,
-    RunDatasetManifest, RunEngineManifest, RunExecutionManifest, RunManifest, RunMetricSnapshot,
-    RunStrategyManifest, Side, SlippageModel, Strategy, StrategyContext, StrategyMetrics, Symbol,
-    TradeRecord,
+    LatencyModel, MarketDataBuffer, MarketEvent, Order, OrderEvent, OrderStatus, OrderType,
+    Portfolio, ReplayRequestManifest, RunDatasetManifest, RunEngineManifest, RunExecutionManifest,
+    RunManifest, RunMetricSnapshot, RunStrategyManifest, Side, SlippageModel, Strategy,
+    StrategyContext, StrategyMetrics, Symbol, TimeInForce, TradeRecord,
 };
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -19,6 +19,17 @@ const STRATEGY_MARKET_DATA_WINDOW: usize = 100;
 
 fn decimal_to_f64(value: Decimal) -> f64 {
     value.to_f64().unwrap_or(0.0)
+}
+
+enum ExecutionDecision {
+    Pending,
+    Fill {
+        fill_quantity: Decimal,
+        execution_price: Decimal,
+        keep_open: bool,
+        remainder_event: Option<OrderEvent>,
+    },
+    Terminal(OrderEvent),
 }
 
 fn execution_commission_bps(settings: &gb_types::ExecutionSettings) -> Option<f64> {
@@ -61,6 +72,7 @@ pub struct Engine {
     strategy_metrics: StrategyMetrics,
     equity_curve: Vec<EquityCurvePoint>,
     trade_log: Vec<TradeRecord>,
+    order_events: Vec<OrderEvent>,
     equity_peak: Decimal,
 }
 
@@ -153,6 +165,7 @@ impl Engine {
             strategy_metrics,
             equity_curve: Vec::new(),
             trade_log: Vec::new(),
+            order_events: Vec::new(),
         })
     }
 
@@ -268,64 +281,80 @@ impl Engine {
 
     /// Execute pending orders based on current market conditions
     async fn execute_pending_orders(&mut self) -> GbResult<()> {
-        let mut executed_orders = Vec::new();
+        let mut remaining_liquidity: HashMap<(Symbol, usize), Decimal> = HashMap::new();
+        let mut next_pending_orders = Vec::new();
         let mut order_events_to_process = Vec::new();
+        let pending_orders = std::mem::take(&mut self.pending_orders);
 
-        for (index, order) in self.pending_orders.iter().enumerate() {
-            if let Some(fill) = self.try_execute_order(order).await? {
-                // Apply fill to portfolio
-                self.portfolio.apply_fill(&fill);
-
-                // Update strategy metrics - just count total trades here
-                // Win/loss determination should be based on P&L, not just execution
-                self.strategy_metrics.total_trades += 1;
-
-                // Log execution
-                info!(
-                    "Executed order: {:?} {} {} at {} (commission {})",
-                    order.side, order.quantity, order.symbol, fill.price, fill.commission
-                );
-                self.trade_log
-                    .push(self.trade_record_from_fill(order, &fill));
-
-                // Prepare order event for strategy callback
-                order_events_to_process.push(gb_types::OrderEvent::OrderFilled {
-                    order_id: order.id,
-                    fill: fill.clone(),
-                });
-
-                executed_orders.push(index);
-            }
-        }
-
-        // Remove executed orders (in reverse order to maintain indices)
-        for &index in executed_orders.iter().rev() {
-            self.pending_orders.remove(index);
-        }
-
-        if !order_events_to_process.is_empty() {
-            self.sync_strategy_context_account_state();
-        }
-
-        // Notify strategy of order events
-        for order_event in order_events_to_process {
-            let actions = match self
-                .strategy
-                .on_order_event(&order_event, &self.strategy_context)
-            {
-                Ok(actions) => actions,
-                Err(e) => {
-                    warn!("Strategy on_order_event error: {}", e);
-                    continue;
+        for mut order in pending_orders {
+            match self.try_execute_order(&order, &mut remaining_liquidity)? {
+                ExecutionDecision::Pending => {
+                    next_pending_orders.push(order);
                 }
-            };
+                ExecutionDecision::Terminal(event) => {
+                    match &event {
+                        OrderEvent::OrderCanceled { .. } => order.status = OrderStatus::Canceled,
+                        OrderEvent::OrderRejected { .. } => order.status = OrderStatus::Rejected,
+                        OrderEvent::OrderExpired { .. } => order.status = OrderStatus::Expired,
+                        _ => {}
+                    }
+                    order_events_to_process.push(event);
+                }
+                ExecutionDecision::Fill {
+                    fill_quantity,
+                    execution_price,
+                    keep_open,
+                    remainder_event,
+                } => {
+                    let commission = self.calculate_commission(fill_quantity, execution_price);
+                    let mut fill = Fill::new(
+                        order.id,
+                        order.symbol.clone(),
+                        order.side,
+                        fill_quantity,
+                        execution_price,
+                        commission,
+                        order.strategy_id.clone(),
+                    );
+                    fill.executed_at = self.current_time;
 
-            for action in actions {
-                self.process_strategy_action(action)?;
+                    order.fill(fill_quantity, execution_price);
+
+                    self.portfolio.apply_fill(&fill);
+                    self.strategy_metrics.total_trades += 1;
+                    self.trade_log
+                        .push(self.trade_record_from_fill(&order, &fill));
+
+                    info!(
+                        "Executed order: {:?} {} {} at {} (commission {})",
+                        order.side, fill_quantity, order.symbol, fill.price, fill.commission
+                    );
+
+                    order_events_to_process.push(OrderEvent::OrderFilled {
+                        order_id: order.id,
+                        fill,
+                    });
+
+                    if let Some(event) = remainder_event {
+                        match &event {
+                            OrderEvent::OrderCanceled { .. } => {
+                                order.status = OrderStatus::Canceled
+                            }
+                            OrderEvent::OrderExpired { .. } => order.status = OrderStatus::Expired,
+                            _ => {}
+                        }
+                        order_events_to_process.push(event);
+                    }
+
+                    if keep_open {
+                        next_pending_orders.push(order);
+                    }
+                }
             }
         }
 
-        Ok(())
+        self.pending_orders = next_pending_orders;
+        self.record_order_events(order_events_to_process)
     }
 
     fn latency_bar_offset(&self) -> usize {
@@ -404,38 +433,204 @@ impl Engine {
         }
     }
 
-    /// Try to execute a single order
-    async fn try_execute_order(&self, order: &Order) -> GbResult<Option<Fill>> {
-        if let Some(bars) = self.market_data.get(&order.symbol) {
-            let Some(current_index) = bars
-                .iter()
-                .position(|bar| bar.timestamp.date_naive() == self.current_time.date_naive())
-            else {
-                return Ok(None);
-            };
+    fn execution_liquidity_cap(&self, bar: &Bar) -> Decimal {
+        let participation = self
+            .config
+            .execution_settings
+            .max_volume_participation
+            .max(Decimal::ZERO)
+            .min(Decimal::ONE);
+        (bar.volume.abs() * participation).round_dp(6)
+    }
 
-            let execution_index = current_index.saturating_add(self.latency_bar_offset());
-            let Some(bar) = bars.get(execution_index) else {
-                return Ok(None);
-            };
+    fn terminal_event_for_unfilled_order(
+        &self,
+        order: &Order,
+        reason: impl Into<String>,
+    ) -> OrderEvent {
+        let reason = reason.into();
+        match order.time_in_force {
+            TimeInForce::Day => OrderEvent::OrderExpired {
+                order_id: order.id,
+                reason,
+            },
+            TimeInForce::IOC | TimeInForce::FOK => OrderEvent::OrderCanceled {
+                order_id: order.id,
+                reason,
+            },
+            TimeInForce::GTC => OrderEvent::OrderCanceled {
+                order_id: order.id,
+                reason,
+            },
+        }
+    }
 
-            let execution_price = self.apply_slippage(bar.open, order.side);
-            let commission = self.calculate_commission(order.quantity, execution_price);
+    fn base_execution_price(&self, order: &Order, bar: &Bar) -> Option<Decimal> {
+        match order.order_type {
+            OrderType::Market => Some(bar.open),
+            OrderType::Limit { price } => match order.side {
+                Side::Buy if bar.low <= price => Some(bar.open.min(price)),
+                Side::Sell if bar.high >= price => Some(bar.open.max(price)),
+                _ => None,
+            },
+            OrderType::Stop { stop_price } => match order.side {
+                Side::Buy if bar.high >= stop_price => Some(bar.open.max(stop_price)),
+                Side::Sell if bar.low <= stop_price => Some(bar.open.min(stop_price)),
+                _ => None,
+            },
+            OrderType::StopLimit {
+                stop_price,
+                limit_price,
+            } => {
+                let stop_triggered = match order.side {
+                    Side::Buy => bar.high >= stop_price,
+                    Side::Sell => bar.low <= stop_price,
+                };
+                if !stop_triggered {
+                    return None;
+                }
+                match order.side {
+                    Side::Buy if bar.low <= limit_price => Some(bar.open.min(limit_price)),
+                    Side::Sell if bar.high >= limit_price => Some(bar.open.max(limit_price)),
+                    _ => None,
+                }
+            }
+        }
+    }
 
-            let fill = Fill::new(
-                order.id,
-                order.symbol.clone(),
-                order.side,
-                order.quantity,
-                execution_price,
-                commission,
-                order.strategy_id.clone(),
-            );
-
-            return Ok(Some(fill));
+    fn record_order_events(&mut self, order_events: Vec<OrderEvent>) -> GbResult<()> {
+        if order_events.is_empty() {
+            return Ok(());
         }
 
-        Ok(None)
+        self.order_events.extend(order_events.iter().cloned());
+        self.sync_strategy_context_account_state();
+
+        for order_event in order_events {
+            let actions = match self
+                .strategy
+                .on_order_event(&order_event, &self.strategy_context)
+            {
+                Ok(actions) => actions,
+                Err(e) => {
+                    warn!("Strategy on_order_event error: {}", e);
+                    continue;
+                }
+            };
+
+            for action in actions {
+                self.process_strategy_action(action)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn try_execute_order(
+        &self,
+        order: &Order,
+        remaining_liquidity: &mut HashMap<(Symbol, usize), Decimal>,
+    ) -> GbResult<ExecutionDecision> {
+        let Some(bars) = self.market_data.get(&order.symbol) else {
+            return Ok(ExecutionDecision::Terminal(OrderEvent::OrderRejected {
+                order_id: order.id,
+                reason: format!("no market data configured for {}", order.symbol),
+            }));
+        };
+
+        let Some(current_index) = bars
+            .iter()
+            .position(|bar| bar.timestamp.date_naive() == self.current_time.date_naive())
+        else {
+            return Ok(ExecutionDecision::Pending);
+        };
+
+        let execution_index = current_index.saturating_add(self.latency_bar_offset());
+        let Some(bar) = bars.get(execution_index) else {
+            return if matches!(order.time_in_force, TimeInForce::GTC) {
+                Ok(ExecutionDecision::Pending)
+            } else {
+                Ok(ExecutionDecision::Terminal(
+                    self.terminal_event_for_unfilled_order(
+                        order,
+                        "latency pushed the order past the available market data window",
+                    ),
+                ))
+            };
+        };
+
+        let Some(base_price) = self.base_execution_price(order, bar) else {
+            return if matches!(order.time_in_force, TimeInForce::GTC) {
+                Ok(ExecutionDecision::Pending)
+            } else {
+                Ok(ExecutionDecision::Terminal(
+                    self.terminal_event_for_unfilled_order(
+                        order,
+                        "order conditions were not met on the current bar",
+                    ),
+                ))
+            };
+        };
+
+        let available_liquidity = remaining_liquidity
+            .entry((order.symbol.clone(), execution_index))
+            .or_insert_with(|| self.execution_liquidity_cap(bar));
+        let fill_quantity = order
+            .remaining_quantity
+            .min((*available_liquidity).max(Decimal::ZERO));
+
+        if matches!(order.time_in_force, TimeInForce::FOK)
+            && fill_quantity < order.remaining_quantity
+        {
+            return Ok(ExecutionDecision::Terminal(OrderEvent::OrderCanceled {
+                order_id: order.id,
+                reason:
+                    "fill-or-kill order could not be fully filled within the configured participation limit"
+                        .to_string(),
+            }));
+        }
+
+        if fill_quantity <= Decimal::ZERO {
+            return if matches!(order.time_in_force, TimeInForce::GTC) {
+                Ok(ExecutionDecision::Pending)
+            } else {
+                Ok(ExecutionDecision::Terminal(
+                    self.terminal_event_for_unfilled_order(
+                        order,
+                        "no executable liquidity available on the current bar",
+                    ),
+                ))
+            };
+        }
+
+        *available_liquidity = (*available_liquidity - fill_quantity).max(Decimal::ZERO);
+        let execution_price = self.apply_slippage(base_price, order.side);
+        let remainder_quantity = order.remaining_quantity - fill_quantity;
+
+        let remainder_event = if remainder_quantity > Decimal::ZERO {
+            match order.time_in_force {
+                TimeInForce::IOC => Some(OrderEvent::OrderCanceled {
+                    order_id: order.id,
+                    reason: "remaining quantity canceled after immediate-or-cancel partial fill"
+                        .to_string(),
+                }),
+                TimeInForce::Day => Some(OrderEvent::OrderExpired {
+                    order_id: order.id,
+                    reason: "remaining quantity expired at the end of the trading bar".to_string(),
+                }),
+                TimeInForce::GTC => None,
+                TimeInForce::FOK => None,
+            }
+        } else {
+            None
+        };
+
+        Ok(ExecutionDecision::Fill {
+            fill_quantity,
+            execution_price,
+            keep_open: remainder_quantity > Decimal::ZERO && remainder_event.is_none(),
+            remainder_event,
+        })
     }
 
     /// Update portfolio values with current market prices
@@ -489,20 +684,48 @@ impl Engine {
         use gb_types::StrategyAction;
 
         match action {
-            StrategyAction::PlaceOrder(order) => {
+            StrategyAction::PlaceOrder(mut order) => {
                 debug!(
                     "Strategy placed order: {:?} {} {} at {:?}",
                     order.side, order.quantity, order.symbol, order.order_type
                 );
-                self.strategy_context.pending_orders.push(order.clone());
-                self.pending_orders.push(order);
+
+                if order.quantity <= Decimal::ZERO {
+                    return self.record_order_events(vec![OrderEvent::OrderRejected {
+                        order_id: order.id,
+                        reason: "order quantity must be positive".to_string(),
+                    }]);
+                }
+
+                if !self.market_data.contains_key(&order.symbol) {
+                    return self.record_order_events(vec![OrderEvent::OrderRejected {
+                        order_id: order.id,
+                        reason: format!("no market data configured for {}", order.symbol),
+                    }]);
+                }
+
+                order.status = OrderStatus::Submitted;
+                order.submitted_at = self.current_time;
+                self.pending_orders.push(order.clone());
+                self.sync_strategy_context_account_state();
+                self.record_order_events(vec![OrderEvent::OrderSubmitted(order)])?;
             }
             StrategyAction::CancelOrder { order_id } => {
                 debug!("Strategy cancelled order: {}", order_id);
-                self.pending_orders.retain(|o| o.id != order_id);
-                self.strategy_context
-                    .pending_orders
-                    .retain(|o| o.id != order_id);
+                let mut cancel_events = Vec::new();
+                self.pending_orders.retain(|order| {
+                    if order.id == order_id {
+                        cancel_events.push(OrderEvent::OrderCanceled {
+                            order_id,
+                            reason: "canceled by strategy".to_string(),
+                        });
+                        false
+                    } else {
+                        true
+                    }
+                });
+                self.sync_strategy_context_account_state();
+                self.record_order_events(cancel_events)?;
             }
             StrategyAction::Log { level, message } => match level {
                 gb_types::LogLevel::Debug => debug!("[Strategy] {}", message),
@@ -620,6 +843,9 @@ impl Engine {
                 slippage_model: execution_settings.slippage_model.clone(),
                 latency_model: execution_settings.latency_model.clone(),
                 market_impact_model: execution_settings.market_impact_model.clone(),
+                max_volume_participation: decimal_to_f64(
+                    execution_settings.max_volume_participation,
+                ),
                 data_settings: self.config.data_settings.clone(),
             },
             replay_request: ReplayRequestManifest {
@@ -743,6 +969,7 @@ impl Engine {
         result.mark_completed(self.portfolio.clone(), self.strategy_metrics.clone());
         result.equity_curve = self.equity_curve.clone();
         result.trade_log = self.trade_log.clone();
+        result.order_events = self.order_events.clone();
         result.performance_metrics = Some(gb_types::PerformanceMetrics::calculate_with_trades(
             &self.portfolio,
             &self.trade_log,
@@ -815,7 +1042,10 @@ impl Engine {
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use gb_types::{OrderEvent, Resolution, Side, StrategyAction, StrategyConfig};
+    use gb_types::{
+        LatencyModel, OrderEvent, OrderStatus, Resolution, Side, StrategyAction, StrategyConfig,
+        TimeInForce,
+    };
 
     #[derive(Debug, Clone)]
     struct NoopStrategy {
@@ -876,7 +1106,7 @@ mod tests {
         Utc.with_ymd_and_hms(2024, 1, day, 0, 0, 0).unwrap()
     }
 
-    fn test_bar(symbol: &Symbol, day: u32, price: i64) -> Bar {
+    fn test_bar_with_volume(symbol: &Symbol, day: u32, price: i64, volume: i64) -> Bar {
         let price = Decimal::from(price);
         Bar::new(
             symbol.clone(),
@@ -885,9 +1115,13 @@ mod tests {
             price,
             price,
             price,
-            Decimal::from(1_000),
+            Decimal::from(volume),
             Resolution::Day,
         )
+    }
+
+    fn test_bar(symbol: &Symbol, day: u32, price: i64) -> Bar {
+        test_bar_with_volume(symbol, day, price, 1_000)
     }
 
     fn test_engine(symbol: Symbol, bars: Vec<Bar>) -> Engine {
@@ -923,6 +1157,7 @@ mod tests {
             strategy_metrics: StrategyMetrics::new("noop".to_string()),
             equity_curve: Vec::new(),
             trade_log: Vec::new(),
+            order_events: Vec::new(),
             equity_peak: Decimal::from(100_000),
         }
     }
@@ -974,7 +1209,7 @@ mod tests {
     #[test]
     fn process_strategy_action_keeps_pending_order_snapshots_in_sync() {
         let symbol = Symbol::equity("AAPL");
-        let mut engine = test_engine(symbol.clone(), Vec::new());
+        let mut engine = test_engine(symbol.clone(), vec![test_bar(&symbol, 1, 100)]);
         let order = Order::market_order(symbol, Side::Buy, Decimal::from(5), "noop".to_string());
         let order_id = order.id;
 
@@ -984,11 +1219,151 @@ mod tests {
         assert_eq!(engine.pending_orders.len(), 1);
         assert_eq!(engine.strategy_context.pending_orders.len(), 1);
         assert_eq!(engine.strategy_context.pending_orders[0].id, order_id);
+        assert!(matches!(
+            engine.order_events.last(),
+            Some(OrderEvent::OrderSubmitted(submitted)) if submitted.id == order_id
+        ));
 
         engine
             .process_strategy_action(StrategyAction::CancelOrder { order_id })
             .unwrap();
         assert!(engine.pending_orders.is_empty());
         assert!(engine.strategy_context.pending_orders.is_empty());
+        assert!(matches!(
+            engine.order_events.last(),
+            Some(OrderEvent::OrderCanceled { order_id: canceled_id, .. }) if *canceled_id == order_id
+        ));
+    }
+
+    #[test]
+    fn process_strategy_action_rejects_non_positive_quantity() {
+        let symbol = Symbol::equity("AAPL");
+        let mut engine = test_engine(symbol.clone(), vec![test_bar(&symbol, 1, 100)]);
+        let mut order = Order::market_order(symbol, Side::Buy, Decimal::ZERO, "noop".to_string());
+        order.quantity = Decimal::ZERO;
+        order.remaining_quantity = Decimal::ZERO;
+
+        engine
+            .process_strategy_action(StrategyAction::PlaceOrder(order.clone()))
+            .unwrap();
+
+        assert!(engine.pending_orders.is_empty());
+        assert!(matches!(
+            engine.order_events.last(),
+            Some(OrderEvent::OrderRejected { order_id, reason }) if *order_id == order.id && reason.contains("positive")
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_pending_orders_partially_fills_gtc_orders_with_participation_limits() {
+        let symbol = Symbol::equity("AAPL");
+        let mut engine = test_engine(
+            symbol.clone(),
+            vec![
+                test_bar_with_volume(&symbol, 1, 100, 1_000),
+                test_bar_with_volume(&symbol, 2, 101, 1_000),
+                test_bar_with_volume(&symbol, 3, 102, 1_000),
+            ],
+        );
+        engine.config.execution_settings.latency_model = LatencyModel::None;
+        engine.config.execution_settings.max_volume_participation = Decimal::new(1, 1); // 10%
+
+        let order = Order::market_order(
+            symbol.clone(),
+            Side::Buy,
+            Decimal::from(150),
+            "noop".to_string(),
+        );
+        engine
+            .process_strategy_action(StrategyAction::PlaceOrder(order))
+            .unwrap();
+
+        engine.current_time = ts(2);
+        engine.execute_pending_orders().await.unwrap();
+        assert_eq!(engine.pending_orders.len(), 1);
+        assert_eq!(
+            engine.pending_orders[0].status,
+            OrderStatus::PartiallyFilled
+        );
+        assert_eq!(
+            engine.pending_orders[0].remaining_quantity,
+            Decimal::from(50)
+        );
+        assert_eq!(
+            engine.portfolio.get_position(&symbol).unwrap().quantity,
+            Decimal::from(100)
+        );
+
+        engine.current_time = ts(3);
+        engine.execute_pending_orders().await.unwrap();
+        assert!(engine.pending_orders.is_empty());
+        assert_eq!(
+            engine.portfolio.get_position(&symbol).unwrap().quantity,
+            Decimal::from(150)
+        );
+        assert_eq!(engine.trade_log.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn execute_pending_orders_cancels_fok_orders_when_liquidity_is_insufficient() {
+        let symbol = Symbol::equity("AAPL");
+        let mut engine = test_engine(
+            symbol.clone(),
+            vec![
+                test_bar_with_volume(&symbol, 1, 100, 1_000),
+                test_bar_with_volume(&symbol, 2, 101, 1_000),
+            ],
+        );
+        engine.config.execution_settings.latency_model = LatencyModel::None;
+        engine.config.execution_settings.max_volume_participation = Decimal::new(1, 1); // 10%
+
+        let mut order =
+            Order::market_order(symbol, Side::Buy, Decimal::from(150), "noop".to_string());
+        order.time_in_force = TimeInForce::FOK;
+        let order_id = order.id;
+        engine
+            .process_strategy_action(StrategyAction::PlaceOrder(order))
+            .unwrap();
+
+        engine.current_time = ts(2);
+        engine.execute_pending_orders().await.unwrap();
+        assert!(engine.pending_orders.is_empty());
+        assert!(engine.portfolio.positions.is_empty());
+        assert!(matches!(
+            engine.order_events.last(),
+            Some(OrderEvent::OrderCanceled { order_id: canceled_id, reason }) if *canceled_id == order_id && reason.contains("fill-or-kill")
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_pending_orders_expires_day_orders_when_not_marketable() {
+        let symbol = Symbol::equity("AAPL");
+        let mut engine = test_engine(
+            symbol.clone(),
+            vec![test_bar(&symbol, 1, 100), test_bar(&symbol, 2, 101)],
+        );
+
+        engine.config.execution_settings.latency_model = LatencyModel::None;
+
+        let mut order = Order::limit_order(
+            symbol,
+            Side::Buy,
+            Decimal::from(10),
+            Decimal::from(90),
+            "noop".to_string(),
+        );
+        order.time_in_force = TimeInForce::Day;
+        let order_id = order.id;
+        engine
+            .process_strategy_action(StrategyAction::PlaceOrder(order))
+            .unwrap();
+
+        engine.current_time = ts(2);
+        engine.execute_pending_orders().await.unwrap();
+        assert!(engine.pending_orders.is_empty());
+        assert!(matches!(
+            engine.order_events.last(),
+            Some(OrderEvent::OrderExpired { order_id: expired_id, reason }) if *expired_id == order_id && reason.contains("conditions were not met")
+        ));
     }
 }

--- a/crates/gb-python/src/lib.rs
+++ b/crates/gb-python/src/lib.rs
@@ -759,6 +759,7 @@ struct PyBacktestResult {
     equity_curve: Vec<EquityPoint>,
     trades: Vec<TradePoint>,
     exposures: Vec<ExposurePoint>,
+    order_events: Vec<serde_json::Value>,
     logs: Vec<String>,
     final_cash: f64,
     final_positions: std::collections::HashMap<String, f64>,
@@ -958,6 +959,12 @@ impl PyBacktestResult {
             })
             .collect::<Vec<_>>();
 
+        let order_events = result
+            .order_events
+            .iter()
+            .filter_map(|event| serde_json::to_value(event).ok())
+            .collect::<Vec<_>>();
+
         let manifest = result
             .manifest
             .as_ref()
@@ -975,6 +982,7 @@ impl PyBacktestResult {
             "Engine-backed backtest completed".to_string(),
             format!("Processed {} equity points", equity_curve.len()),
             format!("Executed {} trades", total_trades as usize),
+            format!("Recorded {} order lifecycle events", order_events.len()),
             format!("Final portfolio value ${:.2}", final_value),
         ];
 
@@ -983,6 +991,7 @@ impl PyBacktestResult {
             equity_curve,
             trades,
             exposures,
+            order_events,
             logs,
             final_cash,
             final_positions,
@@ -1061,6 +1070,18 @@ impl PyBacktestResult {
             let _ = list.append(dict);
         }
         Ok(list.unbind().into())
+    }
+
+    #[getter]
+    fn order_events(&self, py: Python) -> PyResult<PyObject> {
+        let json = py.import("json")?;
+        let payload = serde_json::to_string(&self.order_events).map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Failed to serialize order events: {}",
+                error
+            ))
+        })?;
+        Ok(json.call_method1("loads", (payload,))?.into())
     }
 
     #[getter]

--- a/crates/gb-types/src/backtest.rs
+++ b/crates/gb-types/src/backtest.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::market::{Resolution, Symbol};
+use crate::orders::OrderEvent;
 use crate::portfolio::Portfolio;
 use crate::strategy::{StrategyConfig, StrategyMetrics};
 
@@ -78,6 +79,12 @@ pub struct ExecutionSettings {
     pub slippage_model: SlippageModel,
     pub latency_model: LatencyModel,
     pub market_impact_model: MarketImpactModel,
+    #[serde(default = "default_max_volume_participation")]
+    pub max_volume_participation: Decimal,
+}
+
+fn default_max_volume_participation() -> Decimal {
+    Decimal::new(25, 2)
 }
 
 impl Default for ExecutionSettings {
@@ -91,6 +98,7 @@ impl Default for ExecutionSettings {
             market_impact_model: MarketImpactModel::SquareRoot {
                 factor: Decimal::new(1, 4),
             },
+            max_volume_participation: default_max_volume_participation(),
         }
     }
 }
@@ -196,7 +204,13 @@ pub struct RunExecutionManifest {
     pub slippage_model: SlippageModel,
     pub latency_model: LatencyModel,
     pub market_impact_model: MarketImpactModel,
+    #[serde(default = "default_max_volume_participation_f64")]
+    pub max_volume_participation: f64,
     pub data_settings: DataSettings,
+}
+
+fn default_max_volume_participation_f64() -> f64 {
+    0.25
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -248,6 +262,8 @@ pub struct BacktestResult {
     pub performance_metrics: Option<PerformanceMetrics>,
     pub equity_curve: Vec<EquityCurvePoint>,
     pub trade_log: Vec<TradeRecord>,
+    #[serde(default)]
+    pub order_events: Vec<OrderEvent>,
     pub error_message: Option<String>,
     pub metadata: HashMap<String, serde_json::Value>,
     pub manifest: Option<RunManifest>,
@@ -267,6 +283,7 @@ impl BacktestResult {
             performance_metrics: None,
             equity_curve: Vec::new(),
             trade_log: Vec::new(),
+            order_events: Vec::new(),
             error_message: None,
             metadata: HashMap::new(),
             manifest: None,
@@ -917,6 +934,7 @@ mod tests {
                 slippage_model: SlippageModel::Linear { basis_points: 3 },
                 latency_model: LatencyModel::Fixed { milliseconds: 50 },
                 market_impact_model: MarketImpactModel::None,
+                max_volume_participation: 0.25,
                 data_settings: DataSettings::default(),
             },
             replay_request: ReplayRequestManifest {

--- a/crates/gb-types/src/orders.rs
+++ b/crates/gb-types/src/orders.rs
@@ -22,7 +22,7 @@ impl Side {
             Side::Sell => Side::Buy,
         }
     }
-    
+
     pub fn sign(&self) -> i32 {
         match self {
             Side::Buy => 1,
@@ -35,9 +35,16 @@ impl Side {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum OrderType {
     Market,
-    Limit { price: Decimal },
-    Stop { stop_price: Decimal },
-    StopLimit { stop_price: Decimal, limit_price: Decimal },
+    Limit {
+        price: Decimal,
+    },
+    Stop {
+        stop_price: Decimal,
+    },
+    StopLimit {
+        stop_price: Decimal,
+        limit_price: Decimal,
+    },
 }
 
 /// Time in force specifications
@@ -103,11 +110,16 @@ impl Order {
             metadata: serde_json::Value::Null,
         }
     }
-    
-    pub fn market_order(symbol: Symbol, side: Side, quantity: Decimal, strategy_id: String) -> Self {
+
+    pub fn market_order(
+        symbol: Symbol,
+        side: Side,
+        quantity: Decimal,
+        strategy_id: String,
+    ) -> Self {
         Self::new(symbol, side, quantity, OrderType::Market, strategy_id)
     }
-    
+
     pub fn limit_order(
         symbol: Symbol,
         side: Side,
@@ -115,9 +127,15 @@ impl Order {
         price: Decimal,
         strategy_id: String,
     ) -> Self {
-        Self::new(symbol, side, quantity, OrderType::Limit { price }, strategy_id)
+        Self::new(
+            symbol,
+            side,
+            quantity,
+            OrderType::Limit { price },
+            strategy_id,
+        )
     }
-    
+
     pub fn stop_order(
         symbol: Symbol,
         side: Side,
@@ -125,44 +143,49 @@ impl Order {
         stop_price: Decimal,
         strategy_id: String,
     ) -> Self {
-        Self::new(symbol, side, quantity, OrderType::Stop { stop_price }, strategy_id)
+        Self::new(
+            symbol,
+            side,
+            quantity,
+            OrderType::Stop { stop_price },
+            strategy_id,
+        )
     }
-    
+
     pub fn is_buy(&self) -> bool {
         matches!(self.side, Side::Buy)
     }
-    
+
     pub fn is_sell(&self) -> bool {
         matches!(self.side, Side::Sell)
     }
-    
+
     pub fn is_filled(&self) -> bool {
         self.status == OrderStatus::Filled
     }
-    
+
     pub fn is_active(&self) -> bool {
         matches!(
             self.status,
             OrderStatus::Pending | OrderStatus::Submitted | OrderStatus::PartiallyFilled
         )
     }
-    
+
     pub fn fill(&mut self, quantity: Decimal, price: Decimal) {
         let fill_quantity = quantity.min(self.remaining_quantity);
-        
+
         // Update filled quantity and average price
         let total_filled = self.filled_quantity + fill_quantity;
         if let Some(avg_price) = self.average_fill_price {
-            self.average_fill_price = Some(
-                (avg_price * self.filled_quantity + price * fill_quantity) / total_filled
-            );
+            self.average_fill_price =
+                Some((avg_price * self.filled_quantity + price * fill_quantity) / total_filled);
         } else {
             self.average_fill_price = Some(price);
         }
-        
+
         self.filled_quantity = total_filled;
         self.remaining_quantity = self.quantity - total_filled;
-        
+
         // Update status
         if self.remaining_quantity == Decimal::ZERO {
             self.status = OrderStatus::Filled;
@@ -170,7 +193,7 @@ impl Order {
             self.status = OrderStatus::PartiallyFilled;
         }
     }
-    
+
     pub fn cancel(&mut self) {
         if self.is_active() {
             self.status = OrderStatus::Canceled;
@@ -214,11 +237,11 @@ impl Fill {
             strategy_id,
         }
     }
-    
+
     pub fn gross_amount(&self) -> Decimal {
         self.quantity * self.price
     }
-    
+
     pub fn net_amount(&self) -> Decimal {
         match self.side {
             Side::Buy => -(self.gross_amount() + self.commission),
@@ -234,6 +257,7 @@ pub enum OrderEvent {
     OrderFilled { order_id: OrderId, fill: Fill },
     OrderCanceled { order_id: OrderId, reason: String },
     OrderRejected { order_id: OrderId, reason: String },
+    OrderExpired { order_id: OrderId, reason: String },
 }
 
 impl OrderEvent {
@@ -243,6 +267,7 @@ impl OrderEvent {
             OrderEvent::OrderFilled { order_id, .. } => *order_id,
             OrderEvent::OrderCanceled { order_id, .. } => *order_id,
             OrderEvent::OrderRejected { order_id, .. } => *order_id,
+            OrderEvent::OrderExpired { order_id, .. } => *order_id,
         }
     }
 }
@@ -254,4 +279,4 @@ pub trait OrderManager {
     fn get_order(&self, order_id: OrderId) -> Option<&Order>;
     fn get_active_orders(&self) -> Vec<&Order>;
     fn get_fills(&self) -> Vec<&Fill>;
-} 
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Execution realism:** `gb-engine` now records order lifecycle events, respects time-in-force semantics for day/IOC/FOK orders, and caps fills by a configurable `max_volume_participation` setting so oversized orders can partially fill instead of always executing in one shot.
 - **Run manifests + replayability:** Engine-backed API backtests now emit a typed `manifest` contract with dataset lineage, execution settings, replay-ready request payloads, and headline metric snapshots; Python/runtime helpers can replay the manifest locally and compare results against the captured metrics.
 - **Experiment durability:** GlowBack now persists Streamlit strategy snapshots, completed UI backtest runs, and API backtest history in a shared SQLite-backed experiment registry so saved strategies, comparison runs, and historical `/backtests` listings survive restarts and remain exportable/deletable intentionally.
 - **Engine scaling:** `gb-engine` now keeps per-symbol `StrategyContext` market buffers incrementally, reuses the live context across hot-path callbacks, and ships a Criterion benchmark covering representative 10-symbol/6-month and 50-symbol/1-year workloads instead of rebuilding full-history buffers on every callback.

--- a/docs/concepts/execution-model.md
+++ b/docs/concepts/execution-model.md
@@ -6,8 +6,23 @@ The engine simulates realistic execution:
 - **Slippage**: basis‑point or custom models
 - **Commission**: per‑share or percentage models
 - **Order types**: market, limit, stop, stop‑limit
+- **Time in force**: GTC, day, IOC, and FOK handling in the backtest loop
+- **Liquidity participation**: fills are capped by `execution_settings.max_volume_participation`, so oversized orders can partially fill instead of teleporting through the bar
+- **Lifecycle events**: backtest results now retain submitted / filled / canceled / rejected / expired order events for auditability
 
 The simulator processes events in time order across symbols to avoid look‑ahead bias.
+
+## Order lifecycle slice
+
+GlowBack now applies a first execution-realism slice in the engine itself:
+
+- orders are marked submitted when strategies place them
+- GTC orders can remain open after a partial fill
+- IOC orders cancel any remainder immediately after a partial fill
+- FOK orders cancel when the full requested size cannot be filled inside the configured participation limit
+- day orders expire when their conditions are not met on the execution bar or when only a partial slice is available
+
+This keeps the current engine deterministic while making order outcomes visible to Python and API consumers.
 
 ## Fee Models
 


### PR DESCRIPTION
## Summary
- add real backtest order lifecycle tracking with submitted, filled, canceled, rejected, and expired events
- enforce participation-capped fills plus GTC/day/IOC/FOK handling in `gb-engine`
- surface order events through Python/API results and document the execution-model slice

## Testing
- cargo test --workspace
- python -m unittest api.tests.test_backtest_adapter api.tests.test_run_manifest api.tests.test_experiment_registry

Fixes #104