### PR TITLE
fix: ship typed Python stubs

### DIFF
--- a/crates/gb-python/Cargo.toml
+++ b/crates/gb-python/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 gb-types = { path = "../gb-types" }
 gb-data = { path = "../gb-data" }
 gb-engine = { path = "../gb-engine" }
-pyo3 = { version = "0.29", features = ["auto-initialize", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["auto-initialize", "abi3-py310", "experimental-inspect"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -20,6 +20,8 @@ For clean-checkout smoke paths that validate both source installs and wheel inst
 
 `python_sdk_quickstart.sh` covers the editable `maturin develop` path. `python_sdk_wheel_smoke.sh` builds a wheel, installs it into a fresh virtualenv, and reruns the checked-in example so packaging drift is caught locally before CI.
 
+Both paths also verify the generated `__init__.pyi` and `py.typed` files so type checkers see the supported Python surface.
+
 ## Supported public surface
 
 The module publishes its supported contract via `glowback.__all__`, and the canonical built-in strategy IDs are exposed in `glowback.BUILTIN_STRATEGIES`.

--- a/scripts/python_sdk_quickstart.sh
+++ b/scripts/python_sdk_quickstart.sh
@@ -33,8 +33,19 @@ VIRTUALENV_BIN="$USER_BASE/bin/virtualenv"
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"
 
-maturin develop -m crates/gb-python/Cargo.toml
-python examples/python_sdk_quickstart.py | tee "$LOG_FILE"
+maturin develop --generate-stubs -m crates/gb-python/Cargo.toml
+python - <<'PY' | tee "$LOG_FILE"
+from pathlib import Path
+import glowback
+
+module_root = Path(glowback.__file__).resolve().parent
+required = [module_root / "__init__.pyi", module_root / "py.typed"]
+missing = [str(path) for path in required if not path.exists()]
+if missing:
+    raise SystemExit(f"missing generated type stubs: {', '.join(missing)}")
+print(f"Generated type stubs present: {required[0].name}, {required[1].name}")
+PY
+python examples/python_sdk_quickstart.py | tee -a "$LOG_FILE"
 
 if ! grep -q "✅ Python SDK quickstart completed successfully" "$LOG_FILE"; then
   echo "error: Python SDK quickstart did not reach the expected success marker" >&2

--- a/scripts/python_sdk_wheel_smoke.sh
+++ b/scripts/python_sdk_wheel_smoke.sh
@@ -45,7 +45,7 @@ MATURIN_BIN="$USER_BASE/bin/maturin"
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"
 
-"$MATURIN_BIN" build --release --locked --manifest-path crates/gb-python/Cargo.toml --out "$OUT_DIR"
+"$MATURIN_BIN" build --release --locked --generate-stubs --manifest-path crates/gb-python/Cargo.toml --out "$OUT_DIR"
 
 shopt -s nullglob
 wheels=("$OUT_DIR"/*.whl)
@@ -59,7 +59,18 @@ fi
 WHEEL_PATH="${wheels[0]}"
 echo "==> Installing $WHEEL_PATH"
 python -m pip install --force-reinstall "$WHEEL_PATH"
-python examples/python_sdk_quickstart.py | tee "$LOG_FILE"
+python - <<'PY' | tee "$LOG_FILE"
+from pathlib import Path
+import glowback
+
+module_root = Path(glowback.__file__).resolve().parent
+required = [module_root / "__init__.pyi", module_root / "py.typed"]
+missing = [str(path) for path in required if not path.exists()]
+if missing:
+    raise SystemExit(f"missing generated type stubs: {', '.join(missing)}")
+print(f"Generated type stubs present: {required[0].name}, {required[1].name}")
+PY
+python examples/python_sdk_quickstart.py | tee -a "$LOG_FILE"
 
 if ! grep -q "✅ Python SDK quickstart completed successfully" "$LOG_FILE"; then
   echo "error: Python wheel smoke test did not reach the expected success marker" >&2


### PR DESCRIPTION
## Summary
- enable PyO3 experimental introspection for gb-python
- generate and package `__init__.pyi` + `py.typed` in editable installs and wheels
- verify the stub files in the local quickstart and wheel smoke flows
- document the typed Python surface in the SDK docs

## Tests
- `cargo test -p gb-python --locked --no-default-features`
- `./scripts/python_sdk_quickstart.sh`
- `./scripts/python_sdk_wheel_smoke.sh`

Refs #107
