### PR TITLE
Fix #106: add benchmark reporting workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,32 @@
+name: Benchmark Reports
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Run gb-engine benchmark suite
+        run: ./scripts/run-engine-benchmarks.sh artifacts/benchmarks/strategy-context
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: gb-engine-strategy-context-benchmarks
+          path: artifacts/benchmarks/strategy-context
+          if-no-files-found: error
+          retention-days: 30
+      - name: Summarize benchmark report
+        run: cat artifacts/benchmarks/strategy-context/summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ cargo test --workspace
 # 25 passed; 0 failed
 ```
 
+## Benchmarks
+
+```bash
+./scripts/run-engine-benchmarks.sh artifacts/benchmarks/local
+```
+
+This runs the maintained `gb-engine` hot-path benchmark, generates a compact `summary.md` / `summary.json`, and preserves the raw Criterion output for drill-down.
+
+Scheduled and manual CI benchmark runs upload the same artifact structure from `.github/workflows/benchmarks.yml`, so benchmark history is visible without blocking normal pull requests.
+
 ## Roadmap
 
 **In progress**

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -2,8 +2,52 @@
 
 ## Goals
 
-- Backtest 10 years of daily data for ~500 equities in < 60 seconds on an 8‑core dev machine.
+- Backtest 10 years of daily data for ~500 equities in < 60 seconds on an 8-core dev machine.
+- Keep the engine hot paths measurable so performance work is repeatable instead of anecdotal.
 
-## Benchmarks (planned)
+## Current maintained benchmark slice
 
-We will publish reproducible benchmarks once the engine stabilization work is complete.
+The first maintained benchmark suite focuses on the `gb-engine` strategy-context update hot path. It compares the legacy full-context rebuild approach with the current incremental buffer update path across two representative workloads.
+
+| Scenario | Legacy full rebuild | Incremental buffers | Speedup | Throughput gain |
+| --- | ---: | ---: | ---: | ---: |
+| 10 symbols × 126 days | ≈7.8 ms | ≈287 µs | ≈29x | ≈29x |
+| 50 symbols × 252 days | ≈235 ms | ≈4.9 ms | ≈48x | ≈48x |
+
+These numbers come from `cargo bench -p gb-engine --bench strategy_context -- --noplot` on the current codebase. Treat them as a baseline snapshot, not a universal hardware promise. The scheduled CI benchmark artifact is the source of truth for run-to-run comparisons.
+
+## What gets reported
+
+`./scripts/run-engine-benchmarks.sh` now produces a benchmark artifact bundle with:
+
+- `summary.md` — human-readable table for CI job summaries and quick review
+- `summary.json` — machine-readable benchmark metadata for later automation
+- `raw/criterion/` — copied Criterion output for deeper inspection
+
+The summary includes mean runtime, 95% confidence intervals, throughput, and the incremental-vs-legacy speedup for each scenario.
+
+## How to run locally
+
+```bash
+./scripts/run-engine-benchmarks.sh artifacts/benchmarks/local
+```
+
+That command will:
+
+1. run `cargo bench -p gb-engine --bench strategy_context -- --noplot`
+2. collect the Criterion output under `target/criterion/strategy_context_scaling`
+3. generate `summary.md` and `summary.json` in the requested artifact directory
+
+If you only want the raw Criterion output, you can still run the benchmark directly:
+
+```bash
+cargo bench -p gb-engine --bench strategy_context -- --noplot
+```
+
+## CI reporting
+
+Benchmark reporting is intentionally non-blocking for normal PRs.
+
+- `.github/workflows/benchmarks.yml` runs on a weekly schedule and via manual dispatch.
+- The workflow uploads the benchmark artifact bundle so baselines stay visible without making ordinary CI noisy.
+- Once enough history exists, we can add regression thresholds on top of the generated `summary.json` instead of guessing.

--- a/scripts/benchmark_report.py
+++ b/scripts/benchmark_report.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate a compact benchmark summary from Criterion output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCENARIO_RE = re.compile(r"(?P<symbols>\d+)symbols_(?P<days>\d+)days")
+
+
+@dataclass
+class BenchmarkRow:
+    scenario: str
+    symbols: int | None
+    days: int | None
+    implementation: str
+    group_id: str
+    title: str
+    mean_ns: float
+    ci_lower_ns: float
+    ci_upper_ns: float
+    throughput_elements: int | None
+    throughput_elements_per_second: float | None
+    raw_path: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--criterion-root",
+        default="target/criterion/strategy_context_scaling",
+        help="Criterion benchmark group root to scan.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory that will receive summary.md, summary.json, and copied raw Criterion output.",
+    )
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def human_duration(ns: float) -> str:
+    if ns >= 1_000_000_000:
+        return f"{ns / 1_000_000_000:.2f} s"
+    if ns >= 1_000_000:
+        return f"{ns / 1_000_000:.2f} ms"
+    if ns >= 1_000:
+        return f"{ns / 1_000:.2f} µs"
+    return f"{ns:.0f} ns"
+
+
+def human_throughput(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.2f} M bars/s"
+    if value >= 1_000:
+        return f"{value / 1_000:.2f} K bars/s"
+    return f"{value:.2f} bars/s"
+
+
+def parse_rows(criterion_root: Path) -> list[BenchmarkRow]:
+    rows: list[BenchmarkRow] = []
+    for benchmark_path in sorted(criterion_root.rglob("new/benchmark.json")):
+        estimates_path = benchmark_path.with_name("estimates.json")
+        if not estimates_path.exists():
+            continue
+
+        benchmark = read_json(benchmark_path)
+        estimates = read_json(estimates_path)
+
+        mean = estimates.get("mean") or estimates.get("slope")
+        if not mean:
+            continue
+
+        scenario = benchmark.get("value_str") or benchmark.get("directory_name", "")
+        match = SCENARIO_RE.fullmatch(scenario)
+        throughput = benchmark.get("throughput", {}).get("Elements")
+        mean_ns = float(mean["point_estimate"])
+        ci = mean["confidence_interval"]
+        throughput_per_second = None
+        if throughput:
+            throughput_per_second = throughput / (mean_ns / 1_000_000_000)
+
+        rows.append(
+            BenchmarkRow(
+                scenario=scenario,
+                symbols=int(match.group("symbols")) if match else None,
+                days=int(match.group("days")) if match else None,
+                implementation=benchmark.get("function_id") or benchmark.get("full_id", "unknown"),
+                group_id=benchmark.get("group_id", "unknown"),
+                title=benchmark.get("title") or benchmark.get("full_id", "unknown"),
+                mean_ns=mean_ns,
+                ci_lower_ns=float(ci["lower_bound"]),
+                ci_upper_ns=float(ci["upper_bound"]),
+                throughput_elements=throughput,
+                throughput_elements_per_second=throughput_per_second,
+                raw_path=str(benchmark_path.parent.relative_to(criterion_root.parent)),
+            )
+        )
+
+    rows.sort(key=lambda row: ((row.symbols or 0), (row.days or 0), row.scenario, row.implementation))
+    return rows
+
+
+def build_comparisons(rows: list[BenchmarkRow]) -> list[dict[str, Any]]:
+    by_scenario: dict[str, dict[str, BenchmarkRow]] = {}
+    for row in rows:
+        by_scenario.setdefault(row.scenario, {})[row.implementation] = row
+
+    comparisons: list[dict[str, Any]] = []
+    for scenario, implementations in sorted(by_scenario.items()):
+        legacy = implementations.get("legacy_full_rebuild")
+        incremental = implementations.get("incremental_buffers")
+        if not legacy or not incremental:
+            continue
+        comparisons.append(
+            {
+                "scenario": scenario,
+                "symbols": legacy.symbols,
+                "days": legacy.days,
+                "baseline": legacy.implementation,
+                "candidate": incremental.implementation,
+                "speedup": legacy.mean_ns / incremental.mean_ns,
+                "throughput_gain": (
+                    incremental.throughput_elements_per_second / legacy.throughput_elements_per_second
+                    if incremental.throughput_elements_per_second and legacy.throughput_elements_per_second
+                    else None
+                ),
+            }
+        )
+    return comparisons
+
+
+def render_markdown(rows: list[BenchmarkRow], comparisons: list[dict[str, Any]], criterion_root: Path) -> str:
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    git_sha = os.environ.get("GITHUB_SHA") or os.environ.get("GIT_SHA") or "local"
+    lines = [
+        "# GlowBack benchmark report",
+        "",
+        f"- Generated: {generated_at}",
+        f"- Commit: `{git_sha}`",
+        f"- Source: `{criterion_root}`",
+        "- Command: `cargo bench -p gb-engine --bench strategy_context -- --noplot`",
+        "",
+        "## Benchmarks",
+        "",
+        "| Scenario | Implementation | Mean time | 95% CI | Throughput |",
+        "| --- | --- | ---: | ---: | ---: |",
+    ]
+
+    for row in rows:
+        lines.append(
+            "| "
+            f"{row.scenario} | {row.implementation} | {human_duration(row.mean_ns)} | "
+            f"{human_duration(row.ci_lower_ns)} – {human_duration(row.ci_upper_ns)} | "
+            f"{human_throughput(row.throughput_elements_per_second)} |"
+        )
+
+    if comparisons:
+        lines.extend(
+            [
+                "",
+                "## Hot-path comparison",
+                "",
+                "| Scenario | Faster path | Speedup vs legacy | Throughput gain |",
+                "| --- | --- | ---: | ---: |",
+            ]
+        )
+        for comparison in comparisons:
+            throughput_gain = comparison.get("throughput_gain")
+            throughput_text = f"{throughput_gain:.2f}x" if throughput_gain is not None else "n/a"
+            lines.append(
+                f"| {comparison['scenario']} | {comparison['candidate']} | {comparison['speedup']:.2f}x | {throughput_text} |"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Artifact contents",
+            "",
+            "- `summary.json`: machine-readable benchmark summary",
+            "- `raw/criterion/`: copied Criterion output for drill-down and historical inspection",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    criterion_root = Path(args.criterion_root).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    rows = parse_rows(criterion_root)
+    if not rows:
+        raise SystemExit(f"No benchmark results found under {criterion_root}")
+
+    comparisons = build_comparisons(rows)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    raw_dir = output_dir / "raw" / "criterion"
+    if raw_dir.exists():
+        shutil.rmtree(raw_dir)
+    shutil.copytree(criterion_root, raw_dir)
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "git_sha": os.environ.get("GITHUB_SHA") or os.environ.get("GIT_SHA"),
+        "benchmarks": [asdict(row) for row in rows],
+        "comparisons": comparisons,
+    }
+
+    (output_dir / "summary.json").write_text(json.dumps(payload, indent=2) + "\n")
+    (output_dir / "summary.md").write_text(render_markdown(rows, comparisons, criterion_root))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-engine-benchmarks.sh
+++ b/scripts/run-engine-benchmarks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-artifacts/benchmarks/strategy-context}"
+BENCHMARK_GROUP="strategy_context_scaling"
+
+cd "$ROOT_DIR"
+rm -rf "target/criterion/${BENCHMARK_GROUP}" "$OUTPUT_DIR"
+
+cargo bench -p gb-engine --bench strategy_context -- --noplot
+python3 scripts/benchmark_report.py \
+  --criterion-root "target/criterion/${BENCHMARK_GROUP}" \
+  --output-dir "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add a non-blocking scheduled/manual benchmark workflow that runs the maintained `gb-engine` hot-path benchmark and uploads a reusable artifact bundle
- add scripts to turn Criterion output into compact `summary.md` / `summary.json` reports while preserving the raw benchmark data for drill-down
- document the benchmark slice, current baseline numbers, and local run flow in the performance docs and README

## Testing
- `./scripts/run-engine-benchmarks.sh /tmp/glowback-benchmarks-local`
- `cargo test -p gb-engine --locked`
- `python3 -m py_compile scripts/benchmark_report.py`
- `mkdocs build --strict`

Fixes #106
