### PR TITLE
Fix #110: add strategy lifecycle templates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,6 +133,9 @@ jobs:
         run: cargo build -p ${{ matrix.crate }} --locked --verbose
       - name: Run tests (crate)
         run: cargo test -p ${{ matrix.crate }} --locked --verbose
+      - name: Run strategy lifecycle template example
+        if: matrix.crate == 'gb-engine'
+        run: cargo run -p gb-engine --example strategy_lifecycle_template --locked --quiet
 
   full-workspace:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full_workspace == 'true')

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress
 - Performance analytics (Sharpe, Sortino, Calmar, CAGR, Max Drawdown, etc.)
 - Risk analytics (VaR, CVaR, skewness, kurtosis)
 - Strategy library: Buy & Hold, Moving Average Crossover, Momentum, Mean Reversion, RSI
+- Strategy authoring templates for both the Rust engine lifecycle and the UI's local Python runner lifecycle
 - Storage: Arrow/Parquet with batch loading and round‑trip I/O
 - Catalog: SQLite metadata with indexed queries
 
@@ -82,12 +83,18 @@ cargo test --workspace
 # Basic usage
 cargo run --example basic_usage -p gb-types
 
+# Runnable Rust strategy lifecycle template
+cargo run --example strategy_lifecycle_template -p gb-engine --locked
+
 # Market simulator tests
 cargo test -p gb-engine simulator
 
 # Parquet loader tests
 cargo test -p gb-data parquet
 ```
+
+For the UI-side local strategy lifecycle example, see `ui/examples/lifecycle_strategy.py`
+and the matching validation in `ui/tests/test_backtest_core.py`.
 
 ### Launch the UI
 

--- a/crates/gb-engine/examples/strategy_lifecycle_template.rs
+++ b/crates/gb-engine/examples/strategy_lifecycle_template.rs
@@ -1,0 +1,169 @@
+use chrono::{Duration, Utc};
+use gb_engine::BacktestEngine;
+use gb_types::{
+    BacktestConfig, MarketEvent, Order, OrderEvent, Resolution, Side, Strategy, StrategyAction,
+    StrategyConfig, StrategyContext, StrategyMetrics, Symbol,
+};
+use rust_decimal::Decimal;
+use std::error::Error;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Default)]
+struct LifecycleCounts {
+    initialize_calls: usize,
+    market_event_calls: usize,
+    order_event_calls: usize,
+    day_end_calls: usize,
+    stop_calls: usize,
+    sequence: Vec<String>,
+}
+
+#[derive(Clone)]
+struct LifecycleTemplateStrategy {
+    config: StrategyConfig,
+    counts: Arc<Mutex<LifecycleCounts>>,
+    submitted_order: bool,
+}
+
+impl LifecycleTemplateStrategy {
+    fn new(counts: Arc<Mutex<LifecycleCounts>>) -> Self {
+        let mut config = StrategyConfig::new(
+            "lifecycle_template".to_string(),
+            "Lifecycle Template".to_string(),
+        );
+        config.description =
+            "Minimal runnable template showing the engine strategy lifecycle".to_string();
+
+        Self {
+            config,
+            counts,
+            submitted_order: false,
+        }
+    }
+
+    fn record(&self, label: &str) {
+        let mut counts = self.counts.lock().expect("lifecycle counts lock poisoned");
+        counts.sequence.push(label.to_string());
+        match label {
+            "initialize" => counts.initialize_calls += 1,
+            "on_market_event" => counts.market_event_calls += 1,
+            "on_order_event" => counts.order_event_calls += 1,
+            "on_day_end" => counts.day_end_calls += 1,
+            "on_stop" => counts.stop_calls += 1,
+            _ => {}
+        }
+    }
+}
+
+impl Strategy for LifecycleTemplateStrategy {
+    fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
+        self.config = config.clone();
+        self.record("initialize");
+        Ok(())
+    }
+
+    fn on_market_event(
+        &mut self,
+        event: &MarketEvent,
+        context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
+        self.record("on_market_event");
+        if self.submitted_order {
+            return Ok(vec![]);
+        }
+
+        let symbol = event.symbol().clone();
+        let Some(price) = context.get_current_price(&symbol) else {
+            return Ok(vec![]);
+        };
+        let quantity = (context.get_available_cash() * Decimal::new(50, 2)) / price;
+        if quantity <= Decimal::ZERO {
+            return Ok(vec![]);
+        }
+
+        self.submitted_order = true;
+        Ok(vec![StrategyAction::PlaceOrder(Order::market_order(
+            symbol,
+            Side::Buy,
+            quantity,
+            self.config.strategy_id.clone(),
+        ))])
+    }
+
+    fn on_order_event(
+        &mut self,
+        _event: &OrderEvent,
+        _context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
+        self.record("on_order_event");
+        Ok(vec![])
+    }
+
+    fn on_day_end(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+        self.record("on_day_end");
+        Ok(vec![])
+    }
+
+    fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+        self.record("on_stop");
+        Ok(vec![])
+    }
+
+    fn get_config(&self) -> &StrategyConfig {
+        &self.config
+    }
+
+    fn get_metrics(&self) -> StrategyMetrics {
+        StrategyMetrics::new(self.config.strategy_id.clone())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let symbol = Symbol::equity("AAPL");
+    let mut strategy_config = StrategyConfig::new(
+        "lifecycle_template".to_string(),
+        "Lifecycle Template".to_string(),
+    );
+    strategy_config.add_symbol(symbol.clone());
+
+    let mut config = BacktestConfig::new(
+        "Strategy Lifecycle Template".to_string(),
+        strategy_config.clone(),
+    );
+    config.start_date = Utc::now() - Duration::days(5);
+    config.end_date = Utc::now();
+    config.initial_capital = Decimal::from(100_000);
+    config.resolution = Resolution::Day;
+    config.symbols = vec![symbol];
+    config.strategy_config = strategy_config;
+    config.data_settings.data_source = "sample".to_string();
+
+    let counts = Arc::new(Mutex::new(LifecycleCounts::default()));
+    let strategy = Box::new(LifecycleTemplateStrategy::new(Arc::clone(&counts)));
+    let mut engine = BacktestEngine::new(config).await?;
+    let result = engine.run_with_strategy(strategy).await?;
+
+    let final_portfolio = result
+        .final_portfolio
+        .as_ref()
+        .ok_or("expected a final portfolio from the lifecycle template run")?;
+    let counts = counts.lock().expect("lifecycle counts lock poisoned");
+
+    println!("GlowBack strategy lifecycle template completed successfully");
+    println!("Hook counts: {:?}", *counts);
+    println!("Final equity: ${:.2}", final_portfolio.total_equity);
+    println!("Trades recorded: {}", result.trade_log.len());
+
+    if counts.initialize_calls != 1
+        || counts.stop_calls != 1
+        || counts.market_event_calls == 0
+        || counts.order_event_calls == 0
+        || counts.day_end_calls == 0
+        || result.trade_log.is_empty()
+    {
+        return Err("strategy lifecycle template did not exercise the expected hook flow".into());
+    }
+
+    Ok(())
+}

--- a/crates/gb-engine/src/lib.rs
+++ b/crates/gb-engine/src/lib.rs
@@ -826,6 +826,154 @@ mod tests {
         assert_eq!(captured_config.initial_capital, Decimal::from(250000));
     }
 
+    #[tokio::test]
+    async fn test_strategy_lifecycle_contract_calls_expected_hooks() {
+        use gb_types::{
+            MarketEvent, Order, OrderEvent, Side, Strategy, StrategyAction, StrategyConfig,
+            StrategyContext, StrategyMetrics,
+        };
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Debug, Default)]
+        struct LifecycleStats {
+            initialize_calls: usize,
+            market_event_calls: usize,
+            order_event_calls: usize,
+            day_end_calls: usize,
+            stop_calls: usize,
+            sequence: Vec<String>,
+        }
+
+        #[derive(Clone)]
+        struct LifecycleProbeStrategy {
+            config: StrategyConfig,
+            stats: Arc<Mutex<LifecycleStats>>,
+            submitted_order: bool,
+        }
+
+        impl LifecycleProbeStrategy {
+            fn new(stats: Arc<Mutex<LifecycleStats>>) -> Self {
+                Self {
+                    config: StrategyConfig::new(
+                        "lifecycle_probe".to_string(),
+                        "Lifecycle Probe".to_string(),
+                    ),
+                    stats,
+                    submitted_order: false,
+                }
+            }
+
+            fn record(&self, label: &str) {
+                let mut stats = self.stats.lock().unwrap();
+                stats.sequence.push(label.to_string());
+                match label {
+                    "initialize" => stats.initialize_calls += 1,
+                    "on_market_event" => stats.market_event_calls += 1,
+                    "on_order_event" => stats.order_event_calls += 1,
+                    "on_day_end" => stats.day_end_calls += 1,
+                    "on_stop" => stats.stop_calls += 1,
+                    _ => {}
+                }
+            }
+        }
+
+        impl Strategy for LifecycleProbeStrategy {
+            fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
+                self.config = config.clone();
+                self.record("initialize");
+                Ok(())
+            }
+
+            fn on_market_event(
+                &mut self,
+                event: &MarketEvent,
+                context: &StrategyContext,
+            ) -> Result<Vec<StrategyAction>, String> {
+                self.record("on_market_event");
+                if self.submitted_order {
+                    return Ok(vec![]);
+                }
+
+                let symbol = event.symbol().clone();
+                let Some(price) = context.get_current_price(&symbol) else {
+                    return Ok(vec![]);
+                };
+                let quantity = (context.get_available_cash() * Decimal::new(50, 2)) / price;
+                if quantity <= Decimal::ZERO {
+                    return Ok(vec![]);
+                }
+
+                self.submitted_order = true;
+                Ok(vec![StrategyAction::PlaceOrder(Order::market_order(
+                    symbol,
+                    Side::Buy,
+                    quantity,
+                    self.config.strategy_id.clone(),
+                ))])
+            }
+
+            fn on_order_event(
+                &mut self,
+                _event: &OrderEvent,
+                _context: &StrategyContext,
+            ) -> Result<Vec<StrategyAction>, String> {
+                self.record("on_order_event");
+                Ok(vec![])
+            }
+
+            fn on_day_end(
+                &mut self,
+                _context: &StrategyContext,
+            ) -> Result<Vec<StrategyAction>, String> {
+                self.record("on_day_end");
+                Ok(vec![])
+            }
+
+            fn on_stop(
+                &mut self,
+                _context: &StrategyContext,
+            ) -> Result<Vec<StrategyAction>, String> {
+                self.record("on_stop");
+                Ok(vec![])
+            }
+
+            fn get_config(&self) -> &StrategyConfig {
+                &self.config
+            }
+
+            fn get_metrics(&self) -> StrategyMetrics {
+                StrategyMetrics::new(self.config.strategy_id.clone())
+            }
+        }
+
+        let mut config = create_test_config();
+        config.symbols = vec![Symbol::equity("AAPL")];
+        config.start_date = Utc::now() - Duration::days(5);
+        config.end_date = Utc::now();
+
+        let stats = Arc::new(Mutex::new(LifecycleStats::default()));
+        let strategy = Box::new(LifecycleProbeStrategy::new(Arc::clone(&stats)));
+
+        let mut engine = BacktestEngine::new(config).await.unwrap();
+        let result = engine.run_with_strategy(strategy).await.unwrap();
+        assert!(
+            !result.trade_log.is_empty(),
+            "probe strategy should place at least one trade"
+        );
+
+        let stats = stats.lock().unwrap();
+        assert_eq!(stats.initialize_calls, 1);
+        assert!(stats.market_event_calls > 0);
+        assert!(stats.order_event_calls > 0);
+        assert!(stats.day_end_calls > 0);
+        assert_eq!(stats.stop_calls, 1);
+        assert_eq!(
+            stats.sequence.first().map(String::as_str),
+            Some("initialize")
+        );
+        assert_eq!(stats.sequence.last().map(String::as_str), Some("on_stop"));
+    }
+
     // --- Crypto-specific tests ------------------------------------------------
 
     /// Create a backtest config for crypto symbols

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,11 +1,39 @@
 # Examples
 
-This section will host runnable examples with expected outputs.
+These examples are checked-in, runnable, and tied to real validation paths.
 
-Planned examples:
+## Rust engine lifecycle template
 
-- Buy & Hold on AAPL
-- Moving Average Crossover on SPY
-- Momentum strategy with parameter sweep
+- File: `crates/gb-engine/examples/strategy_lifecycle_template.rs`
+- Command:
 
-If you want a specific example, open an issue and it can be added here.
+```bash
+cargo run --example strategy_lifecycle_template -p gb-engine --locked
+```
+
+What it proves:
+
+- the full Rust strategy lifecycle executes end-to-end
+- a custom strategy can submit orders through the real engine
+- hook counts and final portfolio state are inspectable after the run
+
+## Python-facing lifecycle template
+
+- File: `ui/examples/lifecycle_strategy.py`
+- Validation path:
+
+```bash
+python -m unittest ui.tests.test_backtest_core -v
+```
+
+What it proves:
+
+- the UI local runner supports `on_start`, `on_bar`, `on_day_end`, and `on_finish`
+- the example strategy can place trades and emit lifecycle logs
+- the saved example stays executable instead of drifting into pseudo-code
+
+## Related docs
+
+- [Strategy Templates & Lifecycle](../tutorials/strategy-templates.md)
+- [Python API Reference](../api/python.md)
+- [Getting Started](../getting-started.md)

--- a/docs/tutorials/strategy-templates.md
+++ b/docs/tutorials/strategy-templates.md
@@ -1,22 +1,80 @@
-# Strategy Templates
+# Strategy Templates & Lifecycle
 
-The UI includes built‑in templates for common strategies:
+GlowBack now ships two concrete strategy-authoring templates:
 
-- Buy & Hold
-- Moving Average Crossover
-- Momentum
-- Mean Reversion
+- a **Rust engine template** that shows the real lifecycle hooks used by `gb-engine`
+- a **Python-facing UI template** that shows the optional local-runner hooks for custom strategies
 
-## Use in UI
+## Built-in vs custom strategy paths
 
-1. Open **Strategy Editor**.
-2. Choose a template from the dropdown.
-3. Adjust parameters and save the configuration.
+- **Built-in strategies** (`buy_and_hold`, `ma_crossover`, `momentum`, `mean_reversion`, `rsi`) run through the real Rust engine.
+- **Custom Python strategies** in the Strategy Editor run through the local UI runner today.
+- The templates below make that distinction explicit so users can start with the right contract instead of guessing.
 
-## Use in Rust (conceptual)
+## Rust engine lifecycle contract
 
-```rust
-let strategy = MovingAverageCrossoverStrategy::new()
-  .with_fast_period(10)
-  .with_slow_period(30);
+Custom Rust strategies implement the `Strategy` trait in `gb-types` and participate in this lifecycle:
+
+| Hook | When it runs | Typical use |
+| --- | --- | --- |
+| `initialize` | Once before the first bar | load config, validate parameters, seed state |
+| `on_market_event` | For each market event/bar | generate orders or logs |
+| `on_order_event` | After order lifecycle updates | react to fills, cancels, rejects |
+| `on_day_end` | After the final event of each trading day | rebalance counters, end-of-day bookkeeping |
+| `on_stop` | Once at shutdown | cleanup and final summaries |
+
+### Runnable Rust template
+
+Source: `crates/gb-engine/examples/strategy_lifecycle_template.rs`
+
+Run it locally:
+
+```bash
+cargo run --example strategy_lifecycle_template -p gb-engine --locked
 ```
+
+The example:
+
+- creates a minimal custom strategy
+- records every lifecycle hook invocation
+- submits one market order through the real engine
+- prints the hook counts and final portfolio summary
+
+CI also executes this exact example in `.github/workflows/rust.yml`.
+
+## Python-facing lifecycle template
+
+Source: `ui/examples/lifecycle_strategy.py`
+
+The Strategy Editor now includes a **Lifecycle Template** that demonstrates these hooks for local Python strategies:
+
+- `on_start(portfolio, metadata)`
+- `on_bar(bar, portfolio)`
+- `on_day_end(trading_day, portfolio)`
+- `on_finish(portfolio, summary)`
+
+### Available helper payloads
+
+`metadata` includes:
+
+- `symbols`
+- `start`
+- `end`
+- `resolution`
+- `bars`
+
+`summary` includes:
+
+- `final_cash`
+- `final_positions`
+- `final_value`
+- `total_trades`
+
+The UI example intentionally stays simple: it selects a primary symbol in `on_start`, enters once in `on_bar`, emits a daily checkpoint in `on_day_end`, and reports the final state in `on_finish`.
+
+That example is covered by `ui/tests/test_backtest_core.py`, so the Python-facing path is exercised in CI too.
+
+## Recommendation
+
+If you want the most realistic execution path today, start in **Rust** and use the engine template.
+If you want to sketch logic quickly in the UI, start with the **Lifecycle Template** and treat it as a lighter-weight authoring surface until custom strategies run end-to-end through the Rust engine.

--- a/ui/backtest_core.py
+++ b/ui/backtest_core.py
@@ -1232,6 +1232,23 @@ def _run_real_engine_backtest(strategy_name, strategy_code, market_data, config,
     return _enrich_real_engine_results(result, filtered, config.get("benchmark_symbol"), log_queue=log_queue)
 
 
+def _normalize_local_strategy_logs(logs) -> list[str]:
+    if logs is None:
+        return []
+    if isinstance(logs, str):
+        return [logs]
+    if isinstance(logs, (list, tuple)):
+        return [str(log) for log in logs if log is not None and str(log).strip()]
+    return [str(logs)]
+
+
+def _emit_local_strategy_logs(all_logs: list[str], log_queue, prefix: str, logs) -> None:
+    for log in _normalize_local_strategy_logs(logs):
+        log_line = f"{prefix}: {log}" if prefix else log
+        _queue_put(log_queue, log_line)
+        all_logs.append(log_line)
+
+
 def _run_local_strategy_backtest(strategy_code, market_data, config, progress_queue, log_queue):
     namespace = {}
     exec(strategy_code, namespace)
@@ -1255,15 +1272,43 @@ def _run_local_strategy_backtest(strategy_code, market_data, config, progress_qu
     _queue_put(log_queue, f"Initial capital: ${portfolio.initial_cash:,.2f}")
     _queue_put(log_queue, f"Execution costs: commission={commission_rate:.4f}, slippage={slippage_bps:.2f} bps")
 
+    market_data = market_data.reset_index(drop=True)
     total_bars = len(market_data)
+    if total_bars == 0:
+        _queue_put(log_queue, "ERROR: No market data available")
+        return None
+
     equity_curve = []
     all_logs = []
     latest_prices: dict[str, float] = {}
     previous_value = float(portfolio.initial_cash)
+    metadata = {
+        "symbols": list(dict.fromkeys(str(symbol) for symbol in market_data["symbol"].tolist())),
+        "start": pd.Timestamp(market_data["timestamp"].min()),
+        "end": pd.Timestamp(market_data["timestamp"].max()),
+        "resolution": str(market_data["resolution"].iloc[0]),
+        "bars": total_bars,
+    }
+
+    on_start = getattr(strategy, "on_start", None)
+    if callable(on_start):
+        try:
+            _emit_local_strategy_logs(all_logs, log_queue, "START", on_start(portfolio, metadata))
+        except Exception as exc:
+            _queue_put(log_queue, f"ERROR in on_start: {str(exc)}")
+
+    current_day = None
+    on_day_end = getattr(strategy, "on_day_end", None)
+    on_finish = getattr(strategy, "on_finish", None)
 
     for i, row in market_data.iterrows():
+        timestamp = pd.Timestamp(row["timestamp"])
+        trading_day = timestamp.normalize()
+        if current_day is None:
+            current_day = trading_day
+
         bar = SimpleBar(
-            timestamp=row["timestamp"],
+            timestamp=timestamp,
             symbol=row["symbol"],
             open_price=row["open"],
             high=row["high"],
@@ -1274,12 +1319,7 @@ def _run_local_strategy_backtest(strategy_code, market_data, config, progress_qu
         )
 
         try:
-            logs = strategy.on_bar(bar, portfolio)
-            if logs:
-                for log in logs:
-                    log_line = f"{bar.timestamp.strftime('%Y-%m-%d')}: {log}"
-                    _queue_put(log_queue, log_line)
-                    all_logs.append(log_line)
+            _emit_local_strategy_logs(all_logs, log_queue, timestamp.strftime("%Y-%m-%d"), strategy.on_bar(bar, portfolio))
         except Exception as exc:
             _queue_put(log_queue, f"ERROR on {bar.timestamp}: {str(exc)}")
 
@@ -1301,7 +1341,7 @@ def _run_local_strategy_backtest(strategy_code, market_data, config, progress_qu
 
         equity_curve.append(
             {
-                "timestamp": row["timestamp"],
+                "timestamp": timestamp,
                 "value": portfolio_value,
                 "cash": portfolio.cash,
                 "positions": sum(portfolio.positions.values()),
@@ -1313,11 +1353,40 @@ def _run_local_strategy_backtest(strategy_code, market_data, config, progress_qu
         )
         previous_value = portfolio_value
 
+        next_day = None
+        if i + 1 < total_bars:
+            next_day = pd.Timestamp(market_data.iloc[i + 1]["timestamp"]).normalize()
+        if callable(on_day_end) and current_day is not None and current_day != next_day:
+            try:
+                _emit_local_strategy_logs(
+                    all_logs,
+                    log_queue,
+                    f"DAY END {current_day.date().isoformat()}",
+                    on_day_end(current_day, portfolio),
+                )
+            except Exception as exc:
+                _queue_put(log_queue, f"ERROR in on_day_end ({current_day.date().isoformat()}): {str(exc)}")
+        current_day = next_day
+
         progress = (i + 1) / total_bars
         _queue_put(progress_queue, progress)
         time.sleep(0.01)
 
     _queue_put(log_queue, "Backtest completed!")
+
+    if callable(on_finish):
+        summary = {
+            "bars": total_bars,
+            "symbols": metadata["symbols"],
+            "final_cash": portfolio.cash,
+            "final_positions": portfolio.get_positions(),
+            "final_value": portfolio.calculate_value(latest_prices),
+            "total_trades": len(portfolio.trades),
+        }
+        try:
+            _emit_local_strategy_logs(all_logs, log_queue, "FINISH", on_finish(portfolio, summary))
+        except Exception as exc:
+            _queue_put(log_queue, f"ERROR in on_finish: {str(exc)}")
 
     return _finalize_backtest_results(
         market_data,

--- a/ui/examples/lifecycle_strategy.py
+++ b/ui/examples/lifecycle_strategy.py
@@ -1,0 +1,35 @@
+class LifecycleTemplateStrategy:
+    """Example custom strategy showing the optional UI lifecycle hooks."""
+
+    def __init__(self):
+        self.name = "Lifecycle Template"
+        self.primary_symbol = None
+        self.entered = False
+
+    def on_start(self, portfolio, metadata):
+        self.primary_symbol = metadata["symbols"][0]
+        return [
+            f"Prepared {self.primary_symbol} strategy for {metadata['bars']} bars "
+            f"from {metadata['start'].date().isoformat()} to {metadata['end'].date().isoformat()}"
+        ]
+
+    def on_bar(self, bar, portfolio):
+        if bar.symbol != self.primary_symbol:
+            return []
+
+        if not self.entered and portfolio.get_position(bar.symbol) == 0:
+            shares = int(portfolio.cash * 0.50 / bar.close)
+            if shares > 0:
+                portfolio.buy(bar.symbol, shares, bar.close, bar.timestamp)
+                self.entered = True
+                return [f"Entered {shares} shares of {bar.symbol} at ${bar.close:.2f}"]
+        return []
+
+    def on_day_end(self, trading_day, portfolio):
+        return [f"Marked day end for {trading_day.date().isoformat()} with value ${portfolio.value:.2f}"]
+
+    def on_finish(self, portfolio, summary):
+        return [
+            f"Finished with {summary['total_trades']} trades, cash ${summary['final_cash']:.2f}, "
+            f"value ${summary['final_value']:.2f}"
+        ]

--- a/ui/pages/strategy_editor.py
+++ b/ui/pages/strategy_editor.py
@@ -16,6 +16,7 @@ ENGINE_STRATEGY_TYPES = {
     "Mean Reversion": "mean_reversion",
     "Momentum": "momentum",
     "RSI": "rsi",
+    "Lifecycle Template": "custom",
     "Custom Strategy": "custom",
 }
 
@@ -193,6 +194,45 @@ class MomentumStrategy:
             return [f"SELL: {current_position} shares at ${bar.close} (momentum: {momentum*100:.1f}%)"]
         
         return []
+    ''',
+
+    "Lifecycle Template": '''
+# Lifecycle Template
+# Demonstrates the optional local-runner hooks: on_start, on_day_end, and on_finish.
+
+class LifecycleTemplateStrategy:
+    def __init__(self):
+        self.name = "Lifecycle Template"
+        self.primary_symbol = None
+        self.entered = False
+
+    def on_start(self, portfolio, metadata):
+        self.primary_symbol = metadata["symbols"][0]
+        return [
+            f"Prepared {self.primary_symbol} strategy for {metadata['bars']} bars "
+            f"from {metadata['start'].date().isoformat()} to {metadata['end'].date().isoformat()}"
+        ]
+
+    def on_bar(self, bar, portfolio):
+        if bar.symbol != self.primary_symbol:
+            return []
+
+        if not self.entered and portfolio.get_position(bar.symbol) == 0:
+            shares = int(portfolio.cash * 0.50 / bar.close)
+            if shares > 0:
+                portfolio.buy(bar.symbol, shares, bar.close, bar.timestamp)
+                self.entered = True
+                return [f"Entered {shares} shares of {bar.symbol} at ${bar.close:.2f}"]
+        return []
+
+    def on_day_end(self, trading_day, portfolio):
+        return [f"Marked day end for {trading_day.date().isoformat()} with value ${portfolio.value:.2f}"]
+
+    def on_finish(self, portfolio, summary):
+        return [
+            f"Finished with {summary['total_trades']} trades, cash ${summary['final_cash']:.2f}, "
+            f"value ${summary['final_value']:.2f}"
+        ]
     '''
 }
 
@@ -541,12 +581,27 @@ def show_strategy_documentation():
             def __init__(self):
                 self.name = "My Strategy"
                 # Initialize your strategy variables here
+
+            def on_start(self, portfolio, metadata):
+                # Optional: called once before the first bar
+                return []
             
             def on_bar(self, bar, portfolio):
-                # Your strategy logic here
+                # Required: called on each new bar
                 # Return list of log messages (optional)
                 return []
+
+            def on_day_end(self, trading_day, portfolio):
+                # Optional: called once after the final bar of each trading day
+                return []
+
+            def on_finish(self, portfolio, summary):
+                # Optional: called after the backtest completes
+                return []
         ```
+
+        `metadata` includes `symbols`, `start`, `end`, `resolution`, and `bars`.
+        `summary` includes `final_cash`, `final_positions`, `final_value`, and `total_trades`.
         
         ### Available Data
         
@@ -603,6 +658,34 @@ def show_strategy_documentation():
         st.markdown("""
         ### Example Strategies
         
+        **Lifecycle Template:**
+        ```python
+        class LifecycleTemplateStrategy:
+            def __init__(self):
+                self.name = "Lifecycle Template"
+                self.primary_symbol = None
+                self.entered = False
+
+            def on_start(self, portfolio, metadata):
+                self.primary_symbol = metadata["symbols"][0]
+                return [f"Prepared {self.primary_symbol} strategy for {metadata['bars']} bars"]
+
+            def on_bar(self, bar, portfolio):
+                if bar.symbol == self.primary_symbol and not self.entered:
+                    shares = int(portfolio.cash * 0.50 / bar.close)
+                    if shares > 0:
+                        portfolio.buy(bar.symbol, shares, bar.close, bar.timestamp)
+                        self.entered = True
+                        return [f"Entered {shares} shares of {bar.symbol}"]
+                return []
+
+            def on_day_end(self, trading_day, portfolio):
+                return [f"Day end {trading_day.date().isoformat()} value=${portfolio.value:.2f}"]
+
+            def on_finish(self, portfolio, summary):
+                return [f"Final value ${summary['final_value']:.2f}"]
+        ```
+
         **Simple Moving Average:**
         ```python
         class SimpleMA:

--- a/ui/tests/test_backtest_core.py
+++ b/ui/tests/test_backtest_core.py
@@ -261,6 +261,57 @@ class BuyThenSell:
         self.assertTrue(results['attribution'])
         self.assertIn('overview', results['tearsheet'])
 
+    def test_run_backtest_executes_optional_local_strategy_lifecycle_hooks(self):
+        strategy_code = (
+            Path(__file__).resolve().parents[1] / 'examples' / 'lifecycle_strategy.py'
+        ).read_text()
+        market_data = pd.DataFrame(
+            [
+                {
+                    'timestamp': pd.Timestamp('2026-01-01T00:00:00Z'),
+                    'symbol': 'AAPL',
+                    'open': 100.0,
+                    'high': 101.0,
+                    'low': 99.0,
+                    'close': 100.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+                {
+                    'timestamp': pd.Timestamp('2026-01-02T00:00:00Z'),
+                    'symbol': 'AAPL',
+                    'open': 104.0,
+                    'high': 105.0,
+                    'low': 103.0,
+                    'close': 104.0,
+                    'volume': 1000,
+                    'resolution': 'day',
+                },
+            ]
+        )
+
+        log_queue = queue.Queue()
+        results = run_backtest(
+            strategy_code,
+            market_data,
+            {
+                'initial_capital': 1000.0,
+                'strategy_template': 'Lifecycle Template',
+            },
+            queue.Queue(),
+            log_queue,
+        )
+
+        self.assertIsNotNone(results)
+        self.assertGreater(results['final_positions'].get('AAPL', 0), 0)
+        self.assertTrue(any(line.startswith('START: Prepared AAPL strategy') for line in results['logs']))
+        self.assertTrue(any('DAY END 2026-01-01' in line for line in results['logs']))
+        self.assertTrue(any(line.startswith('FINISH: Finished with 1 trades') for line in results['logs']))
+
+        streamed_logs = list(log_queue.queue)
+        self.assertIn('Backtest completed!', streamed_logs)
+        self.assertTrue(any(line.startswith('START:') for line in streamed_logs))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add optional lifecycle hooks to the UI local custom-strategy runner and ship a runnable Lifecycle Template example
- add gb-engine lifecycle contract coverage plus a runnable Rust example executed by CI
- refresh strategy template docs/examples/README so docs-check has matching documentation

## Testing
- python3 -m unittest discover -s ui/tests -v
- cargo test -p gb-engine --locked --quiet
- cargo run -p gb-engine --example strategy_lifecycle_template --locked --quiet
- mkdocs build --strict

Closes #110