### PR TITLE
ci: drop dead macos-x86_64 (Intel) wheel target

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -45,11 +45,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             manylinux: 2014
             artifact_name: glowback-wheel-linux-x86_64
-          - label: macos-x86_64
-            os: macos-13
-            target: x86_64-apple-darwin
-            manylinux: off
-            artifact_name: glowback-wheel-macos-x86_64
           - label: macos-arm64
             os: macos-14
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Problem
The `Build macos-x86_64 wheel` job (Python Wheels workflow) has been failing for **weeks**. GitHub-hosted `macos-13` (Intel) runners no longer get assigned, so the job sits queued and dies with:

> The job has exceeded the maximum execution time while awaiting a runner for 24h0m0s

This blocks every PR that touches `gb-python` from ever going fully green (e.g. #140, the pyo3 0.29 fix).

## Fix
Drop the dead `macos-x86_64` (Intel, `os: macos-13`) target from the build matrix. Remaining targets:
- `linux-x86_64`
- `macos-arm64` (Apple Silicon)

These cover real distribution. The wheels are abi3, so they stay portable across Python versions. Intel-macOS Python wheels are a dying need and not worth a permanently-broken CI job.

## Result
Python Wheels can complete again; gb-python PRs can reach a clean state.
