### PR TITLE
fix: add Python SDK wheel packaging workflow

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build source distribution
         run: |
           python -m pip install --upgrade pip maturin
-          python -m maturin sdist --locked --manifest-path crates/gb-python/Cargo.toml --out dist
+          python -m maturin sdist --manifest-path crates/gb-python/Cargo.toml --out dist
       - uses: actions/upload-artifact@v4
         with:
           name: glowback-sdist

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,103 @@
+name: Python Wheels
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/gb-python/**"
+      - "examples/python_sdk_quickstart.py"
+      - "scripts/python_sdk_wheel_smoke.sh"
+      - ".github/workflows/python-wheels.yml"
+      - "README.md"
+      - "docs/api/python.md"
+      - "docs/examples/index.md"
+      - "docs/changelog.md"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/gb-python/**"
+      - "examples/python_sdk_quickstart.py"
+      - "scripts/python_sdk_wheel_smoke.sh"
+      - ".github/workflows/python-wheels.yml"
+      - "README.md"
+      - "docs/api/python.md"
+      - "docs/examples/index.md"
+      - "docs/changelog.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-wheels:
+    name: Build ${{ matrix.label }} wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            manylinux: 2014
+            artifact_name: glowback-wheel-linux-x86_64
+          - label: macos-x86_64
+            os: macos-13
+            target: x86_64-apple-darwin
+            manylinux: off
+            artifact_name: glowback-wheel-macos-x86_64
+          - label: macos-arm64
+            os: macos-14
+            target: aarch64-apple-darwin
+            manylinux: off
+            artifact_name: glowback-wheel-macos-arm64
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --locked --manifest-path crates/gb-python/Cargo.toml --out dist
+      - name: Smoke test built wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip virtualenv
+          python -m virtualenv .wheel-venv
+          source .wheel-venv/bin/activate
+          python -m pip install dist/glowback-*.whl
+          python examples/python_sdk_quickstart.py | tee wheel-smoke.log
+          grep -q "✅ Python SDK quickstart completed successfully" wheel-smoke.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Build source distribution
+        run: |
+          python -m pip install --upgrade pip maturin
+          python -m maturin sdist --locked --manifest-path crates/gb-python/Cargo.toml --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: glowback-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,16 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,21 +803,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1197,16 +1172,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
- "bytes",
+ "futures-util",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1594,23 +1570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,49 +1654,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2169,15 +2085,15 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2185,13 +2101,28 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2286,12 +2217,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2316,48 +2269,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2544,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -2687,12 +2618,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -2827,6 +2758,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3015,6 +2952,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi-util"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ High‑performance quantitative backtesting platform built in Rust with Python b
 
 [![CI](https://github.com/LatencyTDH/GlowBack/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/LatencyTDH/GlowBack/actions/workflows/rust.yml)
 [![Docs Smoke](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs-smoke.yml/badge.svg?branch=main)](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs-smoke.yml)
+[![Python Wheels](https://github.com/LatencyTDH/GlowBack/actions/workflows/python-wheels.yml/badge.svg?branch=main)](https://github.com/LatencyTDH/GlowBack/actions/workflows/python-wheels.yml)
 [![Docs](https://github.com/LatencyTDH/GlowBack/actions/workflows/docs.yml/badge.svg?branch=main)](https://latencytdh.github.io/GlowBack/)
 [![Rust Version](https://img.shields.io/badge/rust-stable-blue)](#getting-started)
 [![Python Support](https://img.shields.io/badge/python-3.10%2B-blue)](#python-bindings)
@@ -129,11 +130,14 @@ python -m pip install maturin
 maturin develop -m crates/gb-python/Cargo.toml
 ```
 
-Or run the checked-in clean-venv smoke path:
+Or run the checked-in clean-venv smoke paths:
 
 ```bash
 ./scripts/python_sdk_quickstart.sh
+./scripts/python_sdk_wheel_smoke.sh
 ```
+
+`./scripts/python_sdk_quickstart.sh` validates the editable-source install flow, while `./scripts/python_sdk_wheel_smoke.sh` builds a wheel, installs it into a fresh virtualenv, and reruns the same end-to-end example. CI publishes Linux x86_64 plus macOS x86_64/arm64 wheel artifacts from `.github/workflows/python-wheels.yml`, using PyO3's CPython 3.10+ abi3 compatibility so one wheel works across supported interpreter minors on each platform.
 
 The supported public surface is exported via `glowback.__all__`, and canonical built-in strategy IDs are available in `glowback.BUILTIN_STRATEGIES`.
 The Python runtime now also returns `order_events`, `option_trades`, and `option_events` when a strategy emits those lifecycle records.
@@ -153,7 +157,7 @@ manager.add_sample_provider()
 bars = manager.load_data(symbol, "2023-01-01T00:00:00Z", "2023-12-31T23:59:59Z", "day")
 ```
 
-`cargo test -p gb-python --locked --no-default-features` includes parity checks that compare the Python helpers with the direct Rust engine for `buy_and_hold`, `ma_crossover`, and the experimental `covered_call` path. The docs smoke workflow also runs `./scripts/python_sdk_quickstart.sh`, which builds `gb-python` in an isolated virtualenv and executes `examples/python_sdk_quickstart.py` end to end.
+`cargo test -p gb-python --locked --no-default-features` includes parity checks that compare the Python helpers with the direct Rust engine for `buy_and_hold`, `ma_crossover`, and the experimental `covered_call` path. The docs smoke workflow runs `./scripts/python_sdk_quickstart.sh`, and the dedicated Python wheel workflow builds Linux/macOS wheel artifacts plus a source distribution and smoke-installs those wheels before uploading them.
 
 For a reproducibility-focused companion path, run:
 
@@ -171,6 +175,7 @@ match the captured snapshot within tolerance.
 cargo test --workspace --locked --exclude gb-python
 cargo test -p gb-python --locked --no-default-features
 ./scripts/quickstart.sh
+./scripts/python_sdk_wheel_smoke.sh
 ./scripts/replay_manifest_tutorial.sh
 mkdocs build --strict
 ```

--- a/crates/gb-data/Cargo.toml
+++ b/crates/gb-data/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 
 # CSV and data format support
 csv = "1.3"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 # polars = { version = "0.49", features = ["lazy", "csv"] }
 
 # Local storage

--- a/crates/gb-python/Cargo.toml
+++ b/crates/gb-python/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 gb-types = { path = "../gb-types" }
 gb-data = { path = "../gb-data" }
 gb-engine = { path = "../gb-engine" }
-pyo3 = { version = "0.25", features = ["auto-initialize"] }
+pyo3 = { version = "0.25", features = ["auto-initialize", "abi3-py310"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/gb-python/pyproject.toml
+++ b/crates/gb-python/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["maturin>=1.13,<2"]
+build-backend = "maturin"
+
+[project]
+name = "glowback"
+version = "0.1.0"
+description = "Python bindings for GlowBack"
+requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Rust",
+  "License :: OSI Approved :: MIT License",
+]

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -11,11 +11,14 @@ python -m pip install maturin
 maturin develop -m crates/gb-python/Cargo.toml
 ```
 
-For a clean-checkout smoke path that creates an isolated virtualenv, builds the extension, and runs a checked-in example end to end:
+For clean-checkout smoke paths that validate both source installs and wheel installs end to end:
 
 ```bash
 ./scripts/python_sdk_quickstart.sh
+./scripts/python_sdk_wheel_smoke.sh
 ```
+
+`python_sdk_quickstart.sh` covers the editable `maturin develop` path. `python_sdk_wheel_smoke.sh` builds a wheel, installs it into a fresh virtualenv, and reruns the checked-in example so packaging drift is caught locally before CI.
 
 ## Supported public surface
 
@@ -28,11 +31,11 @@ print(glowback.__all__)
 print(glowback.BUILTIN_STRATEGIES)
 ```
 
-CI parity coverage for the binding lives in `cargo test -p gb-python --locked --no-default-features`, including direct Python-vs-Rust checks for `buy_and_hold` and `ma_crossover`. The docs smoke workflow also runs `./scripts/python_sdk_quickstart.sh` so the documented install/build path stays executable.
+CI parity coverage for the binding lives in `cargo test -p gb-python --locked --no-default-features`, including direct Python-vs-Rust checks for `buy_and_hold` and `ma_crossover`. The docs smoke workflow runs `./scripts/python_sdk_quickstart.sh`, and `.github/workflows/python-wheels.yml` builds CPython 3.10+ abi3 wheel artifacts for Linux x86_64 plus macOS x86_64/arm64, smoke-installs them, and uploads the matching source distribution.
 
 ## Quick Helper
 
-The checked-in companion example lives at `examples/python_sdk_quickstart.py` and exercises both the helper and `BacktestEngine` paths against sample data.
+The checked-in companion example lives at `examples/python_sdk_quickstart.py` and exercises both the helper and `BacktestEngine` paths against sample data. The wheel smoke script reuses this same example so the documented behavior stays aligned across editable installs and packaged artifacts.
 
 
 ```python
@@ -73,6 +76,7 @@ Supported built-ins:
 - `momentum`
 - `mean_reversion`
 - `rsi`
+- `covered_call`
 
 ## Classes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Python wheel packaging:** `gb-python` now builds as a CPython 3.10+ abi3 extension, ships a checked-in `./scripts/python_sdk_wheel_smoke.sh` installer validation path, and has a dedicated `python-wheels.yml` workflow that builds Linux/macOS wheel artifacts plus an sdist and smoke-installs each wheel before upload.
 - **Paper broker parity + audit trail:** `gb-live::PaperBroker` now keeps an append-only audit log for broker events, inventories rejection reasons for sell-over-inventory attempts, and ships a replay test that feeds a backtest order stream back through the paper broker to prove cash/position parity on the sample buy-and-hold path.
 - **Data quality summaries + strict mode:** `gb-data` now validates fetched datasets, persists per-symbol validation summaries in the catalog, records dataset provenance/price-adjustment metadata, and exposes those summaries through run manifests/result metadata. `DataSettings.data_quality_mode` defaults to `warn` and can be set to `fail` to reject datasets with critical issues before a backtest starts.
 - **Execution realism:** `gb-engine` now records order lifecycle events, respects time-in-force semantics for day/IOC/FOK orders, and caps fills by a configurable `max_volume_participation` setting so oversized orders can partially fill instead of always executing in one shot.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -52,6 +52,28 @@ Expected success marker:
 ✅ Python SDK quickstart completed successfully
 ```
 
+## Python SDK wheel smoke example
+
+- File: `scripts/python_sdk_wheel_smoke.sh`
+- Command:
+
+```bash
+./scripts/python_sdk_wheel_smoke.sh
+```
+
+What it proves:
+
+- `gb-python` can be packaged as a wheel from a clean checkout instead of only via editable source installs
+- the built wheel installs into a fresh virtualenv and still imports `glowback` without repo-local hacks
+- the same checked-in Python quickstart example succeeds after wheel installation, so packaging and runtime behavior stay in sync
+- the wheel path stays honest locally and in `.github/workflows/python-wheels.yml`
+
+Expected success marker:
+
+```text
+✅ Python SDK quickstart completed successfully
+```
+
 ## Rust engine lifecycle template
 
 - File: `crates/gb-engine/examples/strategy_lifecycle_template.rs`

--- a/scripts/python_sdk_wheel_smoke.sh
+++ b/scripts/python_sdk_wheel_smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "error: cargo is required for the GlowBack Python wheel smoke test" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required for the GlowBack Python wheel smoke test" >&2
+  exit 1
+fi
+
+OUT_DIR="${GLOWBACK_WHEEL_OUT_DIR:-$(mktemp -d)}"
+VENV_DIR="$(mktemp -d)"
+LOG_FILE="$(mktemp)"
+KEEP_OUT_DIR=0
+if [[ -n "${GLOWBACK_WHEEL_OUT_DIR:-}" ]]; then
+  KEEP_OUT_DIR=1
+  mkdir -p "$OUT_DIR"
+fi
+
+cleanup() {
+  rm -rf "$VENV_DIR"
+  rm -f "$LOG_FILE"
+  if [[ "$KEEP_OUT_DIR" -eq 0 ]]; then
+    rm -rf "$OUT_DIR"
+  fi
+}
+trap cleanup EXIT
+
+echo "==> Running the GlowBack Python wheel smoke test"
+echo "    Repo: $ROOT_DIR"
+echo "    Wheel output: $OUT_DIR"
+echo "    Venv: $VENV_DIR"
+
+python3 -m pip install --user --upgrade pip maturin virtualenv
+USER_BASE="$(python3 -c 'import site; print(site.USER_BASE)')"
+VIRTUALENV_BIN="$USER_BASE/bin/virtualenv"
+MATURIN_BIN="$USER_BASE/bin/maturin"
+"$VIRTUALENV_BIN" "$VENV_DIR"
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+"$MATURIN_BIN" build --release --locked --manifest-path crates/gb-python/Cargo.toml --out "$OUT_DIR"
+
+shopt -s nullglob
+wheels=("$OUT_DIR"/*.whl)
+shopt -u nullglob
+if [[ ${#wheels[@]} -ne 1 ]]; then
+  echo "error: expected exactly one wheel in $OUT_DIR, found ${#wheels[@]}" >&2
+  ls -1 "$OUT_DIR" >&2 || true
+  exit 1
+fi
+
+WHEEL_PATH="${wheels[0]}"
+echo "==> Installing $WHEEL_PATH"
+python -m pip install --force-reinstall "$WHEEL_PATH"
+python examples/python_sdk_quickstart.py | tee "$LOG_FILE"
+
+if ! grep -q "✅ Python SDK quickstart completed successfully" "$LOG_FILE"; then
+  echo "error: Python wheel smoke test did not reach the expected success marker" >&2
+  exit 1
+fi
+
+echo
+echo "Python wheel smoke test succeeded."
+echo "Wheel artifact: $WHEEL_PATH"


### PR DESCRIPTION
## Summary
- build `gb-python` as a CPython 3.10+ abi3 extension so one wheel can cover supported interpreter minors on each platform
- add a checked-in `./scripts/python_sdk_wheel_smoke.sh` path that builds a wheel, installs it into a fresh virtualenv, and reruns the Python SDK quickstart example
- add a dedicated `python-wheels.yml` workflow that builds Linux/macOS wheel artifacts plus an sdist and smoke-installs each built wheel before upload
- document the new wheel-install/package-validation flow across the README, Python API docs, examples index, and changelog

## Testing
- `cargo test -p gb-python --locked --no-default-features`
- `./scripts/python_sdk_wheel_smoke.sh`
- `mkdocs build --strict`

## Notes
- Roadmap slice for #107: this focuses the remaining Python SDK issue on distributable wheel packaging and clean-install validation without claiming the broader notebook gallery / typed API work is complete.

Addresses #107
