### PR TITLE
Fix gb-python for pyo3 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,15 +1330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,15 +1523,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1852,36 +1834,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1889,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1901,13 +1879,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -2752,12 +2729,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ crossbeam-channel = "0.5"
 num-traits = "0.2"
 rust_decimal = { version = "1.33", features = ["serde"] }
 rand = "0.9"
-pyo3 = { version = "0.25", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [profile.dev]
 debug = "line-tables-only"  # Reduces debug build size ~50%; backtraces still work

--- a/crates/gb-python/Cargo.toml
+++ b/crates/gb-python/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 gb-types = { path = "../gb-types" }
 gb-data = { path = "../gb-data" }
 gb-engine = { path = "../gb-engine" }
-pyo3 = { version = "0.25", features = ["auto-initialize", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["auto-initialize", "abi3-py310"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/gb-python/src/lib.rs
+++ b/crates/gb-python/src/lib.rs
@@ -1,6 +1,7 @@
 use num_traits::cast::ToPrimitive;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use pyo3::IntoPyObjectExt;
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 
@@ -1143,12 +1144,12 @@ impl PyBacktestResult {
 #[pymethods]
 impl PyBacktestResult {
     #[getter]
-    fn metrics_summary(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.metrics_summary.clone().into_pyobject(py)?.into())
+    fn metrics_summary(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.metrics_summary.clone().into_py_any(py)
     }
 
     #[getter]
-    fn equity_curve(&self, py: Python) -> PyResult<PyObject> {
+    fn equity_curve(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for point in &self.equity_curve {
             let dict = PyDict::new(py);
@@ -1169,11 +1170,11 @@ impl PyBacktestResult {
             let _ = dict.set_item("drawdown", point.drawdown);
             let _ = list.append(dict);
         }
-        Ok(list.unbind().into())
+        Ok(list.unbind().into_any())
     }
 
     #[getter]
-    fn trades(&self, py: Python) -> PyResult<PyObject> {
+    fn trades(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for trade in &self.trades {
             let dict = PyDict::new(py);
@@ -1194,11 +1195,11 @@ impl PyBacktestResult {
             let _ = dict.set_item("strategy_id", &trade.strategy_id);
             let _ = list.append(dict);
         }
-        Ok(list.unbind().into())
+        Ok(list.unbind().into_any())
     }
 
     #[getter]
-    fn exposures(&self, py: Python) -> PyResult<PyObject> {
+    fn exposures(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for exposure in &self.exposures {
             let dict = PyDict::new(py);
@@ -1209,11 +1210,11 @@ impl PyBacktestResult {
             let _ = dict.set_item("net_exposure_pct", exposure.net_exposure_pct);
             let _ = list.append(dict);
         }
-        Ok(list.unbind().into())
+        Ok(list.unbind().into_any())
     }
 
     #[getter]
-    fn order_events(&self, py: Python) -> PyResult<PyObject> {
+    fn order_events(&self, py: Python) -> PyResult<Py<PyAny>> {
         let json = py.import("json")?;
         let payload = serde_json::to_string(&self.order_events).map_err(|error| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -1221,11 +1222,11 @@ impl PyBacktestResult {
                 error
             ))
         })?;
-        Ok(json.call_method1("loads", (payload,))?.into())
+        Ok(json.call_method1("loads", (payload,))?.unbind())
     }
 
     #[getter]
-    fn option_trades(&self, py: Python) -> PyResult<PyObject> {
+    fn option_trades(&self, py: Python) -> PyResult<Py<PyAny>> {
         let json = py.import("json")?;
         let payload = serde_json::to_string(&self.option_trades).map_err(|error| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -1233,11 +1234,11 @@ impl PyBacktestResult {
                 error
             ))
         })?;
-        Ok(json.call_method1("loads", (payload,))?.into())
+        Ok(json.call_method1("loads", (payload,))?.unbind())
     }
 
     #[getter]
-    fn option_events(&self, py: Python) -> PyResult<PyObject> {
+    fn option_events(&self, py: Python) -> PyResult<Py<PyAny>> {
         let json = py.import("json")?;
         let payload = serde_json::to_string(&self.option_events).map_err(|error| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -1245,7 +1246,7 @@ impl PyBacktestResult {
                 error
             ))
         })?;
-        Ok(json.call_method1("loads", (payload,))?.into())
+        Ok(json.call_method1("loads", (payload,))?.unbind())
     }
 
     #[getter]
@@ -1259,12 +1260,12 @@ impl PyBacktestResult {
     }
 
     #[getter]
-    fn final_positions(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.final_positions.clone().into_pyobject(py)?.into())
+    fn final_positions(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.final_positions.clone().into_py_any(py)
     }
 
     #[getter]
-    fn manifest(&self, py: Python) -> PyResult<PyObject> {
+    fn manifest(&self, py: Python) -> PyResult<Py<PyAny>> {
         match &self.manifest {
             Some(manifest) => {
                 let json = py.import("json")?;
@@ -1274,7 +1275,7 @@ impl PyBacktestResult {
                         error
                     ))
                 })?;
-                Ok(json.call_method1("loads", (payload,))?.into())
+                Ok(json.call_method1("loads", (payload,))?.unbind())
             }
             None => Ok(py.None()),
         }
@@ -1282,7 +1283,7 @@ impl PyBacktestResult {
 
     /// Convert the equity curve to a pandas DataFrame (Jupyter-friendly)
     #[pyo3(signature = (index=None))]
-    fn to_dataframe(&self, py: Python, index: Option<&str>) -> PyResult<PyObject> {
+    fn to_dataframe(&self, py: Python, index: Option<&str>) -> PyResult<Py<PyAny>> {
         let pandas = py.import("pandas").map_err(|_| {
             pyo3::exceptions::PyImportError::new_err(
                 "pandas is required for to_dataframe(). Install with `pip install pandas`.",
@@ -1313,11 +1314,11 @@ impl PyBacktestResult {
             }
         }
 
-        Ok(df.into())
+        Ok(df.unbind())
     }
 
     /// Convert metrics summary to a pandas DataFrame (Jupyter-friendly)
-    fn metrics_dataframe(&self, py: Python) -> PyResult<PyObject> {
+    fn metrics_dataframe(&self, py: Python) -> PyResult<Py<PyAny>> {
         let pandas = py.import("pandas").map_err(|_| {
             pyo3::exceptions::PyImportError::new_err(
                 "pandas is required for metrics_dataframe(). Install with `pip install pandas`.",
@@ -1328,12 +1329,12 @@ impl PyBacktestResult {
         let series = pandas.getattr("Series")?.call1((metrics,))?;
         let df = series.call_method1("to_frame", ("value",))?;
         let df = df.call_method0("sort_index")?;
-        Ok(df.into())
+        Ok(df.unbind())
     }
 
     /// Plot the equity curve using matplotlib (returns Axes)
-    fn plot_equity(&self, py: Python, show: Option<bool>) -> PyResult<PyObject> {
-        let df = self.to_dataframe(py, None)?;
+    fn plot_equity(&self, py: Python, show: Option<bool>) -> PyResult<Py<PyAny>> {
+        let df = self.to_dataframe(py, None)?.into_bound(py);
         let plt = py.import("matplotlib.pyplot").map_err(|_| {
             pyo3::exceptions::PyImportError::new_err(
                 "matplotlib is required for plot_equity(). Install with `pip install matplotlib`.",
@@ -1344,19 +1345,19 @@ impl PyBacktestResult {
         kwargs.set_item("x", "timestamp")?;
         kwargs.set_item("y", "value")?;
         kwargs.set_item("title", "GlowBack Equity Curve")?;
-        let plot = df.getattr(py, "plot")?;
-        let ax = plot.call(py, (), Some(&kwargs))?;
+        let plot = df.getattr("plot")?;
+        let ax = plot.call((), Some(&kwargs))?;
 
         if show.unwrap_or(false) {
             let _ = plt.call_method0("show")?;
         }
 
-        Ok(ax.into())
+        Ok(ax.unbind())
     }
 
     /// Notebook-friendly summary with optional plot
     #[pyo3(signature = (plot=false, index=None))]
-    fn summary(&self, py: Python, plot: Option<bool>, index: Option<&str>) -> PyResult<PyObject> {
+    fn summary(&self, py: Python, plot: Option<bool>, index: Option<&str>) -> PyResult<Py<PyAny>> {
         let metrics = self.metrics_dataframe(py)?;
         let curve = self.to_dataframe(py, index)?;
 
@@ -1367,7 +1368,7 @@ impl PyBacktestResult {
         let summary = PyDict::new(py);
         summary.set_item("metrics", metrics)?;
         summary.set_item("equity_curve", curve)?;
-        Ok(summary.into())
+        Ok(summary.unbind().into_any())
     }
 
     fn __repr__(&self) -> String {
@@ -1577,7 +1578,7 @@ mod tests {
     const TEST_LATENCY_MS: u64 = 250;
 
     fn init_python() {
-        PYTHON_INIT.call_once(pyo3::prepare_freethreaded_python);
+        PYTHON_INIT.call_once(Python::initialize);
     }
 
     fn approx_eq(left: f64, right: f64, tolerance: f64) {
@@ -1592,7 +1593,7 @@ mod tests {
         params: &[(&str, i64)],
     ) -> PyBacktestResult {
         init_python();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let strategy_params = if params.is_empty() {
                 None
             } else {
@@ -1736,7 +1737,7 @@ mod tests {
     #[test]
     fn module_exports_define_the_supported_public_surface() {
         init_python();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::new(py, "glowback").unwrap();
             glowback(py, &module).unwrap();
 


### PR DESCRIPTION
## Summary
- Bump the workspace and gb-python PyO3 dependency from 0.25 to 0.29.0.
- Migrate gb-python Python object returns from the removed `PyObject` alias / ambiguous `into_pyobject(...).into()` conversions to explicit `Py<PyAny>` returns.
- Update PyO3 test helpers from `prepare_freethreaded_python` / `Python::with_gil` to the 0.29 `Python::initialize` / `Python::attach` APIs.

This supersedes the failing Dependabot pyo3 bump in #138 by making `Rust / gb-python` compile against PyO3 0.29.

## Local verification
- `cargo build -p gb-python --locked --verbose` ✅
- `cargo test -p gb-python --locked --no-default-features --verbose` ✅

Note: default-feature `cargo test -p gb-python` still hits the expected local PyO3 extension-module linker behavior; CI already runs gb-python tests with `--no-default-features`.
