### PR TITLE
fix(dependabot): merge duplicate pip /ui entries (overlapping directories)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       - "rust"
       - "no-docs"
 
-  # Python dependencies in the UI directory (pyproject.toml)
+  # Python dependencies in the UI directory (covers pyproject.toml + requirements.txt)
   - package-ecosystem: "pip"
     directory: "/ui"
     schedule:
@@ -37,26 +37,6 @@ updates:
       - "sd"
     assignees:
       - "sd"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "python"
-      - "no-docs"
-
-  # Python dependencies in the UI directory (requirements.txt)
-  - package-ecosystem: "pip"
-    directory: "/ui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    groups:
-      ui-python:
-        update-types:
-          - "minor"
-          - "patch"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Problem
After #141 added `groups:` to the Dependabot config, GitHub's Dependabot config validator started failing on **every** PR with:

> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'pip' has overlapping directories.

The config had **two `pip` entries both pointing at `/ui`** (one notionally for `pyproject.toml`, one for `requirements.txt`). Dependabot tolerated the duplicate before, but identical `groups:` blocks on both made it a hard validation error.

## Fix
Merge the two `pip` `/ui` entries into a single entry. Modern Dependabot's `pip` ecosystem scans both `pyproject.toml` and `requirements.txt` in the directory, so one entry covers both. Kept the richer entry (reviewers/assignees/`open-pull-requests-limit`/grouping).

## Result
`.github/dependabot.yml` validates again; the failing config check clears on all open PRs.
