### PR TITLE
chore(dependabot): group arrow + parquet so they bump in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,19 @@ updates:
       day: "monday"
       time: "09:00"
     groups:
+      # arrow + parquet are version-locked in practice (parquet N requires arrow N).
+      # Group them together across ALL update types (including major) so a major
+      # bump like parquet 55 -> 59 always moves arrow in lockstep instead of
+      # splitting into separate PRs that can't compile. Listed first so it wins
+      # over the general cargo group below.
+      arrow-ecosystem:
+        patterns:
+          - "arrow*"
+          - "parquet*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       cargo:
         update-types:
           - "minor"


### PR DESCRIPTION
## Why
`parquet` and `arrow` are version-locked in practice — `parquet` N is built against `arrow` N's types. But Dependabot treats them as independent crates, so it bumps one without the other. That just broke PR #151 (`parquet` 55→59 while `arrow` stayed 55.2 → every crate failed to compile).

## Change
Add an `arrow-ecosystem` group to the cargo config that matches `arrow*` + `parquet*` across **all** update types (including **major**), listed before the general `cargo` group so it takes precedence. Result: arrow + parquet always bump together in a single PR, at every version level, and can never split into an uncompilable mismatch again.

The existing `cargo` (minor/patch) and `ui-python` groups are unchanged. Other crates' majors still arrive as individual PRs (correct — they warrant individual review).

## Note
This is the durable prevention for the class of failure seen in #151. #151 itself is being fixed separately (bump arrow+parquet to 59 in lockstep).
