### PR TITLE
docs: add executable quickstart smoke path

### DIFF
--- a/.github/workflows/docs-smoke.yml
+++ b/.github/workflows/docs-smoke.yml
@@ -1,0 +1,45 @@
+name: Docs Smoke
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "scripts/quickstart.sh"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - ".github/workflows/docs-smoke.yml"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "scripts/quickstart.sh"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - ".github/workflows/docs-smoke.yml"
+  workflow_dispatch:
+
+jobs:
+  quickstart-and-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run quickstart smoke test
+        run: ./scripts/quickstart.sh
+      - name: Build docs strictly
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install mkdocs-material pymdown-extensions
+          mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 High‑performance quantitative backtesting platform built in Rust with Python bindings and a Streamlit UI.
 
 [![CI](https://github.com/LatencyTDH/GlowBack/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/LatencyTDH/GlowBack/actions/workflows/rust.yml)
-[![Tests](https://img.shields.io/badge/tests-56%20passing-brightgreen)](#testing)
+[![Docs Smoke](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs-smoke.yml/badge.svg?branch=main)](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs-smoke.yml)
 [![Docs](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs.yml/badge.svg?branch=main)](https://latencytdh.github.io/GlowBack/)
-[![Rust Version](https://img.shields.io/badge/rust-stable-blue)](#development-setup)
+[![Rust Version](https://img.shields.io/badge/rust-stable-blue)](#getting-started)
 [![Python Support](https://img.shields.io/badge/python-3.8%2B-blue)](#python-bindings)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)
 
@@ -60,33 +60,29 @@ Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress
 
 ## Getting Started
 
-### Development Setup
+### 5-Minute Quickstart
 
 Prerequisites:
 
 - Rust (latest stable)
-- Python 3.8+ (for Python bindings)
+- Python 3.8+ (for docs/UI workflows)
 
 ```bash
-# Clone
-git clone <repository-url>
-cd glowback
-
-# Run tests
-cargo test --workspace
+git clone https://github.com/LatencyTDH/GlowBack.git
+cd GlowBack
+./scripts/quickstart.sh
 ```
 
-### Run Examples
+The quickstart is intentionally executable from a clean checkout: it builds and runs the `gb-types` basic usage example, then verifies the success markers in the output.
+
+### Next Runs
 
 ```bash
-# Basic usage
-cargo run --example basic_usage -p gb-types
+# Re-run the example directly
+cargo run --locked --example basic_usage -p gb-types
 
-# Market simulator tests
-cargo test -p gb-engine simulator
-
-# Parquet loader tests
-cargo test -p gb-data parquet
+# Full workspace tests
+cargo test --workspace --locked
 ```
 
 ### Launch the UI
@@ -129,9 +125,16 @@ bars = manager.load_data(symbol, "2023-01-01T00:00:00Z", "2023-12-31T23:59:59Z",
 ## Testing
 
 ```bash
-cargo test --workspace
-# 25 passed; 0 failed
+cargo test --workspace --locked
+./scripts/quickstart.sh
+mkdocs build --strict
 ```
+
+The badges at the top of this README are sourced from GitHub Actions so they stay aligned with current CI status instead of drifting into stale manual counts.
+
+## Assumptions and Limitations
+
+GlowBack is usable today, but some surfaces are intentionally still alpha. Start with the explicit boundaries in [docs/assumptions-and-limitations.md](docs/assumptions-and-limitations.md) before planning a production workflow.
 
 ## Roadmap
 

--- a/docs/assumptions-and-limitations.md
+++ b/docs/assumptions-and-limitations.md
@@ -1,0 +1,42 @@
+# Assumptions and Limitations
+
+GlowBack already covers a meaningful research workflow, but it is still an alpha system. This page makes the current boundaries explicit so the quickstart and tutorials stay honest.
+
+## Execution and fills
+
+- Backtests use deterministic bar-based execution with configurable commissions, slippage, latency, and participation caps.
+- The engine models realistic order lifecycle events, but it is not a tick-by-tick exchange simulator.
+- Paper/live parity work is still in progress; do not treat paper execution as broker-grade behavior yet.
+
+## Data quality and sourcing
+
+- Sample/demo data is available for smoke tests and tutorials, but production research still depends on the quality of the input data you load.
+- CSV and provider ingestion validate structure, yet corporate actions, survivorship-bias controls, and deeper dataset provenance are still evolving.
+- Alpha Vantage examples are intentionally conservative because free-tier rate limits can dominate the experience.
+
+## Portfolio accounting
+
+- Core long/short/fractional accounting invariants are covered by tests, including signed market value for short liabilities.
+- More advanced cash management edge cases should still be validated with your own scenarios before relying on them for trading decisions.
+- Multi-asset support is strongest for equities and spot crypto; other asset classes remain narrower.
+
+## Optimization workflow
+
+- GlowBack supports real engine-backed optimization flows, but richer overfit diagnostics, cancellation/resume semantics, and scale-out orchestration remain active roadmap work.
+- Treat optimization results as research aids, not proof of live robustness.
+
+## Live and paper trading
+
+- The `gb-live` crate exists, but real broker adapters are intentionally not positioned as production-ready.
+- Safety controls, parity checks, and auditability remain prerequisites before any real-money workflow should be trusted.
+
+## Options workflow
+
+- The `gb-options` crate provides pricing and contract primitives, but end-to-end options backtesting is still incomplete.
+- Use options support as an experimental surface until the documented engine/accounting path is complete.
+
+## How to use this page
+
+- Start with the [Getting Started](getting-started.md) quickstart to verify your checkout.
+- Use the [Examples](examples/index.md) and tutorials as the source of truth for currently exercised workflows.
+- Check the [Roadmap](roadmap.md) before planning around a feature that sits near one of the boundaries above.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,10 +1,36 @@
 # Examples
 
-This section will host runnable examples with expected outputs.
+## Quickstart smoke example
 
-Planned examples:
+This repo now includes an executable quickstart script that proves a clean checkout can run a complete smoke path.
 
-- Buy & Hold on AAPL
+```bash
+./scripts/quickstart.sh
+```
+
+Under the hood it runs:
+
+```bash
+cargo run --locked --example basic_usage -p gb-types
+```
+
+Expected success markers:
+
+```text
+✅ All basic functionality working!
+🎊 Strategy library complete with 4 different strategies!
+```
+
+The quickstart example exercises:
+
+- symbol, bar, cache, and portfolio primitives
+- sample data provider wiring
+- built-in strategy construction
+- basic error handling
+
+## Next examples to add
+
+- Buy & Hold on AAPL with expected metrics snapshot
 - Moving Average Crossover on SPY
 - Momentum strategy with parameter sweep
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,21 +3,37 @@
 ## Prerequisites
 
 - Rust (latest stable)
-- Python 3.8+ (for Python bindings)
+- Python 3.8+ (for docs, API, and UI workflows)
 
-## Clone and Test
+## 5-Minute Quickstart
+
+Clone the repo and run the checked-in quickstart script:
 
 ```bash
 git clone https://github.com/LatencyTDH/GlowBack.git
 cd GlowBack
-cargo test --workspace
+./scripts/quickstart.sh
 ```
 
-## Run an Example
+That script is the same one used by CI. It builds and runs the `gb-types` basic usage example from a clean checkout, then verifies the expected success markers:
+
+- `✅ All basic functionality working!`
+- `🎊 Strategy library complete with 4 different strategies!`
+
+If you want to inspect the underlying command directly, it is:
 
 ```bash
-cargo run --example basic_usage -p gb-types
+cargo run --locked --example basic_usage -p gb-types
 ```
+
+## What the Quickstart Proves
+
+After the script succeeds, you have verified that this checkout can:
+
+- build the core Rust crates needed for the example
+- exercise sample-data loading and portfolio operations
+- instantiate the built-in strategy library
+- finish a runnable end-to-end smoke path without hidden setup
 
 ## Launch the UI
 
@@ -49,6 +65,6 @@ For production deployment details, see the [Deployment Guide](deployment.md).
 
 ## Next Steps
 
-- Load sample data via the UI
-- Try a built‑in strategy template
-- Review results in the dashboard
+- Read the runnable [Examples](examples/index.md) page for the exact quickstart output snapshot.
+- Review [Assumptions and Limitations](assumptions-and-limitations.md) before moving from sample data to real research data.
+- Try the [Reproducing a Run](tutorials/reproducing-a-run.md) tutorial once you have a completed backtest result.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,7 @@ High‑performance quantitative backtesting platform built in Rust with Python b
 ```bash
 git clone https://github.com/LatencyTDH/GlowBack.git
 cd GlowBack
-cargo test --workspace
-cargo run --example basic_usage -p gb-types
+./scripts/quickstart.sh
 ```
 
 ```bash
@@ -26,9 +25,12 @@ python setup.py
 # Opens http://localhost:8501
 ```
 
+The quickstart script is exercised in CI and validates the expected success markers from the basic usage example.
+
 ## Where to go next
 
-- **Getting Started** for setup and first run
+- **Getting Started** for the 5-minute first run and exact success markers
+- **Assumptions & Limitations** for the current product boundaries
 - **Concepts** for data model and execution details
 - **Tutorials** for common workflows
 - **API Reference** for bindings and crate docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Assumptions & Limitations: assumptions-and-limitations.md
   - Concepts:
       - Core Concepts: concepts/core-concepts.md
       - Data Model: concepts/data-model.md

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "error: cargo is required for the GlowBack quickstart" >&2
+  exit 1
+fi
+
+LOG_FILE="$(mktemp)"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "==> Running the GlowBack 5-minute quickstart"
+echo "    Repo: $ROOT_DIR"
+
+cargo run --locked --example basic_usage -p gb-types | tee "$LOG_FILE"
+
+if ! grep -q "✅ All basic functionality working!" "$LOG_FILE"; then
+  echo "error: quickstart did not reach the expected success marker" >&2
+  exit 1
+fi
+
+if ! grep -q "🎊 Strategy library complete with 4 different strategies!" "$LOG_FILE"; then
+  echo "error: quickstart did not print the strategy library summary" >&2
+  exit 1
+fi
+
+echo
+echo "Quickstart succeeded."
+echo "Next steps: docs/getting-started.md, docs/examples/index.md, docs/tutorials/reproducing-a-run.md"


### PR DESCRIPTION
## Summary
- add a checked-in `scripts/quickstart.sh` smoke path that runs `cargo run --locked --example basic_usage -p gb-types` and verifies the expected success markers
- add a `Docs Smoke` GitHub Actions workflow plus README/docs updates so the first-run path is executable and CI-backed instead of relying on stale manual badge counts
- add explicit assumptions/limitations and examples pages so the documentation sets clearer expectations for current alpha surfaces

## Testing
- `./scripts/quickstart.sh`
- `cargo test -p gb-types --locked`
- `mkdocs build --strict`

Roadmap slice: #113
