### PR TITLE
fix: add paper broker parity audit coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "gb-engine",
  "gb-types",
  "rust_decimal",
  "rust_decimal_macros",

--- a/crates/gb-live/Cargo.toml
+++ b/crates/gb-live/Cargo.toml
@@ -15,5 +15,6 @@ rust_decimal = { workspace = true }
 async-trait = "0.1"
 
 [dev-dependencies]
+gb-engine = { path = "../gb-engine" }
 tokio = { version = "1", features = ["full", "test-util"] }
 rust_decimal_macros = "1.37"

--- a/crates/gb-live/src/engine.rs
+++ b/crates/gb-live/src/engine.rs
@@ -345,7 +345,7 @@ impl<B: Broker, S: Strategy> LiveEngine<B, S> {
                     error!(order_id = %order.id, error = %e, "broker rejected order");
                 }
             },
-            RiskCheckResult::Rejected { reason } => {
+            RiskCheckResult::Rejected { reason, .. } => {
                 self.emit(LiveEngineEvent::OrderRejectedByRisk {
                     order_id: order.id,
                     reason: reason.clone(),

--- a/crates/gb-live/src/paper.rs
+++ b/crates/gb-live/src/paper.rs
@@ -5,7 +5,7 @@
 //! live.
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use gb_types::market::{MarketEvent, Symbol};
 use gb_types::orders::{Fill, Order, OrderId, OrderStatus, OrderType, Side};
 use rust_decimal::Decimal;
@@ -50,6 +50,30 @@ struct PaperPosition {
     average_cost: Decimal,
 }
 
+/// Broker-level audit event categories recorded for paper-trading activity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PaperBrokerAuditKind {
+    Connected,
+    Disconnected,
+    OrderSubmitted,
+    OrderFilled,
+    OrderRejected,
+}
+
+/// Append-only paper-broker audit log entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaperBrokerAuditEntry {
+    pub timestamp: DateTime<Utc>,
+    pub kind: PaperBrokerAuditKind,
+    pub order_id: Option<String>,
+    pub symbol: Option<Symbol>,
+    pub side: Option<Side>,
+    pub quantity: Option<Decimal>,
+    pub price: Option<Decimal>,
+    pub cash: Decimal,
+    pub reason: Option<String>,
+}
+
 /// A fully in-process broker that simulates order execution.
 #[derive(Debug)]
 pub struct PaperBroker {
@@ -61,6 +85,7 @@ pub struct PaperBroker {
     fills: Vec<Fill>,
     latest_prices: HashMap<Symbol, Decimal>,
     subscribed_symbols: Vec<Symbol>,
+    audit_log: Vec<PaperBrokerAuditEntry>,
 }
 
 impl PaperBroker {
@@ -75,6 +100,7 @@ impl PaperBroker {
             fills: Vec::new(),
             latest_prices: HashMap::new(),
             subscribed_symbols: Vec::new(),
+            audit_log: Vec::new(),
         }
     }
 
@@ -114,10 +140,55 @@ impl PaperBroker {
             .unwrap_or(Decimal::ZERO)
     }
 
+    fn record_audit_entry(
+        &mut self,
+        kind: PaperBrokerAuditKind,
+        order_id: Option<String>,
+        symbol: Option<Symbol>,
+        side: Option<Side>,
+        quantity: Option<Decimal>,
+        price: Option<Decimal>,
+        reason: Option<String>,
+    ) {
+        self.audit_log.push(PaperBrokerAuditEntry {
+            timestamp: Utc::now(),
+            kind,
+            order_id,
+            symbol,
+            side,
+            quantity,
+            price,
+            cash: self.cash,
+            reason,
+        });
+    }
+
     fn reject_order(&mut self, order_id: OrderId, reason: &str) {
+        let mut audit_order_id = None;
+        let mut audit_symbol = None;
+        let mut audit_side = None;
+        let mut audit_quantity = None;
+
         if let Some(order) = self.orders.get_mut(&order_id) {
             order.status = OrderStatus::Rejected;
+            audit_order_id = Some(order.id.to_string());
+            audit_symbol = Some(order.symbol.clone());
+            audit_side = Some(order.side);
+            audit_quantity = Some(order.remaining_quantity);
         }
+
+        let audit_price = audit_symbol
+            .as_ref()
+            .and_then(|symbol| self.latest_prices.get(symbol).copied());
+        self.record_audit_entry(
+            PaperBrokerAuditKind::OrderRejected,
+            audit_order_id,
+            audit_symbol,
+            audit_side,
+            audit_quantity,
+            audit_price,
+            Some(reason.to_string()),
+        );
 
         warn!(order_id = %order_id, reason, "paper broker: order rejected");
     }
@@ -232,6 +303,15 @@ impl PaperBroker {
             order.strategy_id.clone(),
         );
         self.fills.push(fill);
+        self.record_audit_entry(
+            PaperBrokerAuditKind::OrderFilled,
+            Some(order_id.to_string()),
+            Some(order.symbol.clone()),
+            Some(order.side),
+            Some(quantity),
+            Some(fill_price),
+            None,
+        );
 
         // Update order status
         if let Some(o) = self.orders.get_mut(&order_id) {
@@ -255,6 +335,11 @@ impl PaperBroker {
         &self.fills
     }
 
+    /// Borrow the append-only paper-broker audit log.
+    pub fn audit_log(&self) -> &[PaperBrokerAuditEntry] {
+        &self.audit_log
+    }
+
     /// Current cash balance.
     pub fn cash(&self) -> Decimal {
         self.cash
@@ -265,12 +350,30 @@ impl PaperBroker {
 impl Broker for PaperBroker {
     async fn connect(&mut self) -> BrokerResult<()> {
         self.connected = true;
+        self.record_audit_entry(
+            PaperBrokerAuditKind::Connected,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         info!("paper broker connected (sandbox mode)");
         Ok(())
     }
 
     async fn disconnect(&mut self) -> BrokerResult<()> {
         self.connected = false;
+        self.record_audit_entry(
+            PaperBrokerAuditKind::Disconnected,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         info!("paper broker disconnected");
         Ok(())
     }
@@ -289,6 +392,9 @@ impl Broker for PaperBroker {
         }
 
         let order_id = order.id;
+        let order_symbol = order.symbol.clone();
+        let order_side = order.side;
+        let order_quantity = order.remaining_quantity;
         order.status = OrderStatus::Submitted;
 
         if order.side == Side::Sell {
@@ -296,6 +402,18 @@ impl Broker for PaperBroker {
             if order.remaining_quantity > available_quantity {
                 order.status = OrderStatus::Rejected;
                 self.orders.insert(order_id, order);
+                self.record_audit_entry(
+                    PaperBrokerAuditKind::OrderRejected,
+                    Some(order_id.to_string()),
+                    Some(order_symbol.clone()),
+                    Some(order_side),
+                    Some(order_quantity),
+                    self.latest_prices.get(&order_symbol).copied(),
+                    Some(
+                        "paper broker does not support short sales; sell quantity exceeds current inventory"
+                            .to_string(),
+                    ),
+                );
                 warn!(
                     order_id = %order_id,
                     symbol = %self.orders[&order_id].symbol,
@@ -313,12 +431,30 @@ impl Broker for PaperBroker {
         {
             if let Some(&price) = self.latest_prices.get(&order.symbol) {
                 self.orders.insert(order_id, order);
+                self.record_audit_entry(
+                    PaperBrokerAuditKind::OrderSubmitted,
+                    Some(order_id.to_string()),
+                    Some(order_symbol),
+                    Some(order_side),
+                    Some(order_quantity),
+                    Some(price),
+                    None,
+                );
                 self.try_fill_order(order_id, price);
                 return Ok(order_id);
             }
         }
 
         self.orders.insert(order_id, order);
+        self.record_audit_entry(
+            PaperBrokerAuditKind::OrderSubmitted,
+            Some(order_id.to_string()),
+            Some(order_symbol.clone()),
+            Some(order_side),
+            Some(order_quantity),
+            self.latest_prices.get(&order_symbol).copied(),
+            None,
+        );
         Ok(order_id)
     }
 
@@ -456,7 +592,13 @@ impl Broker for PaperBroker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
+    use gb_engine::BacktestEngine;
     use gb_types::market::{AssetClass, Bar, Resolution};
+    use gb_types::{
+        BacktestConfig, BuyAndHoldStrategy, ExecutionSettings, LatencyModel, MarketImpactModel,
+        OrderEvent, SlippageModel, StrategyConfig,
+    };
     use rust_decimal_macros::dec;
 
     fn test_symbol() -> Symbol {
@@ -474,6 +616,30 @@ mod tests {
             volume: dec!(1000),
             resolution: Resolution::Day,
         })
+    }
+
+    fn sample_backtest_config() -> BacktestConfig {
+        let mut strategy_config =
+            StrategyConfig::new("paper_replay".into(), "Paper broker parity replay".into());
+        strategy_config.add_symbol(test_symbol());
+
+        let mut config = BacktestConfig::new("Paper broker parity replay".into(), strategy_config);
+        config.start_date = Utc::now() - Duration::days(30);
+        config.end_date = Utc::now();
+        config.initial_capital = dec!(100_000);
+        config.resolution = Resolution::Day;
+        config.symbols = vec![test_symbol()];
+        config.data_settings.data_source = "sample".to_string();
+        config.execution_settings = ExecutionSettings {
+            commission_per_share: Decimal::ZERO,
+            commission_percentage: Decimal::ZERO,
+            minimum_commission: Decimal::ZERO,
+            slippage_model: SlippageModel::None,
+            latency_model: LatencyModel::None,
+            market_impact_model: MarketImpactModel::None,
+            max_volume_participation: Decimal::ONE,
+        };
+        config
     }
 
     #[tokio::test]
@@ -631,6 +797,23 @@ mod tests {
         let balance = broker.get_account_balance().await.unwrap();
         assert!(balance.cash < dec!(100_000));
         assert!(balance.equity > Decimal::ZERO);
+
+        let rejection = broker
+            .audit_log()
+            .iter()
+            .rev()
+            .find(|entry| entry.kind == PaperBrokerAuditKind::OrderRejected)
+            .expect("inventory rejection should be audited");
+        let expected_order_id = sell_id.to_string();
+        assert_eq!(
+            rejection.order_id.as_deref(),
+            Some(expected_order_id.as_str())
+        );
+        assert!(rejection
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("current inventory"));
     }
 
     #[tokio::test]
@@ -646,6 +829,91 @@ mod tests {
         let fill = &broker.get_fills()[0];
         assert_eq!(fill.quantity, dec!(5));
         assert_eq!(fill.side, Side::Buy);
+    }
+
+    #[tokio::test]
+    async fn test_backtest_order_stream_replays_on_paper_broker() {
+        let config = sample_backtest_config();
+        let expected_initial_cash = config.initial_capital;
+        let mut engine = BacktestEngine::new(config).await.unwrap();
+        let result = engine
+            .run_with_strategy(Box::new(BuyAndHoldStrategy::new()))
+            .await
+            .unwrap();
+        let final_portfolio = result
+            .final_portfolio
+            .clone()
+            .expect("completed backtest should produce a portfolio");
+        let expected_fill_count = result
+            .order_events
+            .iter()
+            .filter(|event| matches!(event, OrderEvent::OrderFilled { .. }))
+            .count();
+
+        let mut broker = PaperBroker::new(PaperBrokerConfig {
+            initial_cash: expected_initial_cash,
+            commission_per_share: Decimal::ZERO,
+            slippage_bps: Decimal::ZERO,
+            fill_market_orders_immediately: false,
+        });
+        broker.connect().await.unwrap();
+
+        for event in &result.order_events {
+            match event {
+                OrderEvent::OrderSubmitted(order) => {
+                    broker.submit_order(order.clone()).await.unwrap();
+                }
+                OrderEvent::OrderFilled { fill, .. } => {
+                    broker.process_market_event(&make_bar(fill.symbol.clone(), fill.price));
+                    let replayed_fill = broker
+                        .get_fills()
+                        .last()
+                        .expect("paper replay should emit a fill for each backtest fill");
+                    assert_eq!(replayed_fill.symbol, fill.symbol);
+                    assert_eq!(replayed_fill.side, fill.side);
+                    assert_eq!(replayed_fill.quantity, fill.quantity);
+                    assert_eq!(replayed_fill.price, fill.price);
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            expected_fill_count > 0,
+            "expected backtest to generate fills"
+        );
+        assert_eq!(broker.get_fills().len(), expected_fill_count);
+        assert!(broker.get_open_orders().await.unwrap().is_empty());
+
+        for (symbol, position) in &final_portfolio.positions {
+            if position.quantity != Decimal::ZERO {
+                let final_mark = position.market_value / position.quantity;
+                broker.process_market_event(&make_bar(symbol.clone(), final_mark));
+            }
+        }
+
+        let broker_positions = broker.get_positions().await.unwrap();
+        assert_eq!(broker_positions.len(), final_portfolio.positions.len());
+        for (symbol, position) in &final_portfolio.positions {
+            let replayed_position = broker_positions
+                .iter()
+                .find(|candidate| candidate.symbol == *symbol)
+                .expect("replayed paper broker should retain every backtest position");
+            assert_eq!(replayed_position.quantity, position.quantity);
+            assert_eq!(replayed_position.market_value, position.market_value);
+        }
+
+        let balance = broker.get_account_balance().await.unwrap();
+        assert_eq!(balance.cash, final_portfolio.cash);
+        assert_eq!(balance.equity, final_portfolio.total_equity);
+        assert!(broker
+            .audit_log()
+            .iter()
+            .any(|entry| entry.kind == PaperBrokerAuditKind::OrderSubmitted));
+        assert!(broker
+            .audit_log()
+            .iter()
+            .any(|entry| entry.kind == PaperBrokerAuditKind::OrderFilled));
     }
 
     #[tokio::test]

--- a/crates/gb-live/src/risk.rs
+++ b/crates/gb-live/src/risk.rs
@@ -9,12 +9,46 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::warn;
 
+/// Specific rule that approved or rejected an order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RiskRule {
+    CircuitBreaker,
+    OrderRateLimit,
+    MaxOrderNotional,
+    PositionConcentration,
+    TotalExposure,
+}
+
+/// Audit outcome recorded for each risk decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RiskAuditDecision {
+    Approved,
+    Rejected,
+    WouldReject,
+}
+
+/// Append-only audit log entry for a risk decision.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RiskAuditEntry {
+    pub timestamp: DateTime<Utc>,
+    pub order_id: String,
+    pub symbol: Symbol,
+    pub side: Side,
+    pub quantity: Decimal,
+    pub current_price: Decimal,
+    pub current_equity: Decimal,
+    pub notional: Decimal,
+    pub rule: Option<RiskRule>,
+    pub decision: RiskAuditDecision,
+    pub reason: Option<String>,
+}
+
 /// Result of a risk check — either the order passes or it is rejected with a
 /// human-readable reason.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RiskCheckResult {
     Approved,
-    Rejected { reason: String },
+    Rejected { rule: RiskRule, reason: String },
 }
 
 impl RiskCheckResult {
@@ -84,6 +118,7 @@ struct SessionState {
 pub struct RiskManager {
     config: RiskConfig,
     state: SessionState,
+    audit_log: Vec<RiskAuditEntry>,
 }
 
 impl RiskManager {
@@ -100,6 +135,7 @@ impl RiskManager {
                 circuit_breaker_tripped: false,
                 circuit_breaker_tripped_at: None,
             },
+            audit_log: Vec::new(),
         }
     }
 
@@ -116,8 +152,15 @@ impl RiskManager {
     ) -> RiskCheckResult {
         let result = self.run_checks(order, current_price, current_equity);
 
-        if let RiskCheckResult::Rejected { ref reason } = result {
+        if let RiskCheckResult::Rejected { reason, .. } = &result {
             if self.config.dry_run {
+                self.record_audit_entry(
+                    order,
+                    current_price,
+                    current_equity,
+                    &result,
+                    RiskAuditDecision::WouldReject,
+                );
                 warn!(
                     order_id = %order.id,
                     symbol = %order.symbol,
@@ -128,7 +171,47 @@ impl RiskManager {
             }
         }
 
+        self.record_audit_entry(
+            order,
+            current_price,
+            current_equity,
+            &result,
+            if result.is_approved() {
+                RiskAuditDecision::Approved
+            } else {
+                RiskAuditDecision::Rejected
+            },
+        );
+
         result
+    }
+
+    fn record_audit_entry(
+        &mut self,
+        order: &Order,
+        current_price: Decimal,
+        current_equity: Decimal,
+        result: &RiskCheckResult,
+        decision: RiskAuditDecision,
+    ) {
+        let (rule, reason) = match result {
+            RiskCheckResult::Approved => (None, None),
+            RiskCheckResult::Rejected { rule, reason } => (Some(*rule), Some(reason.clone())),
+        };
+
+        self.audit_log.push(RiskAuditEntry {
+            timestamp: Utc::now(),
+            order_id: order.id.to_string(),
+            symbol: order.symbol.clone(),
+            side: order.side,
+            quantity: order.quantity,
+            current_price,
+            current_equity,
+            notional: order.quantity * current_price,
+            rule,
+            decision,
+            reason,
+        });
     }
 
     /// Run all individual checks in sequence, short-circuiting on the first
@@ -155,6 +238,7 @@ impl RiskManager {
         let notional = order.quantity * current_price;
         if notional > self.config.max_order_notional {
             return RiskCheckResult::Rejected {
+                rule: RiskRule::MaxOrderNotional,
                 reason: format!(
                     "order notional {notional} exceeds limit {}",
                     self.config.max_order_notional
@@ -187,6 +271,7 @@ impl RiskManager {
     fn check_circuit_breaker(&mut self, current_equity: Decimal) -> RiskCheckResult {
         if self.state.circuit_breaker_tripped {
             return RiskCheckResult::Rejected {
+                rule: RiskRule::CircuitBreaker,
                 reason: "circuit breaker tripped — trading halted for the day".into(),
             };
         }
@@ -203,6 +288,7 @@ impl RiskManager {
                     "daily loss circuit breaker tripped"
                 );
                 return RiskCheckResult::Rejected {
+                    rule: RiskRule::CircuitBreaker,
                     reason: format!(
                         "daily loss {loss_pct} exceeds circuit breaker threshold {}",
                         self.config.daily_loss_circuit_breaker
@@ -223,6 +309,7 @@ impl RiskManager {
 
         if self.state.recent_orders.len() >= self.config.max_orders_per_window as usize {
             return RiskCheckResult::Rejected {
+                rule: RiskRule::OrderRateLimit,
                 reason: format!(
                     "order rate limit: {} orders in {} s window",
                     self.config.max_orders_per_window, self.config.order_window_seconds
@@ -261,6 +348,7 @@ impl RiskManager {
 
         if concentration > self.config.limits.position_concentration_limit {
             return RiskCheckResult::Rejected {
+                rule: RiskRule::PositionConcentration,
                 reason: format!(
                     "position concentration {concentration:.2} exceeds limit {}",
                     self.config.limits.position_concentration_limit
@@ -298,6 +386,7 @@ impl RiskManager {
                 mark
             } else {
                 return RiskCheckResult::Rejected {
+                    rule: RiskRule::TotalExposure,
                     reason: format!(
                         "missing mark for existing position {symbol} while computing total exposure"
                     ),
@@ -309,6 +398,7 @@ impl RiskManager {
 
         if new_exposure > self.config.max_total_exposure {
             return RiskCheckResult::Rejected {
+                rule: RiskRule::TotalExposure,
                 reason: format!(
                     "total exposure {new_exposure} would exceed limit {}",
                     self.config.max_total_exposure
@@ -371,6 +461,11 @@ impl RiskManager {
     /// Returns the time at which the circuit breaker was tripped, if at all.
     pub fn circuit_breaker_tripped_at(&self) -> Option<DateTime<Utc>> {
         self.state.circuit_breaker_tripped_at
+    }
+
+    /// Borrow the append-only risk audit log.
+    pub fn audit_log(&self) -> &[RiskAuditEntry] {
+        &self.audit_log
     }
 
     /// Returns a reference to the current risk configuration.
@@ -605,6 +700,105 @@ mod tests {
         let order = Order::market_order(incoming, Side::Buy, dec!(60), "test".into());
         let result = rm.check_order(&order, dec!(100), dec!(100_000));
         assert!(!result.is_approved(), "expected rejection, got {result:?}");
+    }
+
+    #[test]
+    fn test_audit_log_records_max_order_notional_rejection() {
+        let mut rm = default_risk_manager();
+        let order = Order::market_order(test_symbol(), Side::Buy, dec!(1000), "test".into());
+
+        let result = rm.check_order(&order, dec!(150), dec!(100_000));
+        assert!(!result.is_approved());
+
+        let audit = rm.audit_log();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].decision, RiskAuditDecision::Rejected);
+        assert_eq!(audit[0].rule, Some(RiskRule::MaxOrderNotional));
+        assert!(audit[0]
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("order notional"));
+    }
+
+    #[test]
+    fn test_audit_log_records_position_concentration_rejection() {
+        let config = RiskConfig {
+            limits: RiskLimits {
+                position_concentration_limit: dec!(0.25),
+                ..Default::default()
+            },
+            max_order_notional: Decimal::from(1_000_000),
+            max_total_exposure: Decimal::from(1_000_000),
+            ..Default::default()
+        };
+        let mut rm = RiskManager::new(config, dec!(100_000));
+        let order = Order::market_order(test_symbol(), Side::Buy, dec!(200), "test".into());
+
+        let result = rm.check_order(&order, dec!(150), dec!(100_000));
+        assert!(!result.is_approved());
+
+        let audit = rm.audit_log();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].decision, RiskAuditDecision::Rejected);
+        assert_eq!(audit[0].rule, Some(RiskRule::PositionConcentration));
+        assert!(audit[0]
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("position concentration"));
+    }
+
+    #[test]
+    fn test_audit_log_records_total_exposure_rejection() {
+        let config = RiskConfig {
+            max_total_exposure: dec!(25_000),
+            max_order_notional: Decimal::from(1_000_000),
+            limits: RiskLimits {
+                position_concentration_limit: dec!(1.0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut rm = RiskManager::new(config, dec!(100_000));
+        let held = test_symbol();
+        let incoming = equity_symbol("MSFT");
+
+        rm.update_position(&held, Side::Buy, dec!(100), dec!(100));
+        rm.update_market_price(&held, dec!(200));
+
+        let order = Order::market_order(incoming, Side::Buy, dec!(60), "test".into());
+        let result = rm.check_order(&order, dec!(100), dec!(100_000));
+        assert!(!result.is_approved());
+
+        let audit = rm.audit_log();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].decision, RiskAuditDecision::Rejected);
+        assert_eq!(audit[0].rule, Some(RiskRule::TotalExposure));
+        assert!(audit[0]
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("total exposure"));
+    }
+
+    #[test]
+    fn test_dry_run_audit_entry_marks_would_reject() {
+        let config = RiskConfig {
+            max_order_notional: dec!(1_000),
+            dry_run: true,
+            ..Default::default()
+        };
+        let mut rm = RiskManager::new(config, dec!(100_000));
+        let order = Order::market_order(test_symbol(), Side::Buy, dec!(100), "test".into());
+
+        let result = rm.check_order(&order, dec!(150), dec!(100_000));
+        assert!(result.is_approved());
+
+        let audit = rm.audit_log();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].decision, RiskAuditDecision::WouldReject);
+        assert_eq!(audit[0].rule, Some(RiskRule::MaxOrderNotional));
     }
 
     #[test]

--- a/docs/assumptions-and-limitations.md
+++ b/docs/assumptions-and-limitations.md
@@ -28,7 +28,8 @@ GlowBack already covers a meaningful research workflow, but it is still an alpha
 ## Live and paper trading
 
 - The `gb-live` crate exists, but real broker adapters are intentionally not positioned as production-ready.
-- Safety controls, parity checks, and auditability remain prerequisites before any real-money workflow should be trusted.
+- `PaperBroker` now records an append-only audit trail for broker events and inventory/risk rejections, and CI includes a backtest-order-stream replay check against the paper broker on sample data.
+- Broader safety controls, parity checks, and auditability still remain prerequisites before any real-money workflow should be trusted.
 
 ## Options workflow
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Paper broker parity + audit trail:** `gb-live::PaperBroker` now keeps an append-only audit log for broker events, inventories rejection reasons for sell-over-inventory attempts, and ships a replay test that feeds a backtest order stream back through the paper broker to prove cash/position parity on the sample buy-and-hold path.
 - **Data quality summaries + strict mode:** `gb-data` now validates fetched datasets, persists per-symbol validation summaries in the catalog, records dataset provenance/price-adjustment metadata, and exposes those summaries through run manifests/result metadata. `DataSettings.data_quality_mode` defaults to `warn` and can be set to `fail` to reject datasets with critical issues before a backtest starts.
 - **Execution realism:** `gb-engine` now records order lifecycle events, respects time-in-force semantics for day/IOC/FOK orders, and caps fills by a configurable `max_volume_participation` setting so oversized orders can partially fill instead of always executing in one shot.
 - **Python SDK quickstart:** GlowBack now ships a checked-in Python SDK smoke path (`./scripts/python_sdk_quickstart.sh`) plus a companion example (`examples/python_sdk_quickstart.py`) that builds `gb-python` in an isolated virtualenv, validates the documented public surface, and runs both helper-style and engine-style backtests against sample data.


### PR DESCRIPTION
## Summary
- add append-only audit logs to `gb-live` risk and paper-broker flows so rejected orders keep rule/reason context
- add a backtest-order-stream replay test that replays sample buy-and-hold fills through `PaperBroker` and verifies cash/position parity
- document the new paper-broker parity and audit coverage in the changelog and assumptions page

## Testing
- `cargo test -p gb-live --locked`

Fixes #112
