### PR TITLE
feat: add optimization resume support

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -470,3 +470,19 @@ async def cancel_optimization(opt_id: str) -> dict:
             detail="Cannot cancel — optimization not found or already finished",
         )
     return {"optimization_id": opt_id, "state": "cancelled"}
+
+
+@app.post("/v1/optimizations/{opt_id}/resume", responses=VERSIONED_ERROR_RESPONSES)
+@app.post("/optimizations/{opt_id}/resume")
+async def resume_optimization(opt_id: str) -> OptimizationStatus:
+    """Resume a canceled or failed optimization run."""
+    prepared = await opt_store.prepare_resume(opt_id)
+    if not prepared:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot resume — optimization not found or not resumable",
+        )
+
+    status_obj, prior_trials = prepared
+    asyncio.create_task(opt_store.run_optimization(opt_id, prior_trials=prior_trials))
+    return status_obj

--- a/api/app/optimization_runtime.py
+++ b/api/app/optimization_runtime.py
@@ -99,9 +99,12 @@ class OptimizationExecutor:
         self,
         request: OptimizationRequest,
         is_cancelled=None,
+        prior_trials: list[TrialSummary] | None = None,
     ) -> OptimizationExecution:
-        trials: list[TrialSummary] = []
-        completed_trials: list[TrialSummary] = []
+        trials: list[TrialSummary] = list(prior_trials or [])
+        completed_trials: list[TrialSummary] = [
+            trial for trial in trials if trial.status == TrialStatus.completed
+        ]
 
         if request.strategy == SearchStrategyName.bayesian:
             parameter_sets: list[dict[str, Any]] | None = None
@@ -110,7 +113,8 @@ class OptimizationExecutor:
             if not parameter_sets:
                 raise RuntimeError("Search space produced no trial candidates")
 
-        for trial_number in range(1, request.max_trials + 1):
+        start_trial_number = len(trials) + 1
+        for trial_number in range(start_trial_number, request.max_trials + 1):
             if await self._is_cancelled(is_cancelled):
                 return self._build_execution(
                     request=request,
@@ -119,11 +123,14 @@ class OptimizationExecutor:
                     completed_trials=completed_trials,
                 )
 
-            parameters = (
-                parameter_sets[trial_number - 1]
-                if parameter_sets is not None
-                else self._next_bayesian_parameters(request, completed_trials, trial_number)
-            )
+            if parameter_sets is not None:
+                parameter_index = trial_number - 1
+                if parameter_index >= len(parameter_sets):
+                    break
+                parameters = parameter_sets[parameter_index]
+            else:
+                parameters = self._next_bayesian_parameters(request, completed_trials, trial_number)
+
             trial = await asyncio.to_thread(
                 self._evaluate_trial_sync,
                 request,
@@ -548,7 +555,7 @@ def build_optimization_diagnostics(
         "execution_mode": "local_python",
         "ray_cluster_requested": request.ray_cluster is not None,
         "cancellation_supported": True,
-        "resume_supported": False,
+        "resume_supported": True,
     }
 
     if not completed_trials or best_trial is None:
@@ -668,7 +675,7 @@ def build_optimization_manifest(
         "execution_plan": {
             "mode": "local_python",
             "ray_cluster_requested": request.ray_cluster is not None,
-            "resume_supported": False,
+            "resume_supported": True,
             "cancellation_supported": True,
         },
     }

--- a/api/app/optimization_store.py
+++ b/api/app/optimization_store.py
@@ -168,21 +168,27 @@ class OptimizationStore:
             record.finished_at = datetime.now(timezone.utc)
             return True
 
-    async def run_optimization(self, opt_id: str) -> None:
+    async def run_optimization(
+        self,
+        opt_id: str,
+        prior_trials: list[TrialSummary] | None = None,
+    ) -> None:
         async with self._lock:
             record = self._optimizations.get(opt_id)
-            if not record or record.state == OptimizationState.cancelled:
+            if not record:
+                return
+            if prior_trials is None and record.state == OptimizationState.cancelled:
                 return
             record.state = OptimizationState.running
-            record.started_at = datetime.now(timezone.utc)
+            record.started_at = record.started_at or datetime.now(timezone.utc)
             record.error = None
             request = record.request
 
         try:
-            execution = await self._executor.execute(
-                request,
-                is_cancelled=lambda: self._is_cancelled(opt_id),
-            )
+            execute_kwargs = {"is_cancelled": lambda: self._is_cancelled(opt_id)}
+            if prior_trials is not None:
+                execute_kwargs["prior_trials"] = prior_trials
+            execution = await self._executor.execute(request, **execute_kwargs)
         except Exception as exc:
             async with self._lock:
                 record = self._optimizations.get(opt_id)
@@ -194,6 +200,25 @@ class OptimizationStore:
             return
 
         await self._apply_execution(opt_id, execution)
+
+    async def prepare_resume(
+        self,
+        opt_id: str,
+    ) -> tuple[OptimizationStatus, list[TrialSummary]] | None:
+        async with self._lock:
+            record = self._optimizations.get(opt_id)
+            if not record or record.state not in {
+                OptimizationState.cancelled,
+                OptimizationState.failed,
+            }:
+                return None
+
+            prior_trials = [trial.to_summary() for trial in record.trials]
+            record.state = OptimizationState.running
+            record.started_at = record.started_at or datetime.now(timezone.utc)
+            record.finished_at = None
+            record.error = None
+            return record.to_status(), prior_trials
 
     async def _is_cancelled(self, opt_id: str) -> bool:
         async with self._lock:

--- a/api/tests/test_optimization_api.py
+++ b/api/tests/test_optimization_api.py
@@ -24,7 +24,7 @@ from api.app.optimization_store import OptimizationStore
 
 
 class FakeOptimizationExecutor:
-    async def execute(self, request, is_cancelled=None) -> OptimizationExecution:
+    async def execute(self, request, is_cancelled=None, prior_trials=None) -> OptimizationExecution:
         if is_cancelled is not None:
             cancelled = is_cancelled()
             if hasattr(cancelled, "__await__"):
@@ -84,7 +84,7 @@ class FakeOptimizationExecutor:
 
 
 class SlowCancellationExecutor:
-    async def execute(self, request, is_cancelled=None) -> OptimizationExecution:
+    async def execute(self, request, is_cancelled=None, prior_trials=None) -> OptimizationExecution:
         for _ in range(10):
             if is_cancelled is not None:
                 cancelled = is_cancelled()
@@ -94,6 +94,85 @@ class SlowCancellationExecutor:
                     return OptimizationExecution(state=OptimizationState.cancelled, trials=[])
             await asyncio.sleep(0.01)
         return OptimizationExecution(state=OptimizationState.completed, trials=[])
+
+
+class ResumeAwareExecutor:
+    async def execute(self, request, is_cancelled=None, prior_trials=None) -> OptimizationExecution:
+        prior_trials = list(prior_trials or [])
+        initial_trial = TrialSummary(
+            trial_id="trial-1",
+            trial_number=1,
+            status=TrialStatus.completed,
+            parameters={"short_period": 5, "long_period": 20},
+            objective=1.25,
+            metrics={
+                "sharpe_ratio": 1.1,
+                "validation_sharpe_ratio": 1.25,
+                "full_sharpe_ratio": 1.1,
+            },
+            duration_seconds=0,
+        )
+        resumed_trial = TrialSummary(
+            trial_id="trial-2",
+            trial_number=2,
+            status=TrialStatus.completed,
+            parameters={"short_period": 8, "long_period": 24},
+            objective=1.55,
+            metrics={
+                "sharpe_ratio": 1.4,
+                "validation_sharpe_ratio": 1.55,
+                "full_sharpe_ratio": 1.4,
+            },
+            duration_seconds=0,
+        )
+
+        if not prior_trials:
+            return OptimizationExecution(
+                state=OptimizationState.cancelled,
+                trials=[initial_trial],
+                best_trial=initial_trial,
+                replay_backtest={
+                    **request.base_backtest,
+                    "strategy": {
+                        "name": request.base_backtest["strategy"]["name"],
+                        "params": {"short_period": 5, "long_period": 20},
+                    },
+                },
+                diagnostics={
+                    "objective_metric": "sharpe_ratio",
+                    "resume_supported": True,
+                },
+                manifest={
+                    "manifest_version": "1.0",
+                    "kind": "optimization_run",
+                    "diagnostics": {"resume_supported": True},
+                },
+            )
+
+        trials = prior_trials + [resumed_trial]
+        return OptimizationExecution(
+            state=OptimizationState.completed,
+            trials=trials,
+            best_trial=resumed_trial,
+            replay_backtest={
+                **request.base_backtest,
+                "strategy": {
+                    "name": request.base_backtest["strategy"]["name"],
+                    "params": {"short_period": 8, "long_period": 24},
+                },
+            },
+            diagnostics={
+                "objective_metric": "sharpe_ratio",
+                "resume_supported": True,
+            },
+            manifest={
+                "manifest_version": "1.0",
+                "kind": "optimization_run",
+                "diagnostics": {"resume_supported": True},
+                "execution_plan": {"resume_supported": True, "cancellation_supported": True},
+                "trial_lineage": [trial.model_dump(mode="json") for trial in trials],
+            },
+        )
 
 
 def _sample_request() -> OptimizationRequest:
@@ -173,6 +252,50 @@ class OptimizationApiTests(unittest.TestCase):
         self.assertEqual(result["diagnostics"]["best_trial_generalization_gap"], 0.15)
         self.assertEqual(result["manifest"]["manifest_version"], "1.0")
         self.assertEqual(len(result["all_trials"]), 2)
+
+    def test_resume_optimization_continues_from_saved_trials(self) -> None:
+        original_store = main_module.opt_store
+        main_module.opt_store = OptimizationStore(executor=ResumeAwareExecutor())
+        client = TestClient(main_module.app)
+        try:
+            created_response = client.post(
+                "/optimizations",
+                json=_sample_request().model_dump(mode="json"),
+            )
+            self.assertEqual(created_response.status_code, 201)
+            optimization_id = created_response.json()["optimization_id"]
+
+            for _ in range(50):
+                status_response = client.get(f"/optimizations/{optimization_id}")
+                self.assertEqual(status_response.status_code, 200)
+                if status_response.json()["state"] == "cancelled":
+                    break
+                time.sleep(0.02)
+
+            resume_response = client.post(f"/optimizations/{optimization_id}/resume")
+            self.assertEqual(resume_response.status_code, 200)
+            self.assertEqual(resume_response.json()["state"], "running")
+
+            result = None
+            for _ in range(50):
+                status_response = client.get(f"/optimizations/{optimization_id}")
+                self.assertEqual(status_response.status_code, 200)
+                if status_response.json()["state"] == "completed":
+                    result_response = client.get(f"/optimizations/{optimization_id}/results")
+                    self.assertEqual(result_response.status_code, 200)
+                    result = result_response.json()
+                    break
+                time.sleep(0.02)
+
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["state"], "completed")
+            self.assertEqual([trial["trial_number"] for trial in result["all_trials"]], [1, 2])
+            self.assertEqual(result["best_trial"]["parameters"], {"short_period": 8, "long_period": 24})
+            self.assertTrue(result["diagnostics"]["resume_supported"])
+            self.assertTrue(result["manifest"]["execution_plan"]["resume_supported"])
+        finally:
+            main_module.opt_store = original_store
 
 
 class OptimizationStoreTests(unittest.IsolatedAsyncioTestCase):

--- a/api/tests/test_optimization_runtime.py
+++ b/api/tests/test_optimization_runtime.py
@@ -12,6 +12,8 @@ from api.app.optimization_models import (
     SearchStrategyName,
     ValidationMode,
     OptimizationRequest,
+    TrialStatus,
+    TrialSummary,
 )
 from api.app.optimization_runtime import OptimizationExecutor
 
@@ -41,6 +43,22 @@ class ParamAwareBacktestExecutor:
                 "sharpe_ratio": sharpe_ratio,
                 "total_return": total_return,
                 "total_commissions": abs(long_period - short_period) / 10,
+            }
+        }
+
+
+class RecordingBacktestExecutor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, int]] = []
+
+    def run(self, backtest_config: dict) -> dict:
+        params = dict(backtest_config["strategy"]["params"])
+        self.calls.append(params)
+        score = float(int(params["short_period"]) * 10 + int(params["long_period"]))
+        return {
+            "metrics_summary": {
+                "sharpe_ratio": score,
+                "total_return": score * 2,
             }
         }
 
@@ -98,18 +116,79 @@ class OptimizationRuntimeTests(unittest.IsolatedAsyncioTestCase):
             result.diagnostics["parameter_stability"]["short_period"]["best_value"],
             8,
         )
-        self.assertFalse(result.diagnostics["resume_supported"])
+        self.assertTrue(result.diagnostics["resume_supported"])
 
         self.assertIsNotNone(result.manifest)
         assert result.manifest is not None
         self.assertEqual(result.manifest["manifest_version"], "1.0")
         self.assertEqual(result.manifest["request"]["random_seed"], 7)
         self.assertEqual(result.manifest["execution_plan"]["mode"], "local_python")
+        self.assertTrue(result.manifest["execution_plan"]["resume_supported"])
         self.assertEqual(len(result.manifest["trial_lineage"]), 4)
         self.assertEqual(
             result.manifest["best_trial"]["parameters"],
             {"short_period": 8, "long_period": 24},
         )
+
+    async def test_executor_continues_from_prior_trials(self) -> None:
+        executor = OptimizationExecutor(backtest_executor=RecordingBacktestExecutor())
+        prior_trials = [
+            TrialSummary(
+                trial_id="trial-1",
+                trial_number=1,
+                status=TrialStatus.completed,
+                parameters={"short_period": 6, "long_period": 20},
+                objective=80.0,
+                metrics={"sharpe_ratio": 80.0},
+                duration_seconds=0,
+            ),
+            TrialSummary(
+                trial_id="trial-2",
+                trial_number=2,
+                status=TrialStatus.completed,
+                parameters={"short_period": 6, "long_period": 24},
+                objective=84.0,
+                metrics={"sharpe_ratio": 84.0},
+                duration_seconds=0,
+            ),
+        ]
+        resume_request = OptimizationRequest(
+            name="Resume regression",
+            description="Resume from trial lineage",
+            search_space=_request().search_space,
+            strategy=SearchStrategyName.grid,
+            max_trials=4,
+            concurrency=1,
+            objective_metric="sharpe_ratio",
+            direction=ObjectiveDirection.maximize,
+            validation_mode=ValidationMode.holdout,
+            validation_fraction=0.25,
+            walk_forward_windows=1,
+            random_seed=7,
+            grid_steps=2,
+            base_backtest={
+                "symbols": ["AAPL"],
+                "start_date": "2024-01-01T00:00:00Z",
+                "end_date": "2024-01-05T00:00:00Z",
+                "resolution": "day",
+                "strategy": {"name": "ma_crossover", "params": {}},
+                "initial_capital": 100000,
+                "data_source": "sample",
+            },
+        )
+
+        result = await executor.execute(resume_request, prior_trials=prior_trials)
+
+        self.assertEqual(result.state, OptimizationState.completed)
+        self.assertEqual(len(result.trials), 4)
+        self.assertEqual([trial.trial_number for trial in result.trials], [1, 2, 3, 4])
+        self.assertEqual(result.trials[:2], prior_trials)
+        self.assertEqual(executor._backtest_executor.calls, [
+            {"short_period": 8, "long_period": 20},
+            {"short_period": 8, "long_period": 24},
+        ])
+        self.assertTrue(result.diagnostics["resume_supported"])
+        self.assertTrue(result.manifest["execution_plan"]["resume_supported"])
 
 
 if __name__ == "__main__":

--- a/docs/assumptions-and-limitations.md
+++ b/docs/assumptions-and-limitations.md
@@ -22,7 +22,7 @@ GlowBack already covers a meaningful research workflow, but it is still an alpha
 
 ## Optimization workflow
 
-- GlowBack optimization results now surface validation gaps, stability summaries, and an optimization manifest with seed/trial lineage, but resume semantics and true scale-out orchestration remain active roadmap work.
+- GlowBack optimization results now surface validation gaps, stability summaries, and an optimization manifest with seed/trial lineage; resume semantics are supported, but true scale-out orchestration remains active roadmap work.
 - Treat optimization results as research aids, not proof of live robustness.
 
 ## Live and paper trading

--- a/docs/concepts/optimization.md
+++ b/docs/concepts/optimization.md
@@ -15,6 +15,7 @@
 | `GET`  | `/v1/optimizations/{id}`         | Returns run status and best-trial summary |
 | `GET`  | `/v1/optimizations/{id}/results` | Returns ranked trials and a replayable best-trial backtest payload |
 | `POST` | `/v1/optimizations/{id}/cancel`  | Cancels a pending/running optimization |
+| `POST` | `/v1/optimizations/{id}/resume`  | Resumes a canceled or failed optimization from saved trial lineage |
 
 ## Example Request
 


### PR DESCRIPTION
## Summary
- add resume support to optimization execution so cancelled/failed runs can continue from saved trial lineage
- expose a `/v1/optimizations/{id}/resume` endpoint and keep manifest/diagnostic resume support flags in sync
- add regression tests for resumed trial lineage and update the optimization docs

## Tests
- `python -m unittest api.tests.test_optimization_runtime api.tests.test_optimization_api`

Refs #109