### PR TITLE
feat: preview Ray optimizer allocations

### DIFF
--- a/api/app/optimization_runtime.py
+++ b/api/app/optimization_runtime.py
@@ -625,7 +625,7 @@ def build_optimization_manifest(
         f"validation_full_gap_{metric_name}",
     ]
 
-    return {
+    manifest = {
         "manifest_version": "1.0",
         "kind": "optimization_run",
         "generated_at": _isoformat(datetime.now(timezone.utc)),
@@ -678,6 +678,35 @@ def build_optimization_manifest(
             "resume_supported": True,
             "cancellation_supported": True,
         },
+    }
+
+    distributed_preview = _build_distributed_execution_preview(request, trials)
+    if distributed_preview is not None:
+        manifest["execution_plan"]["distributed_preview"] = distributed_preview
+
+    return manifest
+
+
+def _build_distributed_execution_preview(
+    request: OptimizationRequest,
+    trials: list[TrialSummary],
+) -> dict[str, Any] | None:
+    if request.ray_cluster is None:
+        return None
+
+    task_count = len(trials)
+    planned_workers = min(
+        request.ray_cluster.max_concurrent_tasks,
+        request.concurrency,
+        max(task_count, 1),
+    )
+    return {
+        "scheduler": "ray",
+        "status": "preview",
+        "task_count": task_count,
+        "planned_workers": planned_workers,
+        "cluster": request.ray_cluster.model_dump(mode="json"),
+        "trial_numbers": [trial.trial_number for trial in trials],
     }
 
 

--- a/api/tests/test_optimization_runtime.py
+++ b/api/tests/test_optimization_runtime.py
@@ -6,6 +6,7 @@ import unittest
 from api.app.optimization_models import (
     ObjectiveDirection,
     OptimizationState,
+    RayClusterConfig,
     ParameterDef,
     ParameterKind,
     SearchSpaceConfig,
@@ -189,6 +190,38 @@ class OptimizationRuntimeTests(unittest.IsolatedAsyncioTestCase):
         ])
         self.assertTrue(result.diagnostics["resume_supported"])
         self.assertTrue(result.manifest["execution_plan"]["resume_supported"])
+
+    async def test_executor_emits_ray_execution_preview(self) -> None:
+        executor = OptimizationExecutor(backtest_executor=ParamAwareBacktestExecutor())
+        request = _request().model_copy(
+            update={
+                "concurrency": 4,
+                "ray_cluster": RayClusterConfig(
+                    address="ray://example:10001",
+                    namespace="glowback-qa",
+                    max_concurrent_tasks=2,
+                    num_cpus=2.5,
+                    num_gpus=0.0,
+                    pip_packages=["ray==2.46.0"],
+                )
+            }
+        )
+
+        result = await executor.execute(request)
+
+        self.assertIsNotNone(result.manifest)
+        assert result.manifest is not None
+        execution_plan = result.manifest["execution_plan"]
+        self.assertTrue(execution_plan["ray_cluster_requested"])
+        self.assertIn("distributed_preview", execution_plan)
+        preview = execution_plan["distributed_preview"]
+        self.assertEqual(preview["scheduler"], "ray")
+        self.assertEqual(preview["status"], "preview")
+        self.assertEqual(preview["task_count"], 4)
+        self.assertEqual(preview["planned_workers"], 2)
+        self.assertEqual(preview["cluster"]["namespace"], "glowback-qa")
+        self.assertEqual(preview["cluster"]["max_concurrent_tasks"], 2)
+        self.assertEqual(preview["trial_numbers"], [1, 2, 3, 4])
 
 
 if __name__ == "__main__":

--- a/docs/assumptions-and-limitations.md
+++ b/docs/assumptions-and-limitations.md
@@ -22,7 +22,7 @@ GlowBack already covers a meaningful research workflow, but it is still an alpha
 
 ## Optimization workflow
 
-- GlowBack optimization results now surface validation gaps, stability summaries, and an optimization manifest with seed/trial lineage; resume semantics are supported, but true scale-out orchestration remains active roadmap work.
+- GlowBack optimization results now surface validation gaps, stability summaries, and an optimization manifest with seed/trial lineage and a Ray distributed-execution preview; resume semantics are supported, but true scale-out orchestration remains active roadmap work.
 - Treat optimization results as research aids, not proof of live robustness.
 
 ## Live and paper trading

--- a/docs/concepts/optimization.md
+++ b/docs/concepts/optimization.md
@@ -204,8 +204,10 @@ parameters before each real engine run.
 
 `ray_cluster` remains present in the API model for future distributed
 execution, but this shipping path still runs trials locally through the Python
-bindings. The optimization manifest records that execution mode explicitly, so
-results show whether a run used today's local path or a future distributed
+bindings. The optimization manifest records that execution mode explicitly and,
+when a Ray cluster is supplied, includes a `distributed_preview` block with the
+requested cluster settings, planned worker count, and trial numbers. Results
+still show whether a run used today's local path or a future distributed
 scheduler.
 
 ## Rust Crate: `gb-optimizer`


### PR DESCRIPTION
## Summary
- add a Ray distributed-execution preview block to optimization manifests when `ray_cluster` is supplied
- surface the requested cluster settings, planned worker count, and trial numbers without claiming the run executed remotely
- add a regression test plus docs updates for the optimization workflow

## Validation
- `python -m unittest api.tests.test_optimization_runtime api.tests.test_optimization_api`
- `mkdocs build --strict`

Refs #109