### PR TITLE
fix: add covered call engine workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "chrono",
  "criterion",
  "gb-data",
+ "gb-options",
  "gb-types",
  "rust_decimal",
  "serde",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GlowBack provides a fast, realistic backtesting engine with data management, sto
 - Event‑driven simulation engine with slippage/latency/commission models, order lifecycle events, and participation-capped partial fills
 - Data ingestion (CSV, Alpha Vantage, explicit sample/demo data)
 - Arrow/Parquet columnar storage and SQLite metadata catalog
-- Strategy library (5 built‑in strategies; the quickstart smoke path exercises four of them)
+- Strategy library (6 built‑in strategies, including an experimental covered-call workflow; the quickstart smoke path exercises four of them)
 - Python bindings (async support)
 - Streamlit UI for strategy development and analysis
 - Durable experiment registry for saved strategies, historical runs, and cross-session comparisons
@@ -54,7 +54,7 @@ Phase 0+ (Production Infrastructure) is complete. Phase 1 (Alpha) is in progress
 - Multi‑symbol backtesting with chronological event ordering and auditable order submission/fill/cancel/expire traces
 - Performance analytics (Sharpe, Sortino, Calmar, CAGR, Max Drawdown, etc.)
 - Risk analytics (VaR, CVaR, skewness, kurtosis)
-- Built-in strategies: Buy & Hold, Moving Average Crossover, Momentum, Mean Reversion, and RSI
+- Built-in strategies: Buy & Hold, Moving Average Crossover, Momentum, Mean Reversion, RSI, and an experimental Covered Call path
 - Strategy authoring templates for both the Rust engine lifecycle and the UI's local Python runner lifecycle
 - Storage: Arrow/Parquet with batch loading and round‑trip I/O
 - Catalog: SQLite metadata with indexed queries
@@ -136,6 +136,7 @@ Or run the checked-in clean-venv smoke path:
 ```
 
 The supported public surface is exported via `glowback.__all__`, and canonical built-in strategy IDs are available in `glowback.BUILTIN_STRATEGIES`.
+The Python runtime now also returns `order_events`, `option_trades`, and `option_events` when a strategy emits those lifecycle records.
 
 ```python
 import glowback
@@ -152,7 +153,7 @@ manager.add_sample_provider()
 bars = manager.load_data(symbol, "2023-01-01T00:00:00Z", "2023-12-31T23:59:59Z", "day")
 ```
 
-`cargo test -p gb-python --locked --no-default-features` includes parity checks that compare the Python helpers with the direct Rust engine for both `buy_and_hold` and `ma_crossover`. The docs smoke workflow also runs `./scripts/python_sdk_quickstart.sh`, which builds `gb-python` in an isolated virtualenv and executes `examples/python_sdk_quickstart.py` end to end.
+`cargo test -p gb-python --locked --no-default-features` includes parity checks that compare the Python helpers with the direct Rust engine for `buy_and_hold`, `ma_crossover`, and the experimental `covered_call` path. The docs smoke workflow also runs `./scripts/python_sdk_quickstart.sh`, which builds `gb-python` in an isolated virtualenv and executes `examples/python_sdk_quickstart.py` end to end.
 
 ## Testing
 

--- a/api/app/adapter.py
+++ b/api/app/adapter.py
@@ -413,6 +413,8 @@ class RealEngineAdapter:
                 trades=result_payload.get("trades", []),
                 exposures=result_payload.get("exposures", []),
                 order_events=result_payload.get("order_events", []),
+                option_trades=result_payload.get("option_trades", []),
+                option_events=result_payload.get("option_events", []),
                 portfolio_construction=result_payload.get("portfolio_construction") or requested_portfolio,
                 portfolio_diagnostics=result_payload.get("portfolio_diagnostics", []),
                 constraint_hits=result_payload.get("constraint_hits", []),

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -121,6 +121,8 @@ class BacktestResult(BaseModel):
     trades: list[dict[str, Any]] = Field(default_factory=list)
     exposures: list[dict[str, Any]] = Field(default_factory=list)
     order_events: list[dict[str, Any]] = Field(default_factory=list)
+    option_trades: list[dict[str, Any]] = Field(default_factory=list)
+    option_events: list[dict[str, Any]] = Field(default_factory=list)
     portfolio_construction: dict[str, Any] = Field(default_factory=dict)
     portfolio_diagnostics: list[dict[str, Any]] = Field(default_factory=list)
     constraint_hits: list[dict[str, Any]] = Field(default_factory=list)

--- a/api/tests/test_backtest_adapter.py
+++ b/api/tests/test_backtest_adapter.py
@@ -44,6 +44,8 @@ class RealEngineAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "benchmark_curve": [{"timestamp": "2024-01-01T00:00:00Z", "symbol": "SPY", "value": 100500.0}],
                 "trades": [{"timestamp": "2024-01-01T00:00:00Z", "symbol": "AAPL", "action": "BUY", "shares": 10.0, "price": 100.0}],
                 "exposures": [{"timestamp": "2024-01-01T00:00:00Z", "cash_pct": 5.0, "positions_pct": 95.0}],
+                "option_trades": [{"contract_symbol": "AAPL-20240108-105C", "status": "expired", "greeks": {"delta": 0.3}}],
+                "option_events": [{"event": "covered_call_opened", "contract_symbol": "AAPL-20240108-105C"}],
                 "portfolio_construction": {"method": "target_weights", "rebalance_frequency": "weekly"},
                 "portfolio_diagnostics": [{"timestamp": "2024-01-01T00:00:00Z", "rebalanced": True}],
                 "constraint_hits": [{"type": "max_weight_cap", "symbol": "AAPL"}],
@@ -139,6 +141,8 @@ class RealEngineAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.final_cash, 5000.0)
         self.assertEqual(result.final_positions, {"AAPL": 10.0})
         self.assertEqual(result.trades[0]["action"], "BUY")
+        self.assertEqual(result.option_trades[0]["status"], "expired")
+        self.assertEqual(result.option_events[0]["event"], "covered_call_opened")
         self.assertIsNotNone(result.manifest)
         self.assertEqual(result.manifest["replay_request"]["strategy_name"], "buy_and_hold")
 

--- a/crates/gb-engine/Cargo.toml
+++ b/crates/gb-engine/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/bin/engine_service.rs"
 [dependencies]
 gb-types = { path = "../gb-types" }
 gb-data = { path = "../gb-data" }
+gb-options = { path = "../gb-options" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/gb-engine/src/engine.rs
+++ b/crates/gb-engine/src/engine.rs
@@ -3,16 +3,18 @@
 
 use chrono::{DateTime, Duration, Utc};
 use gb_data::DataManager;
+use gb_options::{black_scholes_price, simulate_open, OptionContract, OptionKind, PricingInput};
 use gb_types::{
-    BacktestConfig, BacktestError, BacktestResult, Bar, DataQualityMode, DataValidationSummary,
-    EquityCurvePoint, Fill, GbResult, LatencyModel, MarketDataBuffer, MarketEvent, Order,
-    OrderEvent, OrderStatus, OrderType, Portfolio, ReplayRequestManifest, RunDatasetManifest,
-    RunEngineManifest, RunExecutionManifest, RunManifest, RunMetricSnapshot, RunStrategyManifest,
-    Side, SlippageModel, Strategy, StrategyContext, StrategyMetrics, Symbol, TimeInForce,
-    TradeRecord,
+    BacktestConfig, BacktestError, BacktestResult, Bar, CoveredCallOrder, DataQualityMode,
+    DataValidationSummary, EquityCurvePoint, Fill, GbResult, LatencyModel, MarketDataBuffer,
+    MarketEvent, Order, OrderEvent, OrderStatus, OrderType, Portfolio, ReplayRequestManifest,
+    RunDatasetManifest, RunEngineManifest, RunExecutionManifest, RunManifest, RunMetricSnapshot,
+    RunStrategyManifest, Side, SlippageModel, Strategy, StrategyContext, StrategyMetrics, Symbol,
+    TimeInForce, TradeRecord,
 };
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use serde::Serialize;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
@@ -31,6 +33,85 @@ enum ExecutionDecision {
         remainder_event: Option<OrderEvent>,
     },
     Terminal(OrderEvent),
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OptionGreeksSnapshot {
+    delta: f64,
+    gamma: f64,
+    theta: f64,
+    vega: f64,
+    rho: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OptionPricingSnapshot {
+    spot: f64,
+    implied_volatility: f64,
+    risk_free_rate: f64,
+    dividend_yield: f64,
+    time_to_expiry_years: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OptionSettlementSnapshot {
+    timestamp: String,
+    status: String,
+    spot: f64,
+    shares_delivered: f64,
+    cash_flow: f64,
+    intrinsic_value: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CoveredCallTradeRecord {
+    contract_symbol: String,
+    underlying: String,
+    side: String,
+    contracts: f64,
+    multiplier: f64,
+    strike: f64,
+    premium: f64,
+    commission: f64,
+    net_premium: f64,
+    expiration: String,
+    opened_at: String,
+    status: String,
+    greeks: OptionGreeksSnapshot,
+    pricing: OptionPricingSnapshot,
+    settlement: Option<OptionSettlementSnapshot>,
+    strategy_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OptionLifecycleEvent {
+    timestamp: String,
+    event: String,
+    contract_symbol: String,
+    underlying: String,
+    contracts: f64,
+    strike: f64,
+    spot: f64,
+    shares_delivered: f64,
+    cash_flow: f64,
+    note: String,
+}
+
+#[derive(Debug, Clone)]
+struct OpenCoveredCallPosition {
+    contract: OptionContract,
+    contracts: Decimal,
+    trade_index: usize,
+    strategy_id: String,
+}
+
+fn contract_symbol(contract: &OptionContract) -> String {
+    format!(
+        "{}-{}-{}C",
+        contract.underlying.symbol,
+        contract.expiration.format("%Y%m%d"),
+        contract.strike.round_dp(2)
+    )
 }
 
 fn execution_commission_bps(settings: &gb_types::ExecutionSettings) -> Option<f64> {
@@ -74,6 +155,9 @@ pub struct Engine {
     equity_curve: Vec<EquityCurvePoint>,
     trade_log: Vec<TradeRecord>,
     order_events: Vec<OrderEvent>,
+    option_trades: Vec<CoveredCallTradeRecord>,
+    option_events: Vec<OptionLifecycleEvent>,
+    open_covered_calls: Vec<OpenCoveredCallPosition>,
     equity_peak: Decimal,
     data_validation_summaries: HashMap<String, DataValidationSummary>,
 }
@@ -211,6 +295,9 @@ impl Engine {
             equity_curve: Vec::new(),
             trade_log: Vec::new(),
             order_events: Vec::new(),
+            option_trades: Vec::new(),
+            option_events: Vec::new(),
+            open_covered_calls: Vec::new(),
             data_validation_summaries,
         })
     }
@@ -257,13 +344,16 @@ impl Engine {
             // 3. Update portfolio with current market prices
             self.update_portfolio_values().await?;
 
-            // 4. Generate strategy signals
+            // 4. Process option lifecycle events that settle on the current bar
+            self.process_option_lifecycle().await?;
+
+            // 5. Generate strategy signals
             self.generate_strategy_signals().await?;
 
-            // 5. Call strategy's on_day_end for end-of-day processing
+            // 6. Call strategy's on_day_end for end-of-day processing
             self.call_strategy_day_end().await?;
 
-            // 6. Update daily returns
+            // 7. Update daily returns
             self.update_daily_returns().await?;
 
             // Advance time
@@ -679,6 +769,248 @@ impl Engine {
         })
     }
 
+    fn current_price_for_symbol(&self, symbol: &Symbol) -> Option<Decimal> {
+        self.current_market_bars
+            .iter()
+            .rev()
+            .find(|(candidate, _)| candidate == symbol)
+            .map(|(_, bar)| bar.close)
+            .or_else(|| self.strategy_context.get_current_price(symbol))
+    }
+
+    fn open_covered_call(&mut self, order: CoveredCallOrder) -> GbResult<()> {
+        let Some(spot) = self.current_price_for_symbol(&order.underlying) else {
+            warn!(
+                "Skipping covered call write for {} because no current spot price is available",
+                order.underlying
+            );
+            return Ok(());
+        };
+
+        let required_shares = order.contracts * Decimal::from(100);
+        let held_shares = self
+            .portfolio
+            .get_position(&order.underlying)
+            .map(|position| position.quantity)
+            .unwrap_or(Decimal::ZERO);
+        if held_shares < required_shares {
+            warn!(
+                "Skipping covered call write for {} because only {} shares are held (need {})",
+                order.underlying, held_shares, required_shares
+            );
+            return Ok(());
+        }
+
+        let contract = OptionContract::equity(
+            order.underlying.clone(),
+            OptionKind::Call,
+            order.strike,
+            order.expiration,
+        );
+        let pricing_input = PricingInput {
+            spot: decimal_to_f64(spot),
+            risk_free_rate: decimal_to_f64(order.risk_free_rate),
+            volatility: decimal_to_f64(order.implied_volatility),
+            dividend_yield: decimal_to_f64(order.dividend_yield),
+            time_to_expiry: contract.time_to_expiry(self.current_time),
+        };
+        let pricing = black_scholes_price(&contract, &pricing_input);
+        let strategy_id = self.strategy.get_config().strategy_id.clone();
+        let mut trade = simulate_open(
+            &contract,
+            Side::Sell,
+            order.contracts,
+            &pricing_input,
+            order.commission_per_contract,
+            &strategy_id,
+        )
+        .map_err(|error| BacktestError::ExecutionFailed {
+            message: format!("failed to open covered call: {}", error),
+        })?;
+        trade.executed_at = self.current_time;
+
+        let net_premium = trade.cash_flow();
+        self.portfolio.apply_cash_adjustment(
+            net_premium,
+            net_premium,
+            trade.commission,
+            self.current_time,
+        );
+        self.sync_strategy_context_account_state();
+
+        let trade_index = self.option_trades.len();
+        let contract_label = contract_symbol(&contract);
+        self.option_trades.push(CoveredCallTradeRecord {
+            contract_symbol: contract_label.clone(),
+            underlying: contract.underlying.symbol.clone(),
+            side: "SELL".to_string(),
+            contracts: decimal_to_f64(order.contracts),
+            multiplier: decimal_to_f64(contract.multiplier),
+            strike: decimal_to_f64(contract.strike),
+            premium: decimal_to_f64(pricing.price),
+            commission: decimal_to_f64(trade.commission),
+            net_premium: decimal_to_f64(net_premium),
+            expiration: contract.expiration.to_rfc3339(),
+            opened_at: self.current_time.to_rfc3339(),
+            status: "open".to_string(),
+            greeks: OptionGreeksSnapshot {
+                delta: decimal_to_f64(pricing.greeks.delta),
+                gamma: decimal_to_f64(pricing.greeks.gamma),
+                theta: decimal_to_f64(pricing.greeks.theta),
+                vega: decimal_to_f64(pricing.greeks.vega),
+                rho: decimal_to_f64(pricing.greeks.rho),
+            },
+            pricing: OptionPricingSnapshot {
+                spot: pricing_input.spot,
+                implied_volatility: pricing_input.volatility,
+                risk_free_rate: pricing_input.risk_free_rate,
+                dividend_yield: pricing_input.dividend_yield,
+                time_to_expiry_years: pricing_input.time_to_expiry,
+            },
+            settlement: None,
+            strategy_id: strategy_id.clone(),
+        });
+        self.option_events.push(OptionLifecycleEvent {
+            timestamp: self.current_time.to_rfc3339(),
+            event: "covered_call_opened".to_string(),
+            contract_symbol: contract_label,
+            underlying: contract.underlying.symbol.clone(),
+            contracts: decimal_to_f64(order.contracts),
+            strike: decimal_to_f64(contract.strike),
+            spot: decimal_to_f64(spot),
+            shares_delivered: 0.0,
+            cash_flow: decimal_to_f64(net_premium),
+            note: "opened short call against an existing long equity position".to_string(),
+        });
+        self.open_covered_calls.push(OpenCoveredCallPosition {
+            contract,
+            contracts: order.contracts,
+            trade_index,
+            strategy_id,
+        });
+
+        Ok(())
+    }
+
+    async fn process_option_lifecycle(&mut self) -> GbResult<()> {
+        if self.open_covered_calls.is_empty() {
+            return Ok(());
+        }
+
+        let mut remaining_positions = Vec::new();
+        let mut assignment_events = Vec::new();
+
+        for position in std::mem::take(&mut self.open_covered_calls) {
+            if self.current_time < position.contract.expiration {
+                remaining_positions.push(position);
+                continue;
+            }
+
+            let Some(spot) = self.current_price_for_symbol(&position.contract.underlying) else {
+                remaining_positions.push(position);
+                continue;
+            };
+
+            let contract_label = contract_symbol(&position.contract);
+            let intrinsic_value = position.contract.intrinsic_value(spot);
+            let shares_delivered = position.contract.multiplier * position.contracts;
+            let settlement = if intrinsic_value > Decimal::ZERO {
+                let assignment_order = Order::market_order(
+                    position.contract.underlying.clone(),
+                    Side::Sell,
+                    shares_delivered,
+                    position.strategy_id.clone(),
+                );
+                let mut assignment_fill = Fill::new(
+                    assignment_order.id,
+                    position.contract.underlying.clone(),
+                    Side::Sell,
+                    shares_delivered,
+                    position.contract.strike,
+                    Decimal::ZERO,
+                    position.strategy_id.clone(),
+                );
+                assignment_fill.executed_at = self.current_time;
+                self.portfolio.apply_fill(&assignment_fill);
+                self.strategy_metrics.total_trades += 1;
+
+                let mut trade_record_fill =
+                    self.trade_record_from_fill(&assignment_order, &assignment_fill);
+                trade_record_fill.tags.push("option_assignment".to_string());
+                trade_record_fill.tags.push(contract_label.clone());
+                self.trade_log.push(trade_record_fill);
+                assignment_events.push(OrderEvent::OrderFilled {
+                    order_id: assignment_order.id,
+                    fill: assignment_fill,
+                });
+
+                self.option_events.push(OptionLifecycleEvent {
+                    timestamp: self.current_time.to_rfc3339(),
+                    event: "covered_call_assigned".to_string(),
+                    contract_symbol: contract_label.clone(),
+                    underlying: position.contract.underlying.symbol.clone(),
+                    contracts: decimal_to_f64(position.contracts),
+                    strike: decimal_to_f64(position.contract.strike),
+                    spot: decimal_to_f64(spot),
+                    shares_delivered: decimal_to_f64(shares_delivered),
+                    cash_flow: decimal_to_f64(position.contract.strike * shares_delivered),
+                    note: "short call finished in the money and shares were called away"
+                        .to_string(),
+                });
+
+                (
+                    "assigned".to_string(),
+                    OptionSettlementSnapshot {
+                        timestamp: self.current_time.to_rfc3339(),
+                        status: "assigned".to_string(),
+                        spot: decimal_to_f64(spot),
+                        shares_delivered: decimal_to_f64(shares_delivered),
+                        cash_flow: decimal_to_f64(position.contract.strike * shares_delivered),
+                        intrinsic_value: decimal_to_f64(intrinsic_value),
+                    },
+                )
+            } else {
+                self.option_events.push(OptionLifecycleEvent {
+                    timestamp: self.current_time.to_rfc3339(),
+                    event: "covered_call_expired".to_string(),
+                    contract_symbol: contract_label.clone(),
+                    underlying: position.contract.underlying.symbol.clone(),
+                    contracts: decimal_to_f64(position.contracts),
+                    strike: decimal_to_f64(position.contract.strike),
+                    spot: decimal_to_f64(spot),
+                    shares_delivered: 0.0,
+                    cash_flow: 0.0,
+                    note: "short call expired out of the money".to_string(),
+                });
+
+                (
+                    "expired".to_string(),
+                    OptionSettlementSnapshot {
+                        timestamp: self.current_time.to_rfc3339(),
+                        status: "expired".to_string(),
+                        spot: decimal_to_f64(spot),
+                        shares_delivered: 0.0,
+                        cash_flow: 0.0,
+                        intrinsic_value: 0.0,
+                    },
+                )
+            };
+
+            if let Some(trade_record) = self.option_trades.get_mut(position.trade_index) {
+                trade_record.status = settlement.0;
+                trade_record.settlement = Some(settlement.1);
+            }
+        }
+
+        self.open_covered_calls = remaining_positions;
+        if !assignment_events.is_empty() {
+            self.record_order_events(assignment_events)?;
+        } else {
+            self.sync_strategy_context_account_state();
+        }
+        Ok(())
+    }
+
     /// Update portfolio values with current market prices
     async fn update_portfolio_values(&mut self) -> GbResult<()> {
         let current_prices = self
@@ -772,6 +1104,13 @@ impl Engine {
                 });
                 self.sync_strategy_context_account_state();
                 self.record_order_events(cancel_events)?;
+            }
+            StrategyAction::WriteCoveredCall(order) => {
+                debug!(
+                    "Strategy wrote covered call: {} {} strike {} exp {}",
+                    order.contracts, order.underlying, order.strike, order.expiration
+                );
+                self.open_covered_call(order)?;
             }
             StrategyAction::Log { level, message } => match level {
                 gb_types::LogLevel::Debug => debug!("[Strategy] {}", message),
@@ -1036,6 +1375,22 @@ impl Engine {
                 .values()
                 .any(|summary| summary.sample_data)),
         );
+        result.metadata.insert(
+            "option_trades".to_string(),
+            serde_json::to_value(&self.option_trades)?,
+        );
+        result.metadata.insert(
+            "option_events".to_string(),
+            serde_json::to_value(&self.option_events)?,
+        );
+        result.metadata.insert(
+            "option_support_level".to_string(),
+            serde_json::json!(if self.option_trades.is_empty() {
+                "none"
+            } else {
+                "experimental"
+            }),
+        );
         result.manifest = Some(self.build_run_manifest(result));
 
         info!("Final portfolio value: {}", self.portfolio.total_equity);
@@ -1105,9 +1460,8 @@ mod tests {
     use super::*;
     use chrono::TimeZone;
     use gb_types::{
-        DataQualityMode, DataValidationSummary, DatasetKind, LatencyModel, OrderEvent,
-        OrderStatus, PriceAdjustmentMode, Resolution, Side, StrategyAction, StrategyConfig,
-        TimeInForce,
+        DataQualityMode, DataValidationSummary, DatasetKind, LatencyModel, OrderEvent, OrderStatus,
+        PriceAdjustmentMode, Resolution, Side, StrategyAction, StrategyConfig, TimeInForce,
     };
 
     #[derive(Debug, Clone)]
@@ -1221,6 +1575,9 @@ mod tests {
             equity_curve: Vec::new(),
             trade_log: Vec::new(),
             order_events: Vec::new(),
+            option_trades: Vec::new(),
+            option_events: Vec::new(),
+            open_covered_calls: Vec::new(),
             equity_peak: Decimal::from(100_000),
             data_validation_summaries: HashMap::new(),
         }

--- a/crates/gb-engine/src/lib.rs
+++ b/crates/gb-engine/src/lib.rs
@@ -357,6 +357,7 @@ mod tests {
                     overbought_threshold,
                 ))
             }
+            "covered_call" => Box::new(gb_types::CoveredCallStrategy::new()),
             other => panic!("unsupported manifest replay strategy: {other}"),
         }
     }
@@ -647,6 +648,85 @@ mod tests {
         // Verify we got valid results
         assert!(backtest_result.final_portfolio.is_some());
         assert!(backtest_result.strategy_metrics.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_backtest_with_covered_call_strategy_records_option_lifecycle() {
+        use gb_types::CoveredCallStrategy;
+
+        let mut config = create_test_config();
+        config.symbols = vec![Symbol::equity("AAPL")];
+        config.initial_capital = Decimal::from(50_000);
+        config.start_date = Utc::now() - Duration::days(6);
+        config.end_date = Utc::now();
+        config
+            .strategy_config
+            .set_parameter("call_otm_pct", -20.0f64);
+        config.strategy_config.set_parameter("days_to_expiry", 1i64);
+        config
+            .strategy_config
+            .set_parameter("implied_volatility", 0.20f64);
+        config
+            .strategy_config
+            .set_parameter("commission_per_contract", 0.65f64);
+
+        let mut engine = BacktestEngine::new(config).await.unwrap();
+        let result = engine
+            .run_with_strategy(Box::new(CoveredCallStrategy::new()))
+            .await
+            .unwrap();
+
+        let option_trades = result
+            .metadata
+            .get("option_trades")
+            .and_then(|value| value.as_array())
+            .expect("option trades metadata should be present");
+        assert_eq!(option_trades.len(), 1);
+        assert!(option_trades[0].get("greeks").is_some());
+        assert_eq!(option_trades[0]["status"], serde_json::json!("assigned"));
+
+        let option_events = result
+            .metadata
+            .get("option_events")
+            .and_then(|value| value.as_array())
+            .expect("option events metadata should be present");
+        assert!(option_events.iter().any(|event| {
+            event.get("event") == Some(&serde_json::json!("covered_call_opened"))
+        }));
+        assert!(option_events.iter().any(|event| {
+            event.get("event") == Some(&serde_json::json!("covered_call_assigned"))
+        }));
+        assert!(
+            result
+                .trade_log
+                .iter()
+                .any(|trade| trade.tags.iter().any(|tag| tag == "option_assignment")),
+            "assignment should show up in the underlying trade log"
+        );
+
+        let manifest = result
+            .manifest
+            .clone()
+            .expect("covered call runs should include a manifest");
+        assert_eq!(manifest.replay_request.strategy_name, "covered_call");
+
+        let replay_config = replay_config_from_manifest(&manifest);
+        let replay_strategy = strategy_from_manifest(&manifest);
+        let mut replay_engine = BacktestEngine::new(replay_config).await.unwrap();
+        let replay_result = replay_engine
+            .run_with_strategy(replay_strategy)
+            .await
+            .unwrap();
+        let replay_option_trades = replay_result
+            .metadata
+            .get("option_trades")
+            .and_then(|value| value.as_array())
+            .expect("replay option trades metadata should be present");
+        assert_eq!(replay_option_trades.len(), 1);
+        assert_eq!(
+            replay_option_trades[0]["status"],
+            serde_json::json!("assigned")
+        );
     }
 
     #[tokio::test]

--- a/crates/gb-live/src/engine.rs
+++ b/crates/gb-live/src/engine.rs
@@ -292,6 +292,12 @@ impl<B: Broker, S: Strategy> LiveEngine<B, S> {
                     warn!(order_id = %order_id, error = %e, "cancel failed");
                 }
             }
+            StrategyAction::WriteCoveredCall(order) => {
+                return Err(format!(
+                    "live engine does not support WriteCoveredCall for {} yet",
+                    order.underlying
+                ));
+            }
             StrategyAction::Log { level, message } => match level {
                 gb_types::strategy::LogLevel::Debug => {
                     tracing::debug!(strategy = %self.config.strategy_config.strategy_id, "{message}")

--- a/crates/gb-python/src/lib.rs
+++ b/crates/gb-python/src/lib.rs
@@ -6,17 +6,19 @@ use rust_decimal::Decimal;
 
 use gb_engine::BacktestEngine as RustBacktestEngine;
 use gb_types::{
-    BacktestConfig, BacktestResult as RustBacktestResult, BuyAndHoldStrategy, DataQualityMode,
-    LatencyModel, MeanReversionStrategy, MomentumStrategy, MovingAverageCrossoverStrategy,
-    Resolution, RsiStrategy, SlippageModel, Strategy, StrategyConfig, Symbol,
+    BacktestConfig, BacktestResult as RustBacktestResult, BuyAndHoldStrategy, CoveredCallStrategy,
+    DataQualityMode, LatencyModel, MeanReversionStrategy, MomentumStrategy,
+    MovingAverageCrossoverStrategy, Resolution, RsiStrategy, SlippageModel, Strategy,
+    StrategyConfig, Symbol,
 };
 
-const BUILTIN_STRATEGIES: [&str; 5] = [
+const BUILTIN_STRATEGIES: [&str; 6] = [
     "buy_and_hold",
     "ma_crossover",
     "momentum",
     "mean_reversion",
     "rsi",
+    "covered_call",
 ];
 
 fn supported_builtin_strategies() -> String {
@@ -160,6 +162,7 @@ fn build_strategy(name: &str, params: Option<&Bound<PyDict>>) -> PyResult<Box<dy
                 overbought_threshold,
             )))
         }
+        "covered_call" => Ok(Box::new(CoveredCallStrategy::new())),
         other => Err(pyo3::exceptions::PyValueError::new_err(format!(
             "Unsupported strategy: {}. Supported strategies: {}",
             other,
@@ -394,6 +397,7 @@ fn build_builtin_strategy(
                 overbought_threshold,
             )))
         }
+        "covered_call" => Ok(Box::new(CoveredCallStrategy::new())),
         other => Err(pyo3::exceptions::PyValueError::new_err(format!(
             "Unsupported built-in strategy: {}. Supported strategies: {}",
             other,
@@ -818,6 +822,8 @@ struct PyBacktestResult {
     trades: Vec<TradePoint>,
     exposures: Vec<ExposurePoint>,
     order_events: Vec<serde_json::Value>,
+    option_trades: Vec<serde_json::Value>,
+    option_events: Vec<serde_json::Value>,
     logs: Vec<String>,
     final_cash: f64,
     final_positions: std::collections::HashMap<String, f64>,
@@ -1023,6 +1029,19 @@ impl PyBacktestResult {
             .filter_map(|event| serde_json::to_value(event).ok())
             .collect::<Vec<_>>();
 
+        let option_trades = result
+            .metadata
+            .get("option_trades")
+            .and_then(|value| value.as_array().cloned())
+            .unwrap_or_default();
+        let option_events = result
+            .metadata
+            .get("option_events")
+            .and_then(|value| value.as_array().cloned())
+            .unwrap_or_default();
+        metrics_summary.insert("option_trade_count".to_string(), option_trades.len() as f64);
+        metrics_summary.insert("option_event_count".to_string(), option_events.len() as f64);
+
         let manifest = result
             .manifest
             .as_ref()
@@ -1111,6 +1130,8 @@ impl PyBacktestResult {
             trades,
             exposures,
             order_events,
+            option_trades,
+            option_events,
             logs,
             final_cash,
             final_positions,
@@ -1197,6 +1218,30 @@ impl PyBacktestResult {
         let payload = serde_json::to_string(&self.order_events).map_err(|error| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(
                 "Failed to serialize order events: {}",
+                error
+            ))
+        })?;
+        Ok(json.call_method1("loads", (payload,))?.into())
+    }
+
+    #[getter]
+    fn option_trades(&self, py: Python) -> PyResult<PyObject> {
+        let json = py.import("json")?;
+        let payload = serde_json::to_string(&self.option_trades).map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Failed to serialize option trades: {}",
+                error
+            ))
+        })?;
+        Ok(json.call_method1("loads", (payload,))?.into())
+    }
+
+    #[getter]
+    fn option_events(&self, py: Python) -> PyResult<PyObject> {
+        let json = py.import("json")?;
+        let payload = serde_json::to_string(&self.option_events).map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Failed to serialize option events: {}",
                 error
             ))
         })?;
@@ -1729,5 +1774,32 @@ mod tests {
         let python_result = run_python_builtin_strategy("ma_crossover", &params);
         let rust_result = run_rust_builtin_strategy("ma_crossover", &params);
         assert_python_result_matches_rust(&python_result, &rust_result);
+    }
+
+    #[test]
+    fn covered_call_python_helper_surfaces_option_payloads() {
+        let python_result = run_python_builtin_strategy("covered_call", &[]);
+        let rust_result = run_rust_builtin_strategy("covered_call", &[]);
+        assert_python_result_matches_rust(&python_result, &rust_result);
+
+        let rust_option_trades = rust_result
+            .metadata
+            .get("option_trades")
+            .and_then(|value| value.as_array())
+            .expect("rust covered call result should include option trades metadata");
+        let rust_option_events = rust_result
+            .metadata
+            .get("option_events")
+            .and_then(|value| value.as_array())
+            .expect("rust covered call result should include option events metadata");
+
+        assert!(!python_result.option_trades.is_empty());
+        assert!(!python_result.option_events.is_empty());
+        assert_eq!(python_result.option_trades.len(), rust_option_trades.len());
+        assert_eq!(python_result.option_events.len(), rust_option_events.len());
+        assert_eq!(
+            python_result.metrics_summary["option_trade_count"],
+            rust_option_trades.len() as f64
+        );
     }
 }

--- a/crates/gb-types/src/portfolio.rs
+++ b/crates/gb-types/src/portfolio.rs
@@ -182,6 +182,20 @@ impl Portfolio {
         self.update_totals();
     }
 
+    pub fn apply_cash_adjustment(
+        &mut self,
+        cash_delta: Decimal,
+        realized_pnl_delta: Decimal,
+        commission_delta: Decimal,
+        as_of: DateTime<Utc>,
+    ) {
+        self.cash += cash_delta;
+        self.total_realized_pnl += realized_pnl_delta;
+        self.total_commissions += commission_delta;
+        self.last_updated = as_of;
+        self.update_totals();
+    }
+
     fn update_totals(&mut self) {
         self.total_unrealized_pnl = self.positions.values().map(|p| p.unrealized_pnl).sum();
 

--- a/crates/gb-types/src/strategy.rs
+++ b/crates/gb-types/src/strategy.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::Decimal;
-use rust_decimal::prelude::{ToPrimitive, FromPrimitive};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -28,23 +28,23 @@ impl StrategyContext {
             strategy_id,
         }
     }
-    
+
     pub fn get_position(&self, symbol: &Symbol) -> Option<&Position> {
         self.portfolio.get_position(symbol)
     }
-    
+
     pub fn get_current_price(&self, symbol: &Symbol) -> Option<Decimal> {
         self.market_data.get(symbol)?.get_current_price()
     }
-    
+
     pub fn get_market_data(&self, symbol: &Symbol) -> Option<&MarketDataBuffer> {
         self.market_data.get(symbol)
     }
-    
+
     pub fn get_available_cash(&self) -> Decimal {
         self.portfolio.get_available_cash()
     }
-    
+
     pub fn get_portfolio_value(&self) -> Decimal {
         self.portfolio.total_equity
     }
@@ -66,14 +66,14 @@ impl MarketDataBuffer {
             max_size,
         }
     }
-    
+
     pub fn add_event(&mut self, event: MarketEvent) {
         self.data.push(event);
         if self.data.len() > self.max_size {
             self.data.remove(0);
         }
     }
-    
+
     pub fn get_current_price(&self) -> Option<Decimal> {
         self.data.last().and_then(|event| match event {
             MarketEvent::Bar(bar) => Some(bar.close),
@@ -81,16 +81,17 @@ impl MarketDataBuffer {
             MarketEvent::Quote { bid, ask, .. } => Some((*bid + *ask) / Decimal::from(2)),
         })
     }
-    
+
     pub fn get_latest_bar(&self) -> Option<&crate::market::Bar> {
         self.data.iter().rev().find_map(|event| match event {
             MarketEvent::Bar(bar) => Some(bar),
             _ => None,
         })
     }
-    
+
     pub fn get_bars(&self, count: usize) -> Vec<&crate::market::Bar> {
-        self.data.iter()
+        self.data
+            .iter()
             .filter_map(|event| match event {
                 MarketEvent::Bar(bar) => Some(bar),
                 _ => None,
@@ -104,13 +105,34 @@ impl MarketDataBuffer {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CoveredCallOrder {
+    pub underlying: Symbol,
+    pub contracts: Decimal,
+    pub strike: Decimal,
+    pub expiration: DateTime<Utc>,
+    pub implied_volatility: Decimal,
+    pub risk_free_rate: Decimal,
+    pub dividend_yield: Decimal,
+    pub commission_per_contract: Decimal,
+}
+
 /// Strategy action that can be taken
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum StrategyAction {
     PlaceOrder(Order),
-    CancelOrder { order_id: crate::orders::OrderId },
-    Log { level: LogLevel, message: String },
-    SetParameter { key: String, value: serde_json::Value },
+    CancelOrder {
+        order_id: crate::orders::OrderId,
+    },
+    WriteCoveredCall(CoveredCallOrder),
+    Log {
+        level: LogLevel,
+        message: String,
+    },
+    SetParameter {
+        key: String,
+        value: serde_json::Value,
+    },
 }
 
 /// Log levels for strategy output
@@ -192,20 +214,20 @@ impl StrategyConfig {
             enabled: true,
         }
     }
-    
+
     pub fn add_symbol(&mut self, symbol: Symbol) -> &mut Self {
         self.symbols.push(symbol);
         self
     }
-    
+
     pub fn set_parameter<T: Serialize>(&mut self, key: &str, value: T) -> &mut Self {
         self.parameters.insert(
             key.to_string(),
-            serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
         );
         self
     }
-    
+
     pub fn get_parameter<T>(&self, key: &str) -> Option<T>
     where
         T: for<'de> Deserialize<'de>,
@@ -219,33 +241,30 @@ impl StrategyConfig {
 pub trait Strategy: Send + Sync {
     /// Initialize the strategy with configuration
     fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String>;
-    
+
     /// Process market data event and return actions
     fn on_market_event(
         &mut self,
         event: &MarketEvent,
         context: &StrategyContext,
     ) -> Result<Vec<StrategyAction>, String>;
-    
+
     /// Process order event (fills, cancellations, etc.)
     fn on_order_event(
         &mut self,
         event: &OrderEvent,
         context: &StrategyContext,
     ) -> Result<Vec<StrategyAction>, String>;
-    
+
     /// Called at the end of each trading day
-    fn on_day_end(
-        &mut self,
-        context: &StrategyContext,
-    ) -> Result<Vec<StrategyAction>, String>;
-    
+    fn on_day_end(&mut self, context: &StrategyContext) -> Result<Vec<StrategyAction>, String>;
+
     /// Called when strategy is stopped
     fn on_stop(&mut self, context: &StrategyContext) -> Result<Vec<StrategyAction>, String>;
-    
+
     /// Get strategy configuration
     fn get_config(&self) -> &StrategyConfig;
-    
+
     /// Get strategy metrics
     fn get_metrics(&self) -> StrategyMetrics;
 }
@@ -253,10 +272,22 @@ pub trait Strategy: Send + Sync {
 /// Event emitted by strategies
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum StrategyEvent {
-    Initialized { strategy_id: String, config: StrategyConfig },
-    ActionTaken { strategy_id: String, action: StrategyAction },
-    Error { strategy_id: String, error: String },
-    Stopped { strategy_id: String, metrics: StrategyMetrics },
+    Initialized {
+        strategy_id: String,
+        config: StrategyConfig,
+    },
+    ActionTaken {
+        strategy_id: String,
+        action: StrategyAction,
+    },
+    Error {
+        strategy_id: String,
+        error: String,
+    },
+    Stopped {
+        strategy_id: String,
+        metrics: StrategyMetrics,
+    },
 }
 
 /// Simple buy and hold strategy for testing
@@ -283,7 +314,7 @@ impl Strategy for BuyAndHoldStrategy {
         self.initialized = true;
         Ok(())
     }
-    
+
     fn on_market_event(
         &mut self,
         event: &MarketEvent,
@@ -292,30 +323,30 @@ impl Strategy for BuyAndHoldStrategy {
         if !self.initialized || self.position_opened {
             return Ok(vec![]);
         }
-        
+
         // Buy on first market event
         if let Some(symbol) = self.config.symbols.first() {
             if event.symbol() == symbol {
                 let available_cash = context.get_available_cash();
                 if let Some(price) = context.get_current_price(symbol) {
                     let quantity = available_cash * Decimal::new(95, 2) / price; // Use 95% of cash
-                    
+
                     let order = Order::market_order(
                         symbol.clone(),
                         crate::orders::Side::Buy,
                         quantity,
-                        self.config.strategy_id.clone()
+                        self.config.strategy_id.clone(),
                     );
-                    
+
                     self.position_opened = true;
                     return Ok(vec![StrategyAction::PlaceOrder(order)]);
                 }
             }
         }
-        
+
         Ok(vec![])
     }
-    
+
     fn on_order_event(
         &mut self,
         _event: &OrderEvent,
@@ -323,22 +354,246 @@ impl Strategy for BuyAndHoldStrategy {
     ) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
-    fn on_day_end(
-        &mut self,
-        _context: &StrategyContext,
-    ) -> Result<Vec<StrategyAction>, String> {
+
+    fn on_day_end(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn get_config(&self) -> &StrategyConfig {
         &self.config
     }
-    
+
+    fn get_metrics(&self) -> StrategyMetrics {
+        StrategyMetrics::new(self.config.strategy_id.clone())
+    }
+}
+
+/// Covered Call Strategy
+/// Buys 100 shares of the underlying, then writes a single short call against them.
+#[derive(Debug, Clone)]
+pub struct CoveredCallStrategy {
+    config: StrategyConfig,
+    initialized: bool,
+    pending_share_entry: bool,
+    call_written: bool,
+    contracts: Decimal,
+    call_otm_pct: Decimal,
+    days_to_expiry: i64,
+    implied_volatility: Decimal,
+    risk_free_rate: Decimal,
+    dividend_yield: Decimal,
+    commission_per_contract: Decimal,
+}
+
+impl CoveredCallStrategy {
+    pub fn new() -> Self {
+        let mut config =
+            StrategyConfig::new("covered_call".to_string(), "Covered Call".to_string());
+        config.set_parameter("contracts", 1.0f64);
+        config.set_parameter("call_otm_pct", 5.0f64);
+        config.set_parameter("days_to_expiry", 7i64);
+        config.set_parameter("implied_volatility", 0.25f64);
+        config.set_parameter("risk_free_rate", 0.01f64);
+        config.set_parameter("dividend_yield", 0.0f64);
+        config.set_parameter("commission_per_contract", 0.65f64);
+
+        Self {
+            config,
+            initialized: false,
+            pending_share_entry: false,
+            call_written: false,
+            contracts: Decimal::ONE,
+            call_otm_pct: Decimal::from(5),
+            days_to_expiry: 7,
+            implied_volatility: Decimal::new(25, 2),
+            risk_free_rate: Decimal::new(1, 2),
+            dividend_yield: Decimal::ZERO,
+            commission_per_contract: Decimal::new(65, 2),
+        }
+    }
+
+    fn underlying_symbol(&self) -> Option<&Symbol> {
+        self.config.symbols.first()
+    }
+
+    fn target_share_quantity(&self) -> Decimal {
+        self.contracts * Decimal::from(100)
+    }
+
+    fn build_covered_call_order(
+        &self,
+        context: &StrategyContext,
+        underlying: &Symbol,
+        spot: Decimal,
+    ) -> CoveredCallOrder {
+        let strike_multiplier = Decimal::ONE + (self.call_otm_pct / Decimal::from(100));
+        let strike = (spot * strike_multiplier).round_dp(2);
+        let expiration = context.current_time + chrono::Duration::days(self.days_to_expiry.max(1));
+
+        CoveredCallOrder {
+            underlying: underlying.clone(),
+            contracts: self.contracts,
+            strike,
+            expiration,
+            implied_volatility: self.implied_volatility,
+            risk_free_rate: self.risk_free_rate,
+            dividend_yield: self.dividend_yield,
+            commission_per_contract: self.commission_per_contract,
+        }
+    }
+}
+
+impl Strategy for CoveredCallStrategy {
+    fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
+        self.config = config.clone();
+        self.contracts = self
+            .config
+            .get_parameter::<f64>("contracts")
+            .and_then(Decimal::from_f64_retain)
+            .unwrap_or(Decimal::ONE);
+        self.call_otm_pct = self
+            .config
+            .get_parameter::<f64>("call_otm_pct")
+            .and_then(Decimal::from_f64_retain)
+            .unwrap_or(Decimal::from(5));
+        self.days_to_expiry = self.config.get_parameter("days_to_expiry").unwrap_or(7);
+        self.implied_volatility = self
+            .config
+            .get_parameter::<f64>("implied_volatility")
+            .and_then(Decimal::from_f64_retain)
+            .unwrap_or(Decimal::new(25, 2));
+        self.risk_free_rate = self
+            .config
+            .get_parameter::<f64>("risk_free_rate")
+            .and_then(Decimal::from_f64_retain)
+            .unwrap_or(Decimal::new(1, 2));
+        self.dividend_yield = self
+            .config
+            .get_parameter::<f64>("dividend_yield")
+            .and_then(Decimal::from_f64_retain)
+            .unwrap_or(Decimal::ZERO);
+        self.commission_per_contract = self
+            .config
+            .get_parameter::<f64>("commission_per_contract")
+            .and_then(Decimal::from_f64_retain)
+            .unwrap_or(Decimal::new(65, 2));
+        self.pending_share_entry = false;
+        self.call_written = false;
+        self.initialized = true;
+        Ok(())
+    }
+
+    fn on_market_event(
+        &mut self,
+        event: &MarketEvent,
+        context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
+        if !self.initialized || self.pending_share_entry || self.call_written {
+            return Ok(vec![]);
+        }
+
+        let Some(underlying) = self.underlying_symbol().cloned() else {
+            return Ok(vec![]);
+        };
+        if event.symbol() != &underlying {
+            return Ok(vec![]);
+        }
+
+        let Some(spot) = context.get_current_price(&underlying) else {
+            return Ok(vec![]);
+        };
+        let share_quantity = self.target_share_quantity();
+        if share_quantity <= Decimal::ZERO {
+            return Ok(vec![]);
+        }
+
+        let required_cash = share_quantity * spot;
+        if context.get_available_cash() < required_cash {
+            return Ok(vec![StrategyAction::Log {
+                level: LogLevel::Warning,
+                message: format!(
+                    "Covered call strategy needs at least {} cash to buy {} shares of {}",
+                    required_cash, share_quantity, underlying.symbol
+                ),
+            }]);
+        }
+
+        self.pending_share_entry = true;
+        Ok(vec![StrategyAction::PlaceOrder(Order::market_order(
+            underlying,
+            crate::orders::Side::Buy,
+            share_quantity,
+            self.config.strategy_id.clone(),
+        ))])
+    }
+
+    fn on_order_event(
+        &mut self,
+        event: &OrderEvent,
+        context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
+        let Some(underlying) = self.underlying_symbol().cloned() else {
+            return Ok(vec![]);
+        };
+
+        match event {
+            OrderEvent::OrderFilled { fill, .. }
+                if fill.symbol == underlying
+                    && fill.side == crate::orders::Side::Buy
+                    && !self.call_written =>
+            {
+                let held_shares = context
+                    .get_position(&underlying)
+                    .map(|position| position.quantity)
+                    .unwrap_or(Decimal::ZERO);
+                if held_shares < self.target_share_quantity() {
+                    return Ok(vec![]);
+                }
+
+                let Some(spot) = context.get_current_price(&underlying) else {
+                    return Ok(vec![]);
+                };
+
+                self.pending_share_entry = false;
+                self.call_written = true;
+                let order = self.build_covered_call_order(context, &underlying, spot);
+                Ok(vec![
+                    StrategyAction::WriteCoveredCall(order),
+                    StrategyAction::Log {
+                        level: LogLevel::Info,
+                        message: format!(
+                            "Wrote {} covered call contract(s) on {}",
+                            self.contracts, underlying.symbol
+                        ),
+                    },
+                ])
+            }
+            OrderEvent::OrderCanceled { .. }
+            | OrderEvent::OrderRejected { .. }
+            | OrderEvent::OrderExpired { .. } => {
+                self.pending_share_entry = false;
+                Ok(vec![])
+            }
+            _ => Ok(vec![]),
+        }
+    }
+
+    fn on_day_end(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+        Ok(vec![])
+    }
+
+    fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+        Ok(vec![])
+    }
+
+    fn get_config(&self) -> &StrategyConfig {
+        &self.config
+    }
+
     fn get_metrics(&self) -> StrategyMetrics {
         StrategyMetrics::new(self.config.strategy_id.clone())
     }
@@ -365,13 +620,13 @@ enum Signal {
 impl MovingAverageCrossoverStrategy {
     pub fn new(short_period: usize, long_period: usize) -> Self {
         let mut config = StrategyConfig::new(
-            "ma_crossover".to_string(), 
-            "Moving Average Crossover".to_string()
+            "ma_crossover".to_string(),
+            "Moving Average Crossover".to_string(),
         );
         config.set_parameter("short_period", short_period);
         config.set_parameter("long_period", long_period);
         config.set_parameter("position_size", 0.95f64); // Use 95% of available capital
-        
+
         Self {
             config,
             initialized: false,
@@ -381,19 +636,20 @@ impl MovingAverageCrossoverStrategy {
             last_signal: None,
         }
     }
-    
+
     fn calculate_sma(&self, prices: &[Decimal], period: usize) -> Option<Decimal> {
         if prices.len() < period {
             return None;
         }
-        
+
         let sum: Decimal = prices.iter().rev().take(period).sum();
         Some(sum / Decimal::from(period))
     }
-    
+
     fn get_recent_prices(&self, context: &StrategyContext, symbol: &Symbol) -> Vec<Decimal> {
         if let Some(buffer) = context.get_market_data(symbol) {
-            buffer.get_bars(self.long_period + 1)
+            buffer
+                .get_bars(self.long_period + 1)
                 .iter()
                 .map(|bar| bar.close)
                 .collect()
@@ -408,11 +664,16 @@ impl Strategy for MovingAverageCrossoverStrategy {
         self.config = config.clone();
         self.short_period = self.config.get_parameter("short_period").unwrap_or(10);
         self.long_period = self.config.get_parameter("long_period").unwrap_or(20);
-        self.position_size = self.config.get_parameter::<f64>("position_size").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::new(95, 2));
+        self.position_size = self
+            .config
+            .get_parameter::<f64>("position_size")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::new(95, 2));
         self.initialized = true;
         Ok(())
     }
-    
+
     fn on_market_event(
         &mut self,
         event: &MarketEvent,
@@ -421,17 +682,17 @@ impl Strategy for MovingAverageCrossoverStrategy {
         if !self.initialized {
             return Ok(vec![]);
         }
-        
+
         let symbol = event.symbol();
         let prices = self.get_recent_prices(context, symbol);
-        
+
         if prices.len() < self.long_period {
             return Ok(vec![]);
         }
-        
+
         let short_ma = self.calculate_sma(&prices, self.short_period);
         let long_ma = self.calculate_sma(&prices, self.long_period);
-        
+
         if let (Some(short), Some(long)) = (short_ma, long_ma) {
             let current_signal = if short > long {
                 Some(Signal::Buy)
@@ -440,11 +701,11 @@ impl Strategy for MovingAverageCrossoverStrategy {
             } else {
                 None
             };
-            
+
             // Check for signal change
             if current_signal != self.last_signal {
                 let mut actions = Vec::new();
-                
+
                 match current_signal {
                     Some(Signal::Buy) => {
                         // Close short position if any, then go long
@@ -454,12 +715,12 @@ impl Strategy for MovingAverageCrossoverStrategy {
                                     symbol.clone(),
                                     crate::orders::Side::Buy,
                                     position.quantity.abs(),
-                                    self.config.strategy_id.clone()
+                                    self.config.strategy_id.clone(),
                                 );
                                 actions.push(StrategyAction::PlaceOrder(close_order));
                             }
                         }
-                        
+
                         // Open long position
                         let available_cash = context.get_available_cash();
                         if let Some(price) = context.get_current_price(symbol) {
@@ -469,12 +730,12 @@ impl Strategy for MovingAverageCrossoverStrategy {
                                     symbol.clone(),
                                     crate::orders::Side::Buy,
                                     quantity,
-                                    self.config.strategy_id.clone()
+                                    self.config.strategy_id.clone(),
                                 );
                                 actions.push(StrategyAction::PlaceOrder(order));
                             }
                         }
-                    },
+                    }
                     Some(Signal::Sell) => {
                         // Close long position if any, then go short
                         if let Some(position) = context.get_position(symbol) {
@@ -483,12 +744,12 @@ impl Strategy for MovingAverageCrossoverStrategy {
                                     symbol.clone(),
                                     crate::orders::Side::Sell,
                                     position.quantity,
-                                    self.config.strategy_id.clone()
+                                    self.config.strategy_id.clone(),
                                 );
                                 actions.push(StrategyAction::PlaceOrder(close_order));
                             }
                         }
-                        
+
                         // Open short position (if shorting is enabled)
                         let portfolio_value = context.get_portfolio_value();
                         if let Some(price) = context.get_current_price(symbol) {
@@ -498,41 +759,45 @@ impl Strategy for MovingAverageCrossoverStrategy {
                                     symbol.clone(),
                                     crate::orders::Side::Sell,
                                     quantity,
-                                    self.config.strategy_id.clone()
+                                    self.config.strategy_id.clone(),
                                 );
                                 actions.push(StrategyAction::PlaceOrder(order));
                             }
                         }
-                    },
+                    }
                     None => {
                         // No clear signal, could close positions
                     }
                 }
-                
+
                 self.last_signal = current_signal;
                 return Ok(actions);
             }
         }
-        
+
         Ok(vec![])
     }
-    
-    fn on_order_event(&mut self, _event: &OrderEvent, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+
+    fn on_order_event(
+        &mut self,
+        _event: &OrderEvent,
+        _context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn on_day_end(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn get_config(&self) -> &StrategyConfig {
         &self.config
     }
-    
+
     fn get_metrics(&self) -> StrategyMetrics {
         StrategyMetrics::new(self.config.strategy_id.clone())
     }
@@ -553,34 +818,33 @@ pub struct MomentumStrategy {
 
 impl MomentumStrategy {
     pub fn new(lookback_period: usize, momentum_threshold: f64) -> Self {
-        let mut config = StrategyConfig::new(
-            "momentum".to_string(), 
-            "Momentum Strategy".to_string()
-        );
+        let mut config =
+            StrategyConfig::new("momentum".to_string(), "Momentum Strategy".to_string());
         config.set_parameter("lookback_period", lookback_period);
         config.set_parameter("momentum_threshold", momentum_threshold);
         config.set_parameter("position_size", 0.95f64);
         config.set_parameter("rebalance_frequency", 5); // Rebalance every 5 days
-        
+
         Self {
             config,
             initialized: false,
             lookback_period,
-            momentum_threshold: Decimal::from_f64_retain(momentum_threshold).unwrap_or(Decimal::new(5, 2)),
+            momentum_threshold: Decimal::from_f64_retain(momentum_threshold)
+                .unwrap_or(Decimal::new(5, 2)),
             position_size: Decimal::new(95, 2),
             rebalance_frequency: 5,
             days_since_rebalance: 0,
         }
     }
-    
+
     fn calculate_momentum(&self, prices: &[Decimal]) -> Option<Decimal> {
         if prices.len() < self.lookback_period {
             return None;
         }
-        
+
         let current_price = prices.last()?;
         let past_price = prices.get(prices.len() - self.lookback_period)?;
-        
+
         // Calculate percentage change
         if *past_price != Decimal::ZERO {
             Some((*current_price - *past_price) / *past_price * Decimal::from(100))
@@ -594,13 +858,26 @@ impl Strategy for MomentumStrategy {
     fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
         self.config = config.clone();
         self.lookback_period = self.config.get_parameter("lookback_period").unwrap_or(10);
-        self.momentum_threshold = self.config.get_parameter::<f64>("momentum_threshold").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::new(5, 2));
-        self.position_size = self.config.get_parameter::<f64>("position_size").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::new(95, 2));
-        self.rebalance_frequency = self.config.get_parameter("rebalance_frequency").unwrap_or(5);
+        self.momentum_threshold = self
+            .config
+            .get_parameter::<f64>("momentum_threshold")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::new(5, 2));
+        self.position_size = self
+            .config
+            .get_parameter::<f64>("position_size")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::new(95, 2));
+        self.rebalance_frequency = self
+            .config
+            .get_parameter("rebalance_frequency")
+            .unwrap_or(5);
         self.initialized = true;
         Ok(())
     }
-    
+
     fn on_market_event(
         &mut self,
         event: &MarketEvent,
@@ -609,22 +886,22 @@ impl Strategy for MomentumStrategy {
         if !self.initialized {
             return Ok(vec![]);
         }
-        
+
         let symbol = event.symbol();
-        
+
         // Only rebalance on specified frequency
         if self.days_since_rebalance < self.rebalance_frequency {
             return Ok(vec![]);
         }
-        
+
         if let Some(buffer) = context.get_market_data(symbol) {
             let bars = buffer.get_bars(self.lookback_period + 1);
             let prices: Vec<Decimal> = bars.iter().map(|bar| bar.close).collect();
-            
+
             if let Some(momentum) = self.calculate_momentum(&prices) {
                 let mut actions = Vec::new();
                 let current_position = context.get_position(symbol);
-                
+
                 if momentum > self.momentum_threshold {
                     // Strong positive momentum - go long
                     let target_quantity = if let Some(price) = context.get_current_price(symbol) {
@@ -632,22 +909,25 @@ impl Strategy for MomentumStrategy {
                     } else {
                         Decimal::ZERO
                     };
-                    
-                    let current_quantity = current_position.map(|p| p.quantity).unwrap_or(Decimal::ZERO);
+
+                    let current_quantity = current_position
+                        .map(|p| p.quantity)
+                        .unwrap_or(Decimal::ZERO);
                     let quantity_diff = target_quantity - current_quantity;
-                    
-                    if quantity_diff.abs() > Decimal::new(1, 4) { // Minimum trade size
+
+                    if quantity_diff.abs() > Decimal::new(1, 4) {
+                        // Minimum trade size
                         let side = if quantity_diff > Decimal::ZERO {
                             crate::orders::Side::Buy
                         } else {
                             crate::orders::Side::Sell
                         };
-                        
+
                         let order = Order::market_order(
                             symbol.clone(),
                             side,
                             quantity_diff.abs(),
-                            self.config.strategy_id.clone()
+                            self.config.strategy_id.clone(),
                         );
                         actions.push(StrategyAction::PlaceOrder(order));
                     }
@@ -659,38 +939,42 @@ impl Strategy for MomentumStrategy {
                                 symbol.clone(),
                                 crate::orders::Side::Sell,
                                 position.quantity,
-                                self.config.strategy_id.clone()
+                                self.config.strategy_id.clone(),
                             );
                             actions.push(StrategyAction::PlaceOrder(order));
                         }
                     }
                 }
-                
+
                 self.days_since_rebalance = 0;
                 return Ok(actions);
             }
         }
-        
+
         Ok(vec![])
     }
-    
-    fn on_order_event(&mut self, _event: &OrderEvent, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+
+    fn on_order_event(
+        &mut self,
+        _event: &OrderEvent,
+        _context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn on_day_end(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         self.days_since_rebalance += 1;
         Ok(vec![])
     }
-    
+
     fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn get_config(&self) -> &StrategyConfig {
         &self.config
     }
-    
+
     fn get_metrics(&self) -> StrategyMetrics {
         StrategyMetrics::new(self.config.strategy_id.clone())
     }
@@ -724,15 +1008,15 @@ pub struct RsiStrategy {
 impl MeanReversionStrategy {
     pub fn new(lookback_period: usize, entry_threshold: f64, exit_threshold: f64) -> Self {
         let mut config = StrategyConfig::new(
-            "mean_reversion".to_string(), 
-            "Mean Reversion Strategy".to_string()
+            "mean_reversion".to_string(),
+            "Mean Reversion Strategy".to_string(),
         );
         config.set_parameter("lookback_period", lookback_period);
         config.set_parameter("entry_threshold", entry_threshold);
         config.set_parameter("exit_threshold", exit_threshold);
         config.set_parameter("position_size", 0.25f64); // Smaller positions for mean reversion
         config.set_parameter("max_position_size", 0.95f64);
-        
+
         Self {
             config,
             initialized: false,
@@ -743,28 +1027,37 @@ impl MeanReversionStrategy {
             max_position_size: Decimal::new(95, 2),
         }
     }
-    
+
     fn calculate_z_score(&self, prices: &[Decimal]) -> Option<Decimal> {
         if prices.len() < self.lookback_period {
             return None;
         }
-        
-        let recent_prices: Vec<Decimal> = prices.iter().rev().take(self.lookback_period).cloned().collect();
+
+        let recent_prices: Vec<Decimal> = prices
+            .iter()
+            .rev()
+            .take(self.lookback_period)
+            .cloned()
+            .collect();
         let current_price = *prices.last()?;
-        
+
         // Calculate mean
-        let mean: Decimal = recent_prices.iter().sum::<Decimal>() / Decimal::from(recent_prices.len());
-        
+        let mean: Decimal =
+            recent_prices.iter().sum::<Decimal>() / Decimal::from(recent_prices.len());
+
         // Calculate standard deviation
-        let variance: Decimal = recent_prices.iter()
+        let variance: Decimal = recent_prices
+            .iter()
             .map(|price| (*price - mean) * (*price - mean))
-            .sum::<Decimal>() / Decimal::from(recent_prices.len());
-        
-        let std_dev = variance.to_f64()
+            .sum::<Decimal>()
+            / Decimal::from(recent_prices.len());
+
+        let std_dev = variance
+            .to_f64()
             .map(|v| v.sqrt())
             .and_then(Decimal::from_f64)
             .unwrap_or(Decimal::ZERO);
-        
+
         if std_dev != Decimal::ZERO {
             Some((current_price - mean) / std_dev)
         } else {
@@ -777,14 +1070,34 @@ impl Strategy for MeanReversionStrategy {
     fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
         self.config = config.clone();
         self.lookback_period = self.config.get_parameter("lookback_period").unwrap_or(20);
-        self.entry_threshold = self.config.get_parameter::<f64>("entry_threshold").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::from(2));
-        self.exit_threshold = self.config.get_parameter::<f64>("exit_threshold").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::from(1));
-        self.position_size = self.config.get_parameter::<f64>("position_size").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::new(25, 2));
-        self.max_position_size = self.config.get_parameter::<f64>("max_position_size").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::new(95, 2));
+        self.entry_threshold = self
+            .config
+            .get_parameter::<f64>("entry_threshold")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::from(2));
+        self.exit_threshold = self
+            .config
+            .get_parameter::<f64>("exit_threshold")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::from(1));
+        self.position_size = self
+            .config
+            .get_parameter::<f64>("position_size")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::new(25, 2));
+        self.max_position_size = self
+            .config
+            .get_parameter::<f64>("max_position_size")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::new(95, 2));
         self.initialized = true;
         Ok(())
     }
-    
+
     fn on_market_event(
         &mut self,
         event: &MarketEvent,
@@ -793,34 +1106,39 @@ impl Strategy for MeanReversionStrategy {
         if !self.initialized {
             return Ok(vec![]);
         }
-        
+
         let symbol = event.symbol();
-        
+
         if let Some(buffer) = context.get_market_data(symbol) {
             let bars = buffer.get_bars(self.lookback_period + 5); // Extra buffer for calculation
             let prices: Vec<Decimal> = bars.iter().map(|bar| bar.close).collect();
-            
+
             if let Some(z_score) = self.calculate_z_score(&prices) {
                 let mut actions = Vec::new();
                 let current_position = context.get_position(symbol);
-                let current_quantity = current_position.map(|p| p.quantity).unwrap_or(Decimal::ZERO);
-                
+                let current_quantity = current_position
+                    .map(|p| p.quantity)
+                    .unwrap_or(Decimal::ZERO);
+
                 // Entry signals
                 if z_score < -self.entry_threshold {
                     // Price is significantly below mean - buy opportunity
                     let available_cash = context.get_available_cash();
                     if let Some(price) = context.get_current_price(symbol) {
-                        let max_quantity = (context.get_portfolio_value() * self.max_position_size) / price;
-                        let position_increment = (context.get_portfolio_value() * self.position_size) / price;
-                        
+                        let max_quantity =
+                            (context.get_portfolio_value() * self.max_position_size) / price;
+                        let position_increment =
+                            (context.get_portfolio_value() * self.position_size) / price;
+
                         if current_quantity < max_quantity {
-                            let quantity = (max_quantity - current_quantity).min(position_increment);
+                            let quantity =
+                                (max_quantity - current_quantity).min(position_increment);
                             if quantity > Decimal::new(1, 4) && available_cash > quantity * price {
                                 let order = Order::market_order(
                                     symbol.clone(),
                                     crate::orders::Side::Buy,
                                     quantity,
-                                    self.config.strategy_id.clone()
+                                    self.config.strategy_id.clone(),
                                 );
                                 actions.push(StrategyAction::PlaceOrder(order));
                             }
@@ -830,93 +1148,96 @@ impl Strategy for MeanReversionStrategy {
                     // Price is significantly above mean - sell opportunity
                     let portfolio_value = context.get_portfolio_value();
                     if let Some(price) = context.get_current_price(symbol) {
-                        let max_short_quantity = -(portfolio_value * self.max_position_size) / price;
+                        let max_short_quantity =
+                            -(portfolio_value * self.max_position_size) / price;
                         let position_decrement = (portfolio_value * self.position_size) / price;
-                        
+
                         if current_quantity > max_short_quantity {
-                            let quantity = (current_quantity - max_short_quantity).min(position_decrement);
+                            let quantity =
+                                (current_quantity - max_short_quantity).min(position_decrement);
                             if quantity > Decimal::new(1, 4) {
                                 let order = Order::market_order(
                                     symbol.clone(),
                                     crate::orders::Side::Sell,
                                     quantity,
-                                    self.config.strategy_id.clone()
+                                    self.config.strategy_id.clone(),
                                 );
                                 actions.push(StrategyAction::PlaceOrder(order));
                             }
                         }
                     }
                 }
-                
+
                 // Exit signals - take profits when price moves back toward mean
                 if current_quantity > Decimal::ZERO && z_score > -self.exit_threshold {
                     // Long position, price moving back up toward mean
                     let exit_quantity = current_quantity.min(
-                        (context.get_portfolio_value() * self.position_size) / 
-                        context.get_current_price(symbol).unwrap_or(Decimal::ONE)
+                        (context.get_portfolio_value() * self.position_size)
+                            / context.get_current_price(symbol).unwrap_or(Decimal::ONE),
                     );
-                    
+
                     if exit_quantity > Decimal::new(1, 4) {
                         let order = Order::market_order(
                             symbol.clone(),
                             crate::orders::Side::Sell,
                             exit_quantity,
-                            self.config.strategy_id.clone()
+                            self.config.strategy_id.clone(),
                         );
                         actions.push(StrategyAction::PlaceOrder(order));
                     }
                 } else if current_quantity < Decimal::ZERO && z_score < self.exit_threshold {
                     // Short position, price moving back down toward mean
                     let exit_quantity = current_quantity.abs().min(
-                        (context.get_portfolio_value() * self.position_size) / 
-                        context.get_current_price(symbol).unwrap_or(Decimal::ONE)
+                        (context.get_portfolio_value() * self.position_size)
+                            / context.get_current_price(symbol).unwrap_or(Decimal::ONE),
                     );
-                    
+
                     if exit_quantity > Decimal::new(1, 4) {
                         let order = Order::market_order(
                             symbol.clone(),
                             crate::orders::Side::Buy,
                             exit_quantity,
-                            self.config.strategy_id.clone()
+                            self.config.strategy_id.clone(),
                         );
                         actions.push(StrategyAction::PlaceOrder(order));
                     }
                 }
-                
+
                 return Ok(actions);
             }
         }
-        
+
         Ok(vec![])
     }
-    
-    fn on_order_event(&mut self, _event: &OrderEvent, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+
+    fn on_order_event(
+        &mut self,
+        _event: &OrderEvent,
+        _context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn on_day_end(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn on_stop(&mut self, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
-    
+
     fn get_config(&self) -> &StrategyConfig {
         &self.config
     }
-    
+
     fn get_metrics(&self) -> StrategyMetrics {
         StrategyMetrics::new(self.config.strategy_id.clone())
     }
-} 
+}
 
 impl RsiStrategy {
     pub fn new(lookback_period: usize, oversold_threshold: f64, overbought_threshold: f64) -> Self {
-        let mut config = StrategyConfig::new(
-            "rsi".to_string(),
-            "RSI Strategy".to_string()
-        );
+        let mut config = StrategyConfig::new("rsi".to_string(), "RSI Strategy".to_string());
         config.set_parameter("lookback_period", lookback_period);
         config.set_parameter("oversold_threshold", oversold_threshold);
         config.set_parameter("overbought_threshold", overbought_threshold);
@@ -926,8 +1247,10 @@ impl RsiStrategy {
             config,
             initialized: false,
             lookback_period,
-            oversold_threshold: Decimal::from_f64_retain(oversold_threshold).unwrap_or(Decimal::from(30)),
-            overbought_threshold: Decimal::from_f64_retain(overbought_threshold).unwrap_or(Decimal::from(70)),
+            oversold_threshold: Decimal::from_f64_retain(oversold_threshold)
+                .unwrap_or(Decimal::from(30)),
+            overbought_threshold: Decimal::from_f64_retain(overbought_threshold)
+                .unwrap_or(Decimal::from(70)),
             position_size: Decimal::new(95, 2),
         }
     }
@@ -940,7 +1263,12 @@ impl RsiStrategy {
         let mut gains = Decimal::ZERO;
         let mut losses = Decimal::ZERO;
 
-        let recent_prices = prices.iter().rev().take(self.lookback_period + 1).cloned().collect::<Vec<_>>();
+        let recent_prices = prices
+            .iter()
+            .rev()
+            .take(self.lookback_period + 1)
+            .cloned()
+            .collect::<Vec<_>>();
         let mut recent_prices = recent_prices.into_iter().rev();
         let mut previous = recent_prices.next()?;
 
@@ -975,9 +1303,24 @@ impl Strategy for RsiStrategy {
     fn initialize(&mut self, config: &StrategyConfig) -> Result<(), String> {
         self.config = config.clone();
         self.lookback_period = self.config.get_parameter("lookback_period").unwrap_or(14);
-        self.oversold_threshold = self.config.get_parameter::<f64>("oversold_threshold").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::from(30));
-        self.overbought_threshold = self.config.get_parameter::<f64>("overbought_threshold").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::from(70));
-        self.position_size = self.config.get_parameter::<f64>("position_size").map(Decimal::from_f64_retain).flatten().unwrap_or(Decimal::new(95, 2));
+        self.oversold_threshold = self
+            .config
+            .get_parameter::<f64>("oversold_threshold")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::from(30));
+        self.overbought_threshold = self
+            .config
+            .get_parameter::<f64>("overbought_threshold")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::from(70));
+        self.position_size = self
+            .config
+            .get_parameter::<f64>("position_size")
+            .map(Decimal::from_f64_retain)
+            .flatten()
+            .unwrap_or(Decimal::new(95, 2));
         self.initialized = true;
         Ok(())
     }
@@ -999,7 +1342,9 @@ impl Strategy for RsiStrategy {
             if let Some(rsi) = self.calculate_rsi(&prices) {
                 let mut actions = Vec::new();
                 let current_position = context.get_position(symbol);
-                let current_quantity = current_position.map(|p| p.quantity).unwrap_or(Decimal::ZERO);
+                let current_quantity = current_position
+                    .map(|p| p.quantity)
+                    .unwrap_or(Decimal::ZERO);
 
                 if rsi < self.oversold_threshold {
                     let target_quantity = if let Some(price) = context.get_current_price(symbol) {
@@ -1014,7 +1359,7 @@ impl Strategy for RsiStrategy {
                             symbol.clone(),
                             crate::orders::Side::Buy,
                             quantity_diff,
-                            self.config.strategy_id.clone()
+                            self.config.strategy_id.clone(),
                         );
                         actions.push(StrategyAction::PlaceOrder(order));
                     }
@@ -1024,7 +1369,7 @@ impl Strategy for RsiStrategy {
                             symbol.clone(),
                             crate::orders::Side::Sell,
                             current_quantity,
-                            self.config.strategy_id.clone()
+                            self.config.strategy_id.clone(),
                         );
                         actions.push(StrategyAction::PlaceOrder(order));
                     }
@@ -1037,7 +1382,11 @@ impl Strategy for RsiStrategy {
         Ok(vec![])
     }
 
-    fn on_order_event(&mut self, _event: &OrderEvent, _context: &StrategyContext) -> Result<Vec<StrategyAction>, String> {
+    fn on_order_event(
+        &mut self,
+        _event: &OrderEvent,
+        _context: &StrategyContext,
+    ) -> Result<Vec<StrategyAction>, String> {
         Ok(vec![])
     }
 
@@ -1061,7 +1410,7 @@ impl Strategy for RsiStrategy {
 #[cfg(test)]
 mod strategy_tests {
     use super::*;
-    use crate::market::{Bar, AssetClass, Resolution};
+    use crate::market::{AssetClass, Bar, Resolution};
     use rust_decimal_macros::dec;
 
     fn create_test_symbol() -> Symbol {
@@ -1083,14 +1432,14 @@ mod strategy_tests {
 
     fn create_test_context_with_data(bars: Vec<Bar>) -> StrategyContext {
         let mut context = StrategyContext::new("test_strategy".to_string(), dec!(100000));
-        
+
         let symbol = create_test_symbol();
         let mut buffer = MarketDataBuffer::new(symbol.clone(), 50);
-        
+
         for bar in bars {
             buffer.add_event(MarketEvent::Bar(bar));
         }
-        
+
         context.market_data.insert(symbol, buffer);
         context
     }
@@ -1099,26 +1448,82 @@ mod strategy_tests {
     fn test_buy_and_hold_strategy() {
         let mut strategy = BuyAndHoldStrategy::new();
         let config = StrategyConfig::new("test_bah".to_string(), "Test Buy and Hold".to_string());
-        
+
         // Initialize strategy
         assert!(strategy.initialize(&config).is_ok());
         assert_eq!(strategy.get_config().strategy_id, "test_bah");
-        
+
         // Test metrics
         let metrics = strategy.get_metrics();
         assert_eq!(metrics.strategy_id, "test_bah");
     }
 
     #[test]
+    fn test_covered_call_strategy_enters_shares_then_writes_option() {
+        let mut strategy = CoveredCallStrategy::new();
+        let mut config =
+            StrategyConfig::new("test_cc".to_string(), "Test Covered Call".to_string());
+        config.add_symbol(create_test_symbol());
+        config.set_parameter("contracts", 1.0f64);
+        config.set_parameter("call_otm_pct", 10.0f64);
+        config.set_parameter("days_to_expiry", 7i64);
+
+        assert!(strategy.initialize(&config).is_ok());
+
+        let timestamp = Utc::now();
+        let bar = create_test_bar(dec!(150), timestamp);
+        let mut entry_context = create_test_context_with_data(vec![bar.clone()]);
+        entry_context.current_time = timestamp;
+        let entry_actions = strategy
+            .on_market_event(&MarketEvent::Bar(bar.clone()), &entry_context)
+            .unwrap();
+        assert_eq!(entry_actions.len(), 1);
+
+        let share_order = match &entry_actions[0] {
+            StrategyAction::PlaceOrder(order) => order.clone(),
+            other => panic!("expected share entry order, got {other:?}"),
+        };
+        assert_eq!(share_order.quantity, dec!(100));
+
+        let mut filled_context = create_test_context_with_data(vec![bar.clone()]);
+        filled_context.current_time = timestamp;
+        let fill = crate::orders::Fill::new(
+            share_order.id,
+            create_test_symbol(),
+            crate::orders::Side::Buy,
+            dec!(100),
+            dec!(150),
+            Decimal::ZERO,
+            "test_cc".to_string(),
+        );
+        filled_context.portfolio.apply_fill(&fill);
+
+        let option_actions = strategy
+            .on_order_event(
+                &OrderEvent::OrderFilled {
+                    order_id: share_order.id,
+                    fill,
+                },
+                &filled_context,
+            )
+            .unwrap();
+
+        assert!(option_actions
+            .iter()
+            .any(|action| matches!(action, StrategyAction::WriteCoveredCall(_))));
+    }
+
+    #[test]
     fn test_moving_average_crossover_strategy() {
         let mut strategy = MovingAverageCrossoverStrategy::new(5, 10);
-        let mut config = StrategyConfig::new("test_ma".to_string(), "Test MA Crossover".to_string());
+        let mut config =
+            StrategyConfig::new("test_ma".to_string(), "Test MA Crossover".to_string());
         config.add_symbol(create_test_symbol());
-        
+
         // Initialize strategy
         assert!(strategy.initialize(&config).is_ok());
         assert_eq!(strategy.get_config().strategy_id, "test_ma");
-        
+
         // Create test data with upward trend
         let mut bars = Vec::new();
         let base_time = Utc::now();
@@ -1127,13 +1532,13 @@ mod strategy_tests {
             let bar = create_test_bar(price, base_time + chrono::Duration::days(i));
             bars.push(bar);
         }
-        
+
         let context = create_test_context_with_data(bars);
-        
+
         // Test market event processing
         let last_bar = create_test_bar(dec!(115), base_time + chrono::Duration::days(15));
         let event = MarketEvent::Bar(last_bar);
-        
+
         let actions = strategy.on_market_event(&event, &context);
         assert!(actions.is_ok());
         // Should generate buy signal as short MA crosses above long MA
@@ -1142,13 +1547,14 @@ mod strategy_tests {
     #[test]
     fn test_momentum_strategy() {
         let mut strategy = MomentumStrategy::new(5, 0.05); // 5-day lookback, 5% threshold
-        let mut config = StrategyConfig::new("test_momentum".to_string(), "Test Momentum".to_string());
+        let mut config =
+            StrategyConfig::new("test_momentum".to_string(), "Test Momentum".to_string());
         config.add_symbol(create_test_symbol());
-        
+
         // Initialize strategy
         assert!(strategy.initialize(&config).is_ok());
         assert_eq!(strategy.get_config().strategy_id, "test_momentum");
-        
+
         // Create test data with strong upward momentum
         let mut bars = Vec::new();
         let base_time = Utc::now();
@@ -1157,18 +1563,18 @@ mod strategy_tests {
             let bar = create_test_bar(price, base_time + chrono::Duration::days(i));
             bars.push(bar);
         }
-        
+
         let context = create_test_context_with_data(bars);
-        
+
         // Test market event processing after rebalance period
         strategy.days_since_rebalance = 5; // Set to rebalance frequency
-        
+
         let last_bar = create_test_bar(dec!(120), base_time + chrono::Duration::days(10));
         let event = MarketEvent::Bar(last_bar);
-        
+
         let actions = strategy.on_market_event(&event, &context);
         assert!(actions.is_ok());
-        
+
         // Test day end increment
         let day_end_actions = strategy.on_day_end(&context);
         assert!(day_end_actions.is_ok());
@@ -1178,31 +1584,34 @@ mod strategy_tests {
     #[test]
     fn test_mean_reversion_strategy() {
         let mut strategy = MeanReversionStrategy::new(10, 2.0, 1.0); // 10-day lookback, 2.0 entry, 1.0 exit
-        let mut config = StrategyConfig::new("test_mean_rev".to_string(), "Test Mean Reversion".to_string());
+        let mut config = StrategyConfig::new(
+            "test_mean_rev".to_string(),
+            "Test Mean Reversion".to_string(),
+        );
         config.add_symbol(create_test_symbol());
-        
+
         // Initialize strategy
         assert!(strategy.initialize(&config).is_ok());
         assert_eq!(strategy.get_config().strategy_id, "test_mean_rev");
-        
+
         // Create test data with mean-reverting pattern
         let mut bars = Vec::new();
         let base_time = Utc::now();
         let base_price = dec!(100);
-        
+
         // First create stable prices around 100
         for i in 0..10 {
             let price = base_price + Decimal::from(i % 3 - 1); // 99, 100, 101 pattern
             let bar = create_test_bar(price, base_time + chrono::Duration::days(i));
             bars.push(bar);
         }
-        
+
         let context = create_test_context_with_data(bars);
-        
+
         // Test with price significantly below mean (should trigger buy)
         let low_bar = create_test_bar(dec!(90), base_time + chrono::Duration::days(11)); // -10% from mean
         let event = MarketEvent::Bar(low_bar);
-        
+
         let actions = strategy.on_market_event(&event, &context);
         assert!(actions.is_ok());
         // Should generate buy signal as price is far below mean
@@ -1211,7 +1620,14 @@ mod strategy_tests {
     #[test]
     fn test_rsi_calculation() {
         let strategy = RsiStrategy::new(5, 30.0, 70.0);
-        let prices = vec![dec!(100), dec!(102), dec!(104), dec!(103), dec!(105), dec!(107)];
+        let prices = vec![
+            dec!(100),
+            dec!(102),
+            dec!(104),
+            dec!(103),
+            dec!(105),
+            dec!(107),
+        ];
 
         let rsi = strategy.calculate_rsi(&prices);
         assert!(rsi.is_some());
@@ -1236,7 +1652,10 @@ mod strategy_tests {
         }
 
         let context = create_test_context_with_data(bars);
-        let event = MarketEvent::Bar(create_test_bar(dec!(92), base_time + chrono::Duration::days(7)));
+        let event = MarketEvent::Bar(create_test_bar(
+            dec!(92),
+            base_time + chrono::Duration::days(7),
+        ));
         let actions = strategy.on_market_event(&event, &context);
         assert!(actions.is_ok());
     }
@@ -1245,10 +1664,10 @@ mod strategy_tests {
     fn test_momentum_calculation() {
         let strategy = MomentumStrategy::new(3, 0.05);
         let prices = vec![dec!(100), dec!(102), dec!(101), dec!(105)]; // +5% over 3 periods from start to end
-        
+
         let momentum = strategy.calculate_momentum(&prices);
         assert!(momentum.is_some());
-        
+
         let result = momentum.unwrap();
         // (105 - 102) / 102 * 100 = 2.94% (comparing current to 3 periods ago)
         let expected = (dec!(105) - dec!(102)) / dec!(102) * dec!(100);
@@ -1259,26 +1678,27 @@ mod strategy_tests {
     fn test_z_score_calculation() {
         let strategy = MeanReversionStrategy::new(4, 2.0, 1.0);
         let prices = vec![dec!(98), dec!(100), dec!(102), dec!(100), dec!(110)]; // Last price is outlier
-        
+
         let z_score = strategy.calculate_z_score(&prices);
         assert!(z_score.is_some());
-        
+
         let result = z_score.unwrap();
         // With mean around 100 and std dev around 4.47, z-score should be positive
         assert!(result > dec!(1)); // 110 is above the mean
     }
-    
+
     #[test]
     fn test_strategy_parameter_handling() {
         // Test that strategies properly handle custom parameters
-        let mut config = StrategyConfig::new("test_params".to_string(), "Test Parameters".to_string());
+        let mut config =
+            StrategyConfig::new("test_params".to_string(), "Test Parameters".to_string());
         config.set_parameter("short_period", 8);
         config.set_parameter("long_period", 21);
         config.set_parameter("position_size", 0.80f64);
-        
+
         let mut ma_strategy = MovingAverageCrossoverStrategy::new(5, 10);
         assert!(ma_strategy.initialize(&config).is_ok());
-        
+
         // Verify parameters were applied
         assert_eq!(ma_strategy.short_period, 8);
         assert_eq!(ma_strategy.long_period, 21);
@@ -1290,19 +1710,19 @@ mod strategy_tests {
     fn test_sma_calculation() {
         let strategy = MovingAverageCrossoverStrategy::new(3, 5);
         let prices = vec![dec!(100), dec!(101), dec!(102), dec!(103), dec!(104)];
-        
+
         // Test 3-period SMA
         let sma_3 = strategy.calculate_sma(&prices, 3);
         assert!(sma_3.is_some());
         assert_eq!(sma_3.unwrap(), dec!(103)); // (102 + 103 + 104) / 3
-        
+
         // Test 5-period SMA
         let sma_5 = strategy.calculate_sma(&prices, 5);
         assert!(sma_5.is_some());
         assert_eq!(sma_5.unwrap(), dec!(102)); // (100 + 101 + 102 + 103 + 104) / 5
-        
+
         // Test insufficient data
         let sma_6 = strategy.calculate_sma(&prices, 6);
         assert!(sma_6.is_none());
     }
-} 
+}

--- a/docs/assumptions-and-limitations.md
+++ b/docs/assumptions-and-limitations.md
@@ -33,8 +33,9 @@ GlowBack already covers a meaningful research workflow, but it is still an alpha
 
 ## Options workflow
 
-- The `gb-options` crate provides pricing and contract primitives, but end-to-end options backtesting is still incomplete.
-- Use options support as an experimental surface until the documented engine/accounting path is complete.
+- The `gb-options` crate now has one documented end-to-end engine path: an experimental covered-call workflow that buys 100 shares, prices a short call with Black-Scholes greeks, and records option lifecycle events in Rust/Python/API result payloads.
+- Broader multi-leg options accounting, mark-to-market liability treatment, and richer exercise/assignment flows are still incomplete.
+- Use options support as an experimental surface until the documented engine/accounting path is broader than the current covered-call slice.
 
 ## How to use this page
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,9 +4,9 @@
 
 Run `./scripts/quickstart.sh` from the repository root. It is the same smoke path used by CI and verifies the core Rust example before you spend time on API/UI setup.
 
-## Why does the quickstart say four strategies if the docs list five?
+## Why does the quickstart say four strategies if the docs list six?
 
-The Rust/Python strategy library currently includes five built-ins: `buy_and_hold`, `ma_crossover`, `momentum`, `mean_reversion`, and `rsi`. The quickstart smoke example exercises four non-RSI strategies and keeps its historical success marker so CI can detect drift.
+The Rust/Python strategy library currently includes six built-ins: `buy_and_hold`, `ma_crossover`, `momentum`, `mean_reversion`, `rsi`, and the experimental `covered_call`. The quickstart smoke example still exercises four strategies and keeps its historical success marker so CI can detect drift.
 
 ## Do I need Rust installed to use the UI?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ High‑performance quantitative backtesting platform built in Rust with Python b
 - Event‑driven simulation engine with realistic execution models
 - Data ingestion (CSV, Alpha Vantage, sample data)
 - Arrow/Parquet storage with SQLite metadata catalog
-- Strategy library (5 built‑in strategies; the quickstart smoke path exercises four of them)
+- Strategy library (6 built‑in strategies, including an experimental covered-call workflow; the quickstart smoke path exercises four of them)
 - Python bindings with async support
 - Streamlit UI for strategy development and analysis
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -61,10 +61,52 @@ let iv = implied_volatility(&contract, 8.50, 155.0, 0.05, 0.0, 0.25);
 println!("IV: {:?}", iv);
 ```
 
+## Engine-backed covered-call workflow (experimental)
+
+GlowBack now exposes a narrow end-to-end options path for a covered call:
+
+- `covered_call` is available as a built-in strategy in Rust manifests, the Python bindings, and the engine-backed API/runtime.
+- The strategy buys 100 shares of the underlying, writes one short call, and records the contract premium plus Black-Scholes greeks at entry.
+- Completed runs include `option_trades` and `option_events` payloads alongside the normal equity `trades`/`order_events` so downstream API and Python consumers can inspect option lifecycle details.
+
+Python example:
+
+```python
+from datetime import datetime, timezone
+from glowback_runtime import run_backtest
+
+result = run_backtest(
+    symbols=["AAPL"],
+    start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    end_date=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    strategy_name="covered_call",
+    strategy_params={
+        "contracts": 1,
+        "call_otm_pct": 5.0,
+        "days_to_expiry": 7,
+        "implied_volatility": 0.25,
+        "risk_free_rate": 0.01,
+        "commission_per_contract": 0.65,
+    },
+    data_source="sample",
+)
+
+print(result["option_trades"])
+print(result["option_events"])
+```
+
+Current limitations:
+
+- This is a single-leg covered-call path, not general multi-leg options backtesting.
+- The engine records option lifecycle metadata, but broader option liability mark-to-market accounting is still roadmap work.
+- Assignment/expiration logic is intentionally conservative and should be treated as a research aid, not broker-grade execution semantics.
+
 ## Tests
 
 ```bash
 cargo test -p gb-options
+cargo test -p gb-engine covered_call
+cargo test -p gb-python --locked --no-default-features covered_call
 ```
 
 34 unit tests covering:

--- a/examples/python_sdk_quickstart.py
+++ b/examples/python_sdk_quickstart.py
@@ -59,6 +59,7 @@ if __name__ == "__main__":
             "momentum",
             "mean_reversion",
             "rsi",
+            "covered_call",
         ],
         "BUILTIN_STRATEGIES drifted",
     )

--- a/glowback_runtime.py
+++ b/glowback_runtime.py
@@ -16,6 +16,9 @@ SUPPORTED_STRATEGIES: dict[str, str] = {
     "mean-reversion": "mean_reversion",
     "mean reversion": "mean_reversion",
     "rsi": "rsi",
+    "covered_call": "covered_call",
+    "covered-call": "covered_call",
+    "covered call": "covered_call",
 }
 
 _MANIFEST_REQUIRED_FIELDS = (
@@ -54,7 +57,7 @@ def normalize_strategy_name(name: str | None) -> str:
     if raw in SUPPORTED_STRATEGIES:
         return SUPPORTED_STRATEGIES[raw]
     raise ValueError(
-        "Unsupported strategy. Use one of: buy_and_hold, ma_crossover, momentum, mean_reversion, rsi."
+        "Unsupported strategy. Use one of: buy_and_hold, ma_crossover, momentum, mean_reversion, rsi, covered_call."
     )
 
 
@@ -196,6 +199,9 @@ def run_backtest(
     equity_curve = list(result.equity_curve)
     trades = list(result.trades)
     exposures = list(result.exposures)
+    order_events = list(result.order_events)
+    option_trades = list(result.option_trades)
+    option_events = list(result.option_events)
     logs = list(result.logs)
     final_positions = dict(result.final_positions)
     final_cash = float(result.final_cash)
@@ -206,6 +212,9 @@ def run_backtest(
         "equity_curve": equity_curve,
         "trades": trades,
         "exposures": exposures,
+        "order_events": order_events,
+        "option_trades": option_trades,
+        "option_events": option_events,
         "logs": logs,
         "final_cash": final_cash,
         "final_positions": final_positions,

--- a/ui/backtest_core.py
+++ b/ui/backtest_core.py
@@ -1039,11 +1039,13 @@ def _detect_strategy_name(strategy_code: str, config: dict[str, Any]) -> str:
         return "momentum"
     if "rsistrategy" in normalized_code or "rsi" in normalized_code:
         return "rsi"
+    if "coveredcall" in normalized_code or "covered call" in normalized_code:
+        return "covered_call"
     if "buyandhold" in normalized_code or "buy and hold" in normalized_code:
         return "buy_and_hold"
 
     raise ValueError(
-        "The real engine-backed runner supports built-in strategies only: buy_and_hold, ma_crossover, momentum, mean_reversion, rsi."
+        "The real engine-backed runner supports built-in strategies only: buy_and_hold, ma_crossover, momentum, mean_reversion, rsi, covered_call."
     )
 
 
@@ -1064,6 +1066,14 @@ def _strategy_params_for_engine(strategy_name: str, config: dict[str, Any]) -> d
         params.setdefault("lookback_period", int(config.get("lookback_period", 14)))
         params.setdefault("oversold_threshold", float(config.get("oversold_threshold", 30.0)))
         params.setdefault("overbought_threshold", float(config.get("overbought_threshold", 70.0)))
+    elif strategy_name == "covered_call":
+        params.setdefault("contracts", float(config.get("contracts", 1.0)))
+        params.setdefault("call_otm_pct", float(config.get("call_otm_pct", 5.0)))
+        params.setdefault("days_to_expiry", int(config.get("days_to_expiry", 7)))
+        params.setdefault("implied_volatility", float(config.get("implied_volatility", 0.25)))
+        params.setdefault("risk_free_rate", float(config.get("risk_free_rate", 0.01)))
+        params.setdefault("dividend_yield", float(config.get("dividend_yield", 0.0)))
+        params.setdefault("commission_per_contract", float(config.get("commission_per_contract", 0.65)))
 
     return params
 


### PR DESCRIPTION
## Summary
- add an experimental end-to-end covered-call path that buys shares, prices a short call with greeks, and records option lifecycle metadata in engine results
- expose option_trades and option_events through the Python runtime and API models, and teach manifest replay/UI helpers about the covered_call strategy
- document the new covered-call slice and add targeted engine/Python/API tests

## Testing
- cargo test -p gb-types covered_call
- cargo test -p gb-engine covered_call
- cargo test -p gb-python --no-default-features covered_call
- python -m unittest api.tests.test_backtest_adapter ui.tests.test_backtest_core

Fixes #111