### PR TITLE
Fix #108: add /v1 API aliases and normalized error envelopes

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -20,13 +20,46 @@ uvicorn app.main:app --reload
 
 The server will be available at http://127.0.0.1:8000 with interactive docs at `/docs`.
 
+## Versioning
+
+`/v1/...` is the canonical public API surface.
+The legacy unversioned routes remain available as compatibility aliases for existing local callers:
+
+- `/v1/backtests` ↔ `/backtests`
+- `/v1/optimizations` ↔ `/optimizations`
+- `/v1/healthz` ↔ `/healthz`
+
+Prefer the versioned routes for new integrations so the contract can evolve without breaking older clients.
+
 ## Endpoints
 
-- `POST /backtests` → create a run (returns `run_id` + status)
-- `GET /backtests` → list runs (filter by state)
-- `GET /backtests/{run_id}` → run status
-- `GET /backtests/{run_id}/results` → results payload
-- `GET /backtests/{run_id}/stream` → WebSocket stream (events)
+- `POST /v1/backtests` → create a run (returns `run_id` + status)
+- `GET /v1/backtests` → list runs (filter by state)
+- `GET /v1/backtests/{run_id}` → run status
+- `GET /v1/backtests/{run_id}/results` → results payload
+- `GET /v1/backtests/{run_id}/stream` → WebSocket stream (events)
+- `POST /v1/optimizations` → create an optimization run
+- `GET /v1/optimizations` → list optimization runs
+- `GET /v1/optimizations/{optimization_id}` → optimization status
+- `GET /v1/optimizations/{optimization_id}/results` → optimization result payload
+- `POST /v1/optimizations/{optimization_id}/cancel` → cancel a running optimization
+
+## Error envelope
+
+Versioned routes return a stable error envelope instead of the legacy FastAPI `detail` payload:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Optimization not found",
+    "details": null
+  },
+  "request_id": "1d4d0ac9-4d45-4f8e-9023-3f682d7d48d4"
+}
+```
+
+Validation failures use `error.code = "validation_error"` with structured `details` entries from FastAPI/Pydantic.
 
 ## Notes
 

--- a/api/app/errors.py
+++ b/api/app/errors.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+
+class ApiErrorBody(BaseModel):
+    code: str = Field(description="Stable machine-readable error code")
+    message: str = Field(description="Human-readable summary of the failure")
+    details: Any | None = Field(default=None, description="Optional structured validation or debugging details")
+
+
+class ApiErrorEnvelope(BaseModel):
+    error: ApiErrorBody
+    request_id: str | None = Field(default=None, description="Request correlation id echoed from X-Request-ID when available")
+
+
+VERSIONED_ERROR_RESPONSES = {
+    401: {"model": ApiErrorEnvelope, "description": "Invalid or missing API key"},
+    404: {"model": ApiErrorEnvelope, "description": "Requested resource was not found"},
+    409: {"model": ApiErrorEnvelope, "description": "Request conflicts with current resource state"},
+    413: {"model": ApiErrorEnvelope, "description": "Request body exceeded the configured size limit"},
+    422: {"model": ApiErrorEnvelope, "description": "Request validation failed"},
+    429: {"model": ApiErrorEnvelope, "description": "Client exceeded the configured rate limit"},
+    500: {"model": ApiErrorEnvelope, "description": "Unexpected server error"},
+}
+
+
+def is_versioned_path(path: str) -> bool:
+    return path == "/v1" or path.startswith("/v1/")
+
+
+def _status_code_name(status_code: int) -> str:
+    try:
+        phrase = HTTPStatus(status_code).phrase.lower().replace(" ", "_")
+    except ValueError:
+        phrase = "http_error"
+    return phrase
+
+
+def build_error_payload(
+    *,
+    status_code: int,
+    message: str,
+    request_id: str | None,
+    details: Any | None = None,
+    code: str | None = None,
+) -> dict[str, Any]:
+    envelope = ApiErrorEnvelope(
+        error=ApiErrorBody(
+            code=code or _status_code_name(status_code),
+            message=message,
+            details=details,
+        ),
+        request_id=request_id,
+    )
+    return jsonable_encoder(envelope)
+
+
+def build_error_response(
+    *,
+    status_code: int,
+    message: str,
+    request_id: str | None,
+    details: Any | None = None,
+    code: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=build_error_payload(
+            status_code=status_code,
+            message=message,
+            request_id=request_id,
+            details=details,
+            code=code,
+        ),
+        headers=headers,
+    )

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,10 +9,17 @@ import time
 import uuid
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, WebSocket, WebSocketDisconnect, status
+from fastapi.exception_handlers import (
+    http_exception_handler as default_http_exception_handler,
+    request_validation_exception_handler as default_request_validation_exception_handler,
+)
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .adapter import RealEngineAdapter
 from .auth import require_api_key, validate_api_key
+from .errors import VERSIONED_ERROR_RESPONSES, build_error_response, is_versioned_path
 from .models import BacktestRequest, BacktestResult, BacktestStatus, RunState
 from .optimization_models import OptimizationRequest, OptimizationResult, OptimizationState, OptimizationStatus
 from .optimization_store import OptimizationStore
@@ -133,6 +140,13 @@ async def audit_middleware(request: Request, call_next):
             content_length,
             _MAX_BODY_BYTES,
         )
+        if is_versioned_path(request.url.path):
+            return build_error_response(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                message="Request body too large",
+                request_id=request_id,
+                code="request_too_large",
+            )
         return Response(
             content='{"detail":"Request body too large"}',
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -175,11 +189,60 @@ async def audit_middleware(request: Request, call_next):
     return response
 
 
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+    if not is_versioned_path(request.url.path):
+        return await default_http_exception_handler(request, exc)
+
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else "Request failed"
+    details = None if isinstance(detail, str) else detail
+    return build_error_response(
+        status_code=exc.status_code,
+        message=message,
+        request_id=getattr(request.state, "request_id", None),
+        details=details,
+        headers=exc.headers,
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    if not is_versioned_path(request.url.path):
+        return await default_request_validation_exception_handler(request, exc)
+
+    return build_error_response(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        message="Request validation failed",
+        request_id=getattr(request.state, "request_id", None),
+        details=exc.errors(),
+        code="validation_error",
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    if not is_versioned_path(request.url.path):
+        return Response(
+            content='{"detail":"Internal Server Error"}',
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            media_type="application/json",
+        )
+
+    return build_error_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        message="Internal server error",
+        request_id=getattr(request.state, "request_id", None),
+        code="internal_error",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Health check (unauthenticated, excluded from rate limiting via path guard)
 # ---------------------------------------------------------------------------
 
 
+@app.get("/v1/healthz", include_in_schema=True, dependencies=[])
 @app.get("/healthz", include_in_schema=True, dependencies=[])
 async def health_check() -> dict:
     """Liveness probe — no auth required."""
@@ -191,6 +254,12 @@ async def health_check() -> dict:
 # ---------------------------------------------------------------------------
 
 
+@app.post(
+    "/v1/backtests",
+    response_model=BacktestStatus,
+    status_code=status.HTTP_201_CREATED,
+    responses=VERSIONED_ERROR_RESPONSES,
+)
 @app.post("/backtests", response_model=BacktestStatus, status_code=status.HTTP_201_CREATED)
 async def create_backtest(request: BacktestRequest) -> BacktestStatus:
     status_obj = await store.create_run(request)
@@ -198,6 +267,7 @@ async def create_backtest(request: BacktestRequest) -> BacktestStatus:
     return status_obj
 
 
+@app.get("/v1/backtests", response_model=list[BacktestStatus], responses=VERSIONED_ERROR_RESPONSES)
 @app.get("/backtests", response_model=list[BacktestStatus])
 async def list_backtests(
     state: RunState | None = Query(default=None),
@@ -206,6 +276,7 @@ async def list_backtests(
     return await store.list_runs(state=state, limit=limit)
 
 
+@app.get("/v1/backtests/{run_id}", response_model=BacktestStatus, responses=VERSIONED_ERROR_RESPONSES)
 @app.get("/backtests/{run_id}", response_model=BacktestStatus)
 async def get_backtest(run_id: str) -> BacktestStatus:
     status_obj = await store.get_status(run_id)
@@ -214,6 +285,11 @@ async def get_backtest(run_id: str) -> BacktestStatus:
     return status_obj
 
 
+@app.get(
+    "/v1/backtests/{run_id}/results",
+    response_model=BacktestResult,
+    responses=VERSIONED_ERROR_RESPONSES,
+)
 @app.get("/backtests/{run_id}/results", response_model=BacktestResult)
 async def get_backtest_results(run_id: str) -> BacktestResult:
     result = await store.get_result(run_id)
@@ -225,6 +301,7 @@ async def get_backtest_results(run_id: str) -> BacktestResult:
     return result
 
 
+@app.websocket("/v1/backtests/{run_id}/stream")
 @app.websocket("/backtests/{run_id}/stream")
 async def stream_backtest(
     websocket: WebSocket,
@@ -314,6 +391,12 @@ async def stream_backtest(
 
 
 @app.post(
+    "/v1/optimizations",
+    response_model=OptimizationStatus,
+    status_code=status.HTTP_201_CREATED,
+    responses=VERSIONED_ERROR_RESPONSES,
+)
+@app.post(
     "/optimizations",
     response_model=OptimizationStatus,
     status_code=status.HTTP_201_CREATED,
@@ -325,6 +408,7 @@ async def create_optimization(request: OptimizationRequest) -> OptimizationStatu
     return status_obj
 
 
+@app.get("/v1/optimizations", response_model=list[OptimizationStatus], responses=VERSIONED_ERROR_RESPONSES)
 @app.get("/optimizations", response_model=list[OptimizationStatus])
 async def list_optimizations(
     limit: int = Query(default=50, ge=1, le=200),
@@ -333,6 +417,11 @@ async def list_optimizations(
     return await opt_store.list_optimizations(limit=limit)
 
 
+@app.get(
+    "/v1/optimizations/{opt_id}",
+    response_model=OptimizationStatus,
+    responses=VERSIONED_ERROR_RESPONSES,
+)
 @app.get("/optimizations/{opt_id}", response_model=OptimizationStatus)
 async def get_optimization(opt_id: str) -> OptimizationStatus:
     """Get current status of an optimization run."""
@@ -344,6 +433,11 @@ async def get_optimization(opt_id: str) -> OptimizationStatus:
     return status_obj
 
 
+@app.get(
+    "/v1/optimizations/{opt_id}/results",
+    response_model=OptimizationResult,
+    responses=VERSIONED_ERROR_RESPONSES,
+)
 @app.get("/optimizations/{opt_id}/results", response_model=OptimizationResult)
 async def get_optimization_results(opt_id: str) -> OptimizationResult:
     """Get full results of a completed optimization run."""
@@ -365,6 +459,7 @@ async def get_optimization_results(opt_id: str) -> OptimizationResult:
     return result
 
 
+@app.post("/v1/optimizations/{opt_id}/cancel", responses=VERSIONED_ERROR_RESPONSES)
 @app.post("/optimizations/{opt_id}/cancel")
 async def cancel_optimization(opt_id: str) -> dict:
     """Cancel a running optimization."""

--- a/api/tests/test_v1_api_contract.py
+++ b/api/tests/test_v1_api_contract.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import time
+import unittest
+
+from fastapi.testclient import TestClient
+
+import api.app.main as main_module
+from api.app.adapter import RealEngineAdapter
+from api.app.models import RunState
+from api.app.optimization_models import (
+    ObjectiveDirection,
+    OptimizationRequest,
+    OptimizationState,
+    ParameterDef,
+    ParameterKind,
+    SearchSpaceConfig,
+    SearchStrategyName,
+    TrialStatus,
+    TrialSummary,
+    ValidationMode,
+)
+from api.app.optimization_runtime import OptimizationExecution
+from api.app.optimization_store import OptimizationStore
+from api.app.store import RunStore
+
+
+class FakeOptimizationExecutor:
+    async def execute(self, request, is_cancelled=None) -> OptimizationExecution:
+        if is_cancelled is not None:
+            cancelled = is_cancelled()
+            if hasattr(cancelled, "__await__"):
+                cancelled = await cancelled
+            if cancelled:
+                return OptimizationExecution(state=OptimizationState.cancelled, trials=[])
+
+        trials = [
+            TrialSummary(
+                trial_id="trial-1",
+                trial_number=1,
+                status=TrialStatus.completed,
+                parameters={"short_period": 5, "long_period": 20},
+                objective=1.25,
+                metrics={
+                    "sharpe_ratio": 1.1,
+                    "validation_sharpe_ratio": 1.25,
+                    "full_sharpe_ratio": 1.1,
+                },
+                duration_seconds=0,
+            ),
+            TrialSummary(
+                trial_id="trial-2",
+                trial_number=2,
+                status=TrialStatus.completed,
+                parameters={"short_period": 8, "long_period": 24},
+                objective=1.55,
+                metrics={
+                    "sharpe_ratio": 1.4,
+                    "validation_sharpe_ratio": 1.55,
+                    "full_sharpe_ratio": 1.4,
+                },
+                duration_seconds=0,
+            ),
+        ]
+        return OptimizationExecution(
+            state=OptimizationState.completed,
+            trials=trials,
+            best_trial=trials[1],
+            replay_backtest={
+                **request.base_backtest,
+                "strategy": {
+                    "name": request.base_backtest["strategy"]["name"],
+                    "params": {"short_period": 8, "long_period": 24},
+                },
+            },
+        )
+
+
+def _sample_request() -> OptimizationRequest:
+    return OptimizationRequest(
+        name="MA Crossover Sweep",
+        description="Regression fixture",
+        search_space=SearchSpaceConfig(
+            parameters=[
+                ParameterDef(
+                    name="short_period",
+                    kind=ParameterKind.int_range,
+                    low=5,
+                    high=20,
+                ),
+                ParameterDef(
+                    name="long_period",
+                    kind=ParameterKind.int_range,
+                    low=20,
+                    high=60,
+                ),
+            ]
+        ),
+        strategy=SearchStrategyName.random,
+        max_trials=2,
+        concurrency=1,
+        objective_metric="sharpe_ratio",
+        direction=ObjectiveDirection.maximize,
+        validation_mode=ValidationMode.walk_forward,
+        validation_fraction=0.25,
+        walk_forward_windows=2,
+        base_backtest={
+            "symbols": ["AAPL"],
+            "start_date": "2020-01-01T00:00:00Z",
+            "end_date": "2024-01-01T00:00:00Z",
+            "resolution": "day",
+            "strategy": {"name": "ma_crossover", "params": {}},
+            "initial_capital": 100000,
+            "data_source": "sample",
+        },
+    )
+
+
+class VersionedApiContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_store = main_module.store
+        self.original_adapter = main_module.adapter
+        self.original_opt_store = main_module.opt_store
+
+        main_module.store = RunStore()
+        main_module.adapter = RealEngineAdapter(main_module.store)
+        main_module.opt_store = OptimizationStore(executor=FakeOptimizationExecutor())
+        self.client = TestClient(main_module.app)
+
+    def tearDown(self) -> None:
+        main_module.store = self.original_store
+        main_module.adapter = self.original_adapter
+        main_module.opt_store = self.original_opt_store
+
+    def test_versioned_backtest_list_alias_exists(self) -> None:
+        response = self.client.get("/v1/backtests")
+        legacy_response = self.client.get("/backtests")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(legacy_response.status_code, 200)
+        self.assertEqual(response.json(), legacy_response.json())
+
+    def test_versioned_backtest_not_found_uses_error_envelope(self) -> None:
+        response = self.client.get("/v1/backtests/missing-run")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+        self.assertEqual(response.json()["error"]["message"], "Run not found")
+        self.assertEqual(response.headers["x-request-id"], response.json()["request_id"])
+
+    def test_legacy_backtest_not_found_keeps_detail_shape(self) -> None:
+        response = self.client.get("/backtests/missing-run")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Run not found"})
+
+    def test_versioned_optimization_validation_error_uses_error_envelope(self) -> None:
+        payload = _sample_request().model_dump(mode="json")
+        payload.pop("name")
+
+        response = self.client.post("/v1/optimizations", json=payload)
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.json()["error"]["code"], "validation_error")
+        self.assertEqual(response.json()["error"]["message"], "Request validation failed")
+        self.assertTrue(
+            any(detail["loc"][-1] == "name" for detail in response.json()["error"]["details"])
+        )
+
+    def test_versioned_optimization_routes_complete_successfully(self) -> None:
+        response = self.client.post("/v1/optimizations", json=_sample_request().model_dump(mode="json"))
+
+        self.assertEqual(response.status_code, 201)
+        created = response.json()
+        self.assertIn(created["state"], {"pending", "running", "completed"})
+        optimization_id = created["optimization_id"]
+
+        result = None
+        for _ in range(50):
+            status_response = self.client.get(f"/v1/optimizations/{optimization_id}")
+            self.assertEqual(status_response.status_code, 200)
+            self.assertIn(status_response.json()["state"], {state.value for state in OptimizationState})
+            if status_response.json()["state"] == OptimizationState.completed.value:
+                result_response = self.client.get(f"/v1/optimizations/{optimization_id}/results")
+                self.assertEqual(result_response.status_code, 200)
+                result = result_response.json()
+                break
+            time.sleep(0.02)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["state"], OptimizationState.completed.value)
+        self.assertEqual(result["best_trial"]["status"], TrialStatus.completed.value)
+        self.assertEqual(result["replay_backtest"]["strategy"]["params"], {"short_period": 8, "long_period": 24})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/api/fastapi.md
+++ b/docs/api/fastapi.md
@@ -16,6 +16,11 @@ uvicorn app.main:app --reload
 
 Interactive docs are available at `/docs`.
 
+## Versioning
+
+`/v1/...` is the canonical contract for external clients.
+The original unversioned routes are still available as compatibility aliases so existing local integrations do not break overnight, but new callers should target `/v1`.
+
 ## Authentication (stub)
 
 If `GLOWBACK_API_KEY` is set in the environment, requests must include either:
@@ -42,15 +47,19 @@ The gateway also sets basic security headers (`X-Content-Type-Options`, `X-Frame
 
 ## REST Endpoints
 
-- `POST /backtests` → create run
-- `GET /backtests` → list runs (filter by state)
-- `GET /backtests/{run_id}` → run status
-- `GET /backtests/{run_id}/results` → results payload
+- `POST /v1/backtests` → create run
+- `GET /v1/backtests` → list runs (filter by state)
+- `GET /v1/backtests/{run_id}` → run status
+- `GET /v1/backtests/{run_id}/results` → results payload
+- `POST /v1/optimizations` → create optimization run
+- `GET /v1/optimizations/{optimization_id}` → optimization status
+- `GET /v1/optimizations/{optimization_id}/results` → optimization result payload
+- `POST /v1/optimizations/{optimization_id}/cancel` → cancel a running optimization
 
 ### Create Run
 
 ```json
-POST /backtests
+POST /v1/backtests
 {
   "symbols": ["AAPL", "MSFT"],
   "start_date": "2024-01-01T00:00:00Z",
@@ -73,9 +82,51 @@ POST /backtests
 }
 ```
 
+### Curl Example
+
+```bash
+curl -X POST http://127.0.0.1:8000/v1/backtests \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: dev-secret' \
+  -d '{
+    "symbols": ["AAPL"],
+    "start_date": "2024-01-01T00:00:00Z",
+    "end_date": "2024-06-30T00:00:00Z",
+    "resolution": "day",
+    "strategy": {"name": "ma_crossover", "params": {"short_period": 10, "long_period": 30}},
+    "initial_capital": 100000,
+    "data_source": "sample"
+  }'
+```
+
+### Python Example
+
+```python
+import requests
+
+payload = {
+    "symbols": ["AAPL"],
+    "start_date": "2024-01-01T00:00:00Z",
+    "end_date": "2024-06-30T00:00:00Z",
+    "resolution": "day",
+    "strategy": {"name": "ma_crossover", "params": {"short_period": 10, "long_period": 30}},
+    "initial_capital": 100000,
+    "data_source": "sample",
+}
+
+response = requests.post(
+    "http://127.0.0.1:8000/v1/backtests",
+    headers={"X-API-Key": "dev-secret"},
+    json=payload,
+    timeout=30,
+)
+response.raise_for_status()
+run_status = response.json()
+```
+
 ## Results Payload (sample)
 
-`GET /backtests/{run_id}/results`
+`GET /v1/backtests/{run_id}/results`
 
 ```json
 {
@@ -198,19 +249,43 @@ Notes:
 - `returns`, `daily_return`, `max_drawdown`, and `volatility` are expressed as percentages.
 - `total_pnl` is an absolute value in account currency.
 
+## Error Envelope
+
+Versioned routes return a normalized error body:
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "loc": ["body", "name"],
+        "msg": "Field required",
+        "type": "missing"
+      }
+    ]
+  },
+  "request_id": "1d4d0ac9-4d45-4f8e-9023-3f682d7d48d4"
+}
+```
+
+Common codes include `validation_error`, `unauthorized`, `not_found`, `conflict`, `too_many_requests`, and `request_too_large`.
+Legacy unversioned routes still use FastAPI's original `{"detail": ...}` shape for compatibility.
+
 ## WebSocket Streaming
 
-`GET /backtests/{run_id}/stream`
+`GET /v1/backtests/{run_id}/stream`
 
 - Emits ordered events with `event_id`, `type`, and `payload`.
 - Clients can pass `?last_event_id=<id>` to resume from a specific event.
 
 ## Notes
 
-- Backtest runs, event history, and completed results are persisted in a local SQLite experiment registry, so `/backtests` survives service restarts.
+- Backtest runs, event history, and completed results are persisted in a local SQLite experiment registry, so `/v1/backtests` survives service restarts.
 - Backtests execute through the same Rust engine-backed path used by the embedded Python runtime.
 - Request `data_source: "sample"` for the built-in sample provider, or `data_source: "csv"` plus `csv_data_path` for local CSV bundles.
 - Benchmark-relative metrics are computed from the returned strategy and benchmark curves, and portfolio-construction fields remain part of the API contract and result payloads when available.
-- `/optimizations` uses the same real `gb-python` execution path for built-in strategies.
+- `/v1/optimizations` uses the same real `gb-python` execution path for built-in strategies.
 - The `manifest` payload is designed to be replayed locally with `glowback_runtime.replay_manifest(...)`; see the "Reproducing a Run" tutorial.
 


### PR DESCRIPTION
## Summary
- add canonical `/v1` aliases for the backtest, optimization, websocket, and health endpoints while keeping the original unversioned routes available as compatibility aliases
- introduce a shared versioned error envelope with request ids and structured validation details, wired into HTTP exceptions, validation failures, and request-size guardrails without breaking legacy callers
- document the versioned contract with curl/Python examples and add regression tests that cover both the new `/v1` behavior and legacy compatibility

## Testing
- `python -m unittest discover -s api/tests -v`
- `mkdocs build --strict`

Fixes #108
