### PR TITLE
feat: add Python SDK parameter sweep example

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -52,6 +52,27 @@ Expected success marker:
 ✅ Python SDK quickstart completed successfully
 ```
 
+## Python SDK parameter sweep example
+
+- File: `examples/python_sdk_parameter_sweep.py`
+- Command:
+
+```bash
+python examples/python_sdk_parameter_sweep.py
+```
+
+What it proves:
+
+- the Python bindings can run a small deterministic parameter sweep against the real engine
+- repeated `run_builtin_strategy(...)` calls keep the manifest replay payload and sampled parameters aligned
+- `momentum` tuning stays on the supported public surface instead of requiring a custom Rust-only harness
+
+Expected success marker:
+
+```text
+✅ Python SDK parameter sweep completed successfully
+```
+
 ## Python SDK wheel smoke example
 
 - File: `scripts/python_sdk_wheel_smoke.sh`
@@ -150,7 +171,6 @@ Expected success marker:
 
 ## Next examples to add
 
-- Momentum strategy with parameter sweep
 - API workflow smoke path with checked-in request/response fixtures
 
 ## Related docs

--- a/docs/tutorials/notebook.md
+++ b/docs/tutorials/notebook.md
@@ -61,8 +61,21 @@ ax = result.plot_equity()
 
 - Checked-in script: `examples/python_sdk_quickstart.py`
 - Smoke wrapper: `scripts/python_sdk_quickstart.sh`
+- Sweep example: `examples/python_sdk_parameter_sweep.py`
+- Replay example: `examples/replay_manifest_tutorial.py`
 
 Use the script when you want a copy-pasteable starting point outside Jupyter, then lift the same calls into a notebook cell.
+
+## Notebook gallery
+
+Use these small notebook-sized workflows as the durable starting point for the Python SDK:
+
+- First backtest: `glowback.run_buy_and_hold(...)` from the quickstart example
+- Custom parameterized strategy: `glowback.run_builtin_strategy(...)` with `momentum` or `ma_crossover` parameters
+- Parameter sweep: the checked-in `examples/python_sdk_parameter_sweep.py`
+- Reproducible replay: the checked-in `examples/replay_manifest_tutorial.py`
+
+The notebook-friendly API stays the same across these paths: run a backtest, inspect `result.metrics_summary`, `result.equity_curve`, and `result.manifest`, then copy the same calls into a notebook cell for interactive analysis.
 
 ## Notes
 

--- a/examples/python_sdk_parameter_sweep.py
+++ b/examples/python_sdk_parameter_sweep.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from itertools import product
+
+import glowback
+
+SYMBOLS = ["AAPL"]
+START_DATE = "2024-01-01T00:00:00Z"
+END_DATE = "2024-06-30T23:59:59Z"
+INITIAL_CAPITAL = 100000.0
+DATA_SOURCE = "sample"
+SWEEP = list(product([8, 12, 16], [0.03, 0.05, 0.08]))
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def run_trial(lookback_period: int, momentum_threshold: float) -> dict[str, object]:
+    strategy_params = {
+        "lookback_period": lookback_period,
+        "momentum_threshold": momentum_threshold,
+    }
+    result = glowback.run_builtin_strategy(
+        symbols=SYMBOLS,
+        start_date=START_DATE,
+        end_date=END_DATE,
+        strategy_name="momentum",
+        strategy_params=strategy_params,
+        resolution="day",
+        initial_capital=INITIAL_CAPITAL,
+        name=f"Momentum sweep lookback={lookback_period} threshold={momentum_threshold}",
+        data_source=DATA_SOURCE,
+        data_quality_mode="warn",
+        commission_bps=5,
+        slippage_bps=2,
+        latency_ms=0,
+    )
+
+    manifest = result.manifest
+    require(manifest is not None, "manifest should be present")
+    require(
+        manifest["replay_request"]["strategy_name"] == "momentum",
+        "strategy name drifted",
+    )
+    replay_params = manifest["replay_request"]["strategy_params"]
+    require(
+        replay_params["lookback_period"] == lookback_period,
+        "lookback_period drifted",
+    )
+    require(
+        abs(float(replay_params["momentum_threshold"]) - momentum_threshold) < 1e-12,
+        "momentum_threshold drifted",
+    )
+    require(
+        manifest["execution"]["data_settings"]["data_source"] == DATA_SOURCE,
+        "data source drifted",
+    )
+
+    metrics = result.metrics_summary
+    return {
+        "score": metrics["sharpe_ratio"],
+        "final_value": metrics["final_value"],
+        "lookback_period": lookback_period,
+        "momentum_threshold": momentum_threshold,
+        "result": result,
+    }
+
+
+if __name__ == "__main__":
+    ranked_trials: list[dict[str, object]] = []
+
+    for lookback_period, momentum_threshold in SWEEP:
+        trial = run_trial(lookback_period, momentum_threshold)
+        ranked_trials.append(trial)
+        print(
+            f"trial lookback={lookback_period} threshold={momentum_threshold:.2f} "
+            f"sharpe={trial['score']:.4f} final_value=${trial['final_value']:.2f}"
+        )
+
+    ranked_trials.sort(
+        key=lambda trial: (
+            float(trial["score"]),
+            float(trial["final_value"]),
+        ),
+        reverse=True,
+    )
+    best = ranked_trials[0]
+
+    print(
+        "Best momentum sweep:",
+        f"lookback={best['lookback_period']}",
+        f"threshold={best['momentum_threshold']:.2f}",
+        f"sharpe={best['score']:.4f}",
+        f"final_value=${best['final_value']:.2f}",
+    )
+    print("Top 3 sweep results:")
+    for trial in ranked_trials[:3]:
+        print(
+            f"- lookback={trial['lookback_period']} "
+            f"threshold={trial['momentum_threshold']:.2f} "
+            f"sharpe={trial['score']:.4f} "
+            f"final_value=${trial['final_value']:.2f}"
+        )
+
+    print("✅ Python SDK parameter sweep completed successfully")


### PR DESCRIPTION
## Summary
- add a checked-in Python SDK parameter sweep example for the momentum strategy
- document the new runnable example in the examples index
- expand the notebook tutorial with a concrete gallery of Python SDK workflows

Refs #107

## Validation
- `maturin develop --generate-stubs -m crates/gb-python/Cargo.toml`
- `python examples/python_sdk_quickstart.py`
- `python examples/python_sdk_parameter_sweep.py`
- `PYTHONPATH=$ROOT python examples/replay_manifest_tutorial.py`
- `mkdocs build --strict`